### PR TITLE
Allow to create a group without name

### DIFF
--- a/Model/Group.php
+++ b/Model/Group.php
@@ -20,7 +20,7 @@ abstract class Group implements GroupInterface
     protected $name;
     protected $roles;
 
-    public function __construct($name, $roles = array())
+    public function __construct($name = null, $roles = array())
     {
         $this->name = $name;
         $this->roles = $roles;


### PR DESCRIPTION
In my current project, the group is managed internally. So, in my case, the group name is useless.
