### PR TITLE
Fixed the security configuration location in "Minimal configuration"

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -211,7 +211,7 @@ would have to be set to "main", as shown in the proceeding examples:
 
 ::
 
-    # app/config/config.yml
+    # app/config/security.yml
     security:
         providers:
             fos_userbundle:


### PR DESCRIPTION
It seems to me that the indicated location for the security config (app/config/config.yml) is incorrect. This, I believe is where the security config should go.
