### PR TITLE
Fix help message to include email

### DIFF
--- a/Command/CreateUserCommand.php
+++ b/Command/CreateUserCommand.php
@@ -57,11 +57,11 @@ The <info>fos:user:create</info> command creates a user:
 
   <info>php app/console fos:user:create matthieu</info>
 
-This interactive shell will first ask you for a password.
+This interactive shell will ask you for an email and then a password.
 
-You can alternatively specify the password as a second argument:
+You can alternatively specify the email and password as the second and third arguments:
 
-  <info>php app/console fos:user:create matthieu mypassword</info>
+  <info>php app/console fos:user:create matthieu matthieu@example.com mypassword</info>
 
 You can create a super admin via the super-admin flag:
 


### PR DESCRIPTION
Fix the examples on the --help message to include the email of the user as well, when creating a user with a password, all in one command
