### PR TITLE
make token generation reusable for other fields

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -652,7 +652,7 @@ abstract class User implements UserInterface
     }
 
     /**
-     * Updates the confirmation token if it is not set.
+     * Generates the confirmation token if it is not set.
      */
     public function generateConfirmationToken()
     {


### PR DESCRIPTION
This allows using the token generation method for other fields than just `confirmationToken`.
