### PR TITLE
Config

### DIFF
--- a/DependencyInjection/UserExtension.php
+++ b/DependencyInjection/UserExtension.php
@@ -23,6 +23,9 @@ class UserExtension extends Extension
             if (!in_array(strtolower($config['db_driver']), array('orm', 'mongodb'))) {
                 throw new \InvalidArgumentException(sprintf('Invalid db driver "%s".', $config['db_driver']));
             }
+            if ($container->hasDefinition('fos_user.user_manager')){
+                throw new \InvalidArgumentException('The db_driver parameter cannot be defined twice.');
+            }
             $loader->load(sprintf('%s.xml', $config['db_driver']));
         }
 


### PR DESCRIPTION
This allow to define the fos_user config in several files without having to put the required definitions in all the files. You have to put them in the first parsed file (the imported one). This way it is for example possible to disable the confirmation email in an environment without redifining all the config.

This commit replaces the latest commit of [pull request 7](https://github.com/FriendsOfSymfony/UserBundle/pull/7) by placing the checks at the beginning of the method
