### PR TITLE
Security fixes

### DIFF
--- a/Command/ActivateUserCommand.php
+++ b/Command/ActivateUserCommand.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Symfony\Component\Security\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use FOS\UserBundle\Model\User;
 
 /*

--- a/Command/ChangePasswordCommand.php
+++ b/Command/ChangePasswordCommand.php
@@ -3,7 +3,7 @@
 namespace FOS\UserBundle\Command;
 
 use FOS\UserBundle\Model\User;
-use Symfony\Component\Security\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Bundle\FrameworkBundle\Command\Command as BaseCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Command/CreateUserCommand.php
+++ b/Command/CreateUserCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 
 use FOS\UserBundle\Model\User;
-use Symfony\Component\Security\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Bundle\FrameworkBundle\Command\Command as BaseCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;

--- a/Command/DeactivateUserCommand.php
+++ b/Command/DeactivateUserCommand.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Symfony\Component\Security\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use FOS\UserBundle\Model\User;
 
 /*

--- a/Command/DemoteSuperAdminCommand.php
+++ b/Command/DemoteSuperAdminCommand.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Symfony\Component\Security\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use FOS\UserBundle\Model\User;
 
 /*

--- a/Command/PromoteSuperAdminCommand.php
+++ b/Command/PromoteSuperAdminCommand.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Symfony\Component\Security\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use FOS\UserBundle\Model\User;
 
 /*

--- a/Security/Encoder/EncoderFactory.php
+++ b/Security/Encoder/EncoderFactory.php
@@ -45,7 +45,7 @@ class EncoderFactory implements EncoderFactoryInterface
     }
 
     /**
-     * @see Symfony\Component\Security\Encoder.EncoderFactory::getEncoder()
+     * @see Symfony\Component\Security\Core\Encoder\EncoderFactory::getEncoder()
      */
     public function getEncoder(AccountInterface $account)
     {

--- a/Templating/Helper/SecurityHelper.php
+++ b/Templating/Helper/SecurityHelper.php
@@ -4,7 +4,7 @@ namespace FOS\UserBundle\Templating\Helper;
 
 use Symfony\Bundle\SecurityBundle\Templating\Helper\SecurityHelper as BaseSecurityHelper;
 use FOS\UserBundle\Model\User;
-use Symfony\Component\Security\SecurityContext;
+use Symfony\Component\Security\Core\SecurityContext;
 
 /**
  * SecurityHelper.

--- a/Tests/Document/DocumentUserManagerTest.php
+++ b/Tests/Document/DocumentUserManagerTest.php
@@ -73,7 +73,7 @@ class DocumentUserManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Security\Exception\UsernameNotFoundException
+     * @expectedException Symfony\Component\Security\Core\Exception\UsernameNotFoundException
      */
     public function testLoadUserByUsernameWithMissingUser()
     {

--- a/Tests/Model/UserManagerTest.php
+++ b/Tests/Model/UserManagerTest.php
@@ -79,7 +79,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
 
     private function getMockPasswordEncoder()
     {
-        return $this->getMock('Symfony\Component\Security\Encoder\PasswordEncoderInterface');
+        return $this->getMock('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface');
     }
 
     private function getUser()

--- a/Tests/Security/Encoder/EncoderFactoryTest.php
+++ b/Tests/Security/Encoder/EncoderFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace FOS\UserBundle\Tests\Security\Encoder;
 
-use Symfony\Component\Security\Encoder\MessageDigestPasswordEncoder;
+use Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder;
 use FOS\UserBundle\Security\Encoder\EncoderFactory;
 
 class EncoderFactoryTest extends \PHPUnit_Framework_TestCase
@@ -14,7 +14,7 @@ class EncoderFactoryTest extends \PHPUnit_Framework_TestCase
     public function testGetEncoderWithUserAccount()
     {
         $factory = new EncoderFactory(
-            'Symfony\Component\Security\Encoder\MessageDigestPasswordEncoder',
+            'Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder',
             false,
             1,
             $this->getMock('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')
@@ -36,7 +36,7 @@ class EncoderFactoryTest extends \PHPUnit_Framework_TestCase
     public function testGetEncoderWithGenericAccount()
     {
         $genericFactory = $this->getMock('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface');
-        $encoder = $this->getMock('Symfony\Component\Security\Encoder\PasswordEncoderInterface');
+        $encoder = $this->getMock('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface');
 
         $genericFactory
             ->expects($this->once())
@@ -46,6 +46,6 @@ class EncoderFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory = new EncoderFactory(null , false, 1, $genericFactory);
 
-        $this->assertSame($encoder, $factory->getEncoder($this->getMock('Symfony\Component\Security\User\AccountInterface')));
+        $this->assertSame($encoder, $factory->getEncoder($this->getMock('Symfony\Component\Security\Core\User\AccountInterface')));
     }
 }


### PR DESCRIPTION
fixed all invalid namespace occurences.
The tests don't pass, and it seems that they've been broken for a while.
Also some of the tests are simply wrong (DocumentUserManagerTest, EntityUserManagerTest).
