### PR TITLE
Suggest installation to vendor/bundles

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -12,12 +12,12 @@ Features
 Installation
 ============
 
-Add UserBundle to your src/ dir
+Add UserBundle to your vendor/bundles/ dir
 -------------------------------------
 
 ::
 
-    $ git submodule add git://github.com/FriendsOfSymfony/UserBundle.git src/FOS/UserBundle
+    $ git submodule add git://github.com/FriendsOfSymfony/UserBundle.git vendor/bundles/FOS/UserBundle
 
 Add the FOS namespace to your autoloader
 ----------------------------------------
@@ -25,7 +25,7 @@ Add the FOS namespace to your autoloader
 ::
     // app/autoload.php
     $loader->registerNamespaces(array(
-        'FOS' => __DIR__.'/../src',
+        'FOS' => __DIR__.'/../vendor/bundles',
         // your other namespaces
     );
 


### PR DESCRIPTION
From the other bundles I have seen and in Symfony itself i have seen the recommendation to place outside or third party bundles in the vendor/bundles directory, leaving the src directory only for your more direct bundles.

Not sure if you will agree or the reasoning behind this, its ok if this gets rejected. Anyway i decided to submit a patch to help you guys along, the bundle seems to work just fine since its completely namespace based.

Hope this helps. Let me know if anything else needs to be done.
