### PR TITLE
Provide methods to get a user's display name and search by display name.

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -237,6 +237,16 @@ abstract class User implements UserInterface
     }
 
     /**
+     * Get the name as it is to be displayed to end users.
+     *
+     * @return string
+     */
+    public function getDisplayName()
+    {
+        return $this->getUsername();
+    }
+
+    /**
      * Implementation of AccountInterface
      * @return string
      */

--- a/Model/UserInterface.php
+++ b/Model/UserInterface.php
@@ -14,6 +14,8 @@ use Symfony\Component\Security\User\AdvancedAccountInterface;
 
 interface UserInterface extends AdvancedAccountInterface
 {
+    function getDisplayName();
+
     function addRole($role);
 
     function getAlgorithm();

--- a/Model/UserManager.php
+++ b/Model/UserManager.php
@@ -65,6 +65,17 @@ abstract class UserManager implements UserManagerInterface, UserProviderInterfac
     }
 
     /**
+     * Finds a user by its display name
+     *
+     * @param string $displayName
+     * @return User
+     */
+    public function findUserByDisplayName($displayName)
+    {
+        return $this->findUserByUsername($displayName);
+    }
+
+    /**
      * Finds a user either by email, or username
      *
      * @param string $usernameOrEmail

--- a/Model/UserManagerInterface.php
+++ b/Model/UserManagerInterface.php
@@ -61,6 +61,13 @@ interface UserManagerInterface
     function findUserByUsername($username);
 
     /**
+     * Find a user by its display name
+     * @param   string  $displayName
+     * @return  User or null if user does not exist
+     */
+    function findUserByDisplayName($displayName);
+
+    /**
      * Find a user by its email
      * @param   string  $email
      * @return  User or null if user does not exist

--- a/Tests/Model/UserTest.php
+++ b/Tests/Model/UserTest.php
@@ -11,6 +11,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
         $user->setUsername('tony');
         $this->assertEquals('tony', $user->getUsername());
+        $this->assertEquals('tony', $user->getDisplayName());
     }
 
     public function testEmail()
@@ -21,7 +22,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $user->setEmail('tony@mail.org');
         $this->assertEquals('tony@mail.org', $user->getEmail());
     }
-    
+
     protected function getUser()
     {
         return $this->getMockForAbstractClass('Bundle\FOS\UserBundle\Model\User');


### PR DESCRIPTION
The display name in the default implementation simply returns the regular
username. The get and search methods exist so that third party Bundles can
make the semantic distinction between a username and a display name without
having to know whether they are different at all. The username is to be
used for login and other internal use, while the display name should be
shown in UIs. So when a user searches by a user's name, it will be a search
by display name. If one then chooses to overwrite displayName with e.g.
firstname + lastname, third party Bundles continue to work correctly
without modification.
