### PR TITLE
Fix erroneous config filename

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -113,7 +113,7 @@ enabled in your kernel and in your project's configuration::
         );
     }
 
-    # app/config/config.yml
+    # app/config/security.yml
     security:
         providers:
             # the naming of a security provider is up to you, we chose "fos_userbundle"


### PR DESCRIPTION
Fix erroneous filename in the section dealing with configuring security.providers
