### PR TITLE
Fixes an exception thrown by the console

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -133,7 +133,7 @@ abstract class User implements UserInterface
     /**
      * @var array
      */
-    protected $roles;
+    protected $roles = array();
 
     /**
      * @var Boolean


### PR DESCRIPTION
[ErrorException]
  Warning: in_array() expects parameter 2 to be array, null given in vendor/bundles/FOS/UserBundle/Model/User.php line 171
