### PR TITLE
Fixed missing colon in YAML for services section on overriding_forms.md

### DIFF
--- a/Resources/doc/overriding_forms.md
+++ b/Resources/doc/overriding_forms.md
@@ -122,7 +122,7 @@ Or if you prefer YAML:
 ``` yaml
 # src/Acme/UserBundle/Resources/config/services.yml
 services:
-    acme_user.registration.form.type
+    acme_user.registration.form.type:
         class: Acme\UserBundle\Form\Type\RegistrationFormType
         arguments: [%fos_user.model.user.class%]
         tags:


### PR DESCRIPTION
Services YAML was missing a colon.
