### PR TITLE
Logout

### DIFF
--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -23,4 +23,9 @@ class SecurityController extends Controller
             'error'         => $error,
         ));
     }
+
+    public function logoutAction()
+    {
+        throw new \RuntimeException('You must activate the logout in your security firewall configuration.');
+    }
 }


### PR DESCRIPTION
The logout action is not reached when the logout is enabled. It is only there for make the debugging easier if someone missed this point in his security configuration.
