### PR TITLE
Validation fix

### DIFF
--- a/Controller/UserController.php
+++ b/Controller/UserController.php
@@ -103,11 +103,21 @@ class UserController extends Controller
         $manager = $this->get('fos_user.user_manager');
         $user = $manager->createUser();
         $form = $this->get('fos_user.form.user');
-        $form->bind($this->get('request'), $user);
-        $manager->updateCanonicalFields($user);
+        $form->setData($user);
+
+        $request = $this->get('request');
+
+        if ('POST' == $request->getMethod()) {
+            $values = $request->request->get($form->getName(), array());
+            $files = $request->files->get($form->getName(), array());
+
+            $form->submit(array_replace_recursive($values, $files));
+
+            $manager->updateCanonicalFields($user);
+            $form->validate();
+        }
 
         if ($form->isValid()) {
-            $user = $form->getData();
             if ($this->container->getParameter('fos_user.email.confirmation.enabled')) {
                 $user->setEnabled(false);
                 $manager->updateUser($user);

--- a/Model/User.php
+++ b/Model/User.php
@@ -452,7 +452,7 @@ abstract class User implements UserInterface
      */
     public function isUser(UserInterface $user = null)
     {
-        return null !== $user && $this->getUsername() === $user->getUsername();
+        return null !== $user && $this->getId() === $user->getId();
     }
 
     public function incrementCreatedAt()

--- a/Model/UserManagerInterface.php
+++ b/Model/UserManagerInterface.php
@@ -123,7 +123,7 @@ interface UserManagerInterface
     function updatePassword(UserInterface $user);
 
     /**
-     * Checks the uniqueness of the given fields
+     * Checks the uniqueness of the given fields, returns true if its unique
      *
      * @param UserInterface $value
      * @param Constraint $constraint


### PR DESCRIPTION
this fixes the way we bind. the current bind() method already does the validation, so we are setting the canonical fields too late.

also the validation for Entity is currently broken, though i think the issue is in isUser().
see https://github.com/FriendsOfSymfony/UserBundle/issues/#issue/32
