### PR TITLE
Changed 'form-login' to 'form_login'

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -646,7 +646,7 @@ Security configuration
         firewalls:
             main:
                 pattern:      .*
-                form-login:
+                form_login:
                     provider:       fos_userbundle
                     login_path:     /login
                     use_forward:    false


### PR DESCRIPTION
I think I've spotted a typo in the documentation
