### PR TITLE
"Undefined index: form"  when setting any property in fos_user.group.form

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -237,6 +237,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('group_class')->isRequired()->cannotBeEmpty()->end()
                         ->arrayNode('form')
+                            ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('type')->defaultValue('FOS\UserBundle\Form\GroupFormType')->end()
                                 ->scalarNode('handler')->defaultValue('FOS\UserBundle\Form\GroupFormHandler')->end()


### PR DESCRIPTION
Fixed case when setting only one property of fos_user.group.form
