### PR TITLE
Refactored parent class of ChangePasswordFormType

### DIFF
--- a/Form/ChangePasswordFormType.php
+++ b/Form/ChangePasswordFormType.php
@@ -4,11 +4,11 @@ namespace FOS\UserBundle\Form;
 
 use Symfony\Component\Form\FormBuilder;
 
-class ChangePasswordFormType extends ResetPasswordFormType
+class ChangePasswordFormType extends AbstractType
 {
     public function buildForm(FormBuilder $builder, array $options)
     {
         $builder->add('current', 'password');
-        parent::buildForm($builder, $options);
+        $builder->add('new', 'repeated', array('type' => 'password'));
     }
 }


### PR DESCRIPTION
The ResetPasswordFormType does only contain one line of code
which is really trivial. Another level of inheritance should not
be used just for this. (And by the way, resetting and changing
passwords already suggest from the naming that they are totally different)
