### PR TITLE
Added dollar sign notation to path

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -247,7 +247,7 @@ security:
         - { path: ^/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin/, role: ROLE_ADMIN }
+        - { path: ^/admin$, role: ROLE_ADMIN }
 
     role_hierarchy:
         ROLE_ADMIN:       ROLE_USER


### PR DESCRIPTION
{ path: ^/admin/, role: ROLE_ADMIN }

is incorrect.

It should be

{ path: ^/admin, role: ROLE_ADMIN } or { path: ^/admin$, role: ROLE_ADMIN }

otherwise, it will not force the user to log in
