### PR TITLE
Remove abstract keyword as class is formally completely defined

### DIFF
--- a/Entity/User.php
+++ b/Entity/User.php
@@ -12,6 +12,6 @@ namespace FOS\UserBundle\Entity;
 
 use FOS\UserBundle\Model\User as AbstractUser;
 
-abstract class User extends AbstractUser
+class User extends AbstractUser
 {
 }


### PR DESCRIPTION
Group also lacks this and IMHO there's no good reason for it
