### PR TITLE
Groups

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -152,6 +152,7 @@ abstract class User implements UserInterface
         $this->expired = false;
         $this->roles = array();
         $this->credentialsExpired = false;
+        $this->groups = new ArrayCollection();
     }
 
     public function addRole($role)
@@ -331,8 +332,10 @@ abstract class User implements UserInterface
     {
         $roles = $this->roles;
 
-        foreach ($this->getGroups() as $group) {
-            $roles = array_merge($roles, $group->getRoles());
+        if (null !== $this->getGroups()) {
+            foreach ($this->getGroups() as $group) {
+                $roles = array_merge($roles, $group->getRoles());
+            }
         }
 
         // we need to make sure to have at least one role
@@ -683,7 +686,7 @@ abstract class User implements UserInterface
      */
     public function getGroups()
     {
-        return $this->groups ?: $this->groups = new ArrayCollection();
+        return $this->groups;
     }
 
     /**
@@ -694,8 +697,10 @@ abstract class User implements UserInterface
     public function getGroupNames()
     {
         $names = array();
-        foreach ($this->getGroups() as $group) {
-            $names[] = $group->getName();
+        if (null !== $this->getGroups()) {
+            foreach ($this->getGroups() as $group) {
+                $names[] = $group->getName();
+            }
         }
 
         return $names;
@@ -709,7 +714,7 @@ abstract class User implements UserInterface
      */
     public function hasGroup($name)
     {
-        return in_array($name, $this->getGroupNames());
+        return null !== $this->getGroups() && in_array($name, $this->getGroupNames());
     }
 
     /**
@@ -720,7 +725,7 @@ abstract class User implements UserInterface
      **/
     public function addGroup(GroupInterface $group)
     {
-        if (!$this->getGroups()->contains($group)) {
+        if (null !== $this->getGroups() && !$this->getGroups()->contains($group)) {
             $this->getGroups()->add($group);
         }
     }
@@ -733,7 +738,7 @@ abstract class User implements UserInterface
      **/
     public function removeGroup(GroupInterface $group)
     {
-        if ($this->getGroups()->contains($group)) {
+        if (null !== $this->getGroups() && $this->getGroups()->contains($group)) {
             $this->getGroups()->remove($group);
         }
     }


### PR DESCRIPTION
This moves the instantiation of the Group collection to the constructor instead of the getter. It changes all method breaking them when the groups are not mapped (in this case, the collection is not initialized).

I made this change because of https://github.com/FriendsOfSymfony/UserBundle/pull/94 but I'm not sure it should be merged. Here are my reasons:
- `getGroups` return `null` when the groups are not mapped which is not traversable (this is why the other method need a check)
- when using groups this adds an overhead as each method checks for `null` which will never be the case in this case (the collection is initialized either in the constructor, either by Doctrine)

So I'm really not sure it should be merged (but if we want this, this one needs to be used over the other which breaks `getRoles` and the methods relative to the groups)
