### PR TITLE
Add the default role only if no role was explicitly set

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -153,9 +153,6 @@ abstract class User implements UserInterface, GroupableInterface
     public function addRole($role)
     {
         $role = strtoupper($role);
-        if ($role === self::ROLE_DEFAULT) {
-            return;
-        }
 
         if (!in_array($role, $this->roles, true)) {
             $this->roles[] = $role;
@@ -374,7 +371,9 @@ abstract class User implements UserInterface, GroupableInterface
         }
 
         // we need to make sure to have at least one role
-        $roles[] = self::ROLE_DEFAULT;
+        if(count($roles) == 0) {
+            $roles[] = self::ROLE_DEFAULT;
+        }
 
         return array_unique($roles);
     }

--- a/Tests/Model/UserTest.php
+++ b/Tests/Model/UserTest.php
@@ -92,6 +92,35 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($user1->equals($user3));
     }
 
+    public function testUserHasDefaultRoleOnlyIfNoOtherRolesArePresent()
+    {
+        $user = $this->getUser();
+
+        $this->assertTrue($user->hasRole(User::ROLE_DEFAULT));
+        
+        $newrole = 'ROLE_X';
+        
+        $user->addRole($newrole);
+
+        $this->assertFalse($user->hasRole(User::ROLE_DEFAULT));
+        $this->assertTrue($user->hasRole($newrole));
+    }
+    
+    public function testUserHasDefaultRoleWhenExplicitlySet()
+    {
+        $user = $this->getUser();
+        
+        $newrole = 'ROLE_X';
+        
+        $user->addRole($newrole);
+        
+        $this->assertFalse($user->hasRole(User::ROLE_DEFAULT));
+        
+        $user->addRole(User::ROLE_DEFAULT);
+        
+        $this->assertTrue($user->hasRole(User::ROLE_DEFAULT));
+    }
+    
     protected function getUser()
     {
         return $this->getMockForAbstractClass('FOS\UserBundle\Model\User');


### PR DESCRIPTION
Hi!

This commit fixes that the User::ROLE_DEFAULT gets added every time to the User, regardless of what roles that User has already and this for me is unexpected behavior.

If no role is set explicitly, then by default the User will have the User::ROLE_DEFAULT (even this seems strange to me, if a User has no role, then it should have none, not some random magic one).

If one role, ROLE_X is set, then the User will have only that role.

If both ROLE_DEFAULT and ROLE_X are set, then the User will have both those roles.

Without this fix, it can happen that if I set a User to have ROLE_ADMIN it will have ROLE_DEFAULT too, even tho I didn't want that. If I do want to have the User both ROLE_ADMIN and ROLE_DEFAULT, then I'll set up the role inheritance properly in my firewall settings.

Hope this all makes sense :)

Happy hackin'!
