### PR TITLE
Overriding role constants in derived User class

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -153,7 +153,7 @@ abstract class User implements UserInterface, GroupableInterface
     public function addRole($role)
     {
         $role = strtoupper($role);
-        if ($role === self::ROLE_DEFAULT) {
+        if ($role === static::ROLE_DEFAULT) {
             return;
         }
 
@@ -374,7 +374,7 @@ abstract class User implements UserInterface, GroupableInterface
         }
 
         // we need to make sure to have at least one role
-        $roles[] = self::ROLE_DEFAULT;
+        $roles[] = static::ROLE_DEFAULT;
 
         return array_unique($roles);
     }
@@ -481,7 +481,7 @@ abstract class User implements UserInterface, GroupableInterface
      */
     public function isSuperAdmin()
     {
-        return $this->hasRole(self::ROLE_SUPER_ADMIN);
+        return $this->hasRole(static::ROLE_SUPER_ADMIN);
     }
 
     /**
@@ -611,9 +611,9 @@ abstract class User implements UserInterface, GroupableInterface
     public function setSuperAdmin($boolean)
     {
         if (true === $boolean) {
-            $this->addRole(self::ROLE_SUPER_ADMIN);
+            $this->addRole(static::ROLE_SUPER_ADMIN);
         } else {
-            $this->removeRole(self::ROLE_SUPER_ADMIN);
+            $this->removeRole(static::ROLE_SUPER_ADMIN);
         }
     }
 


### PR DESCRIPTION
```
<?php
// src/Acme/UserBundle/Entity/User.php
namespace Acme\UserBundle\Entity;

use FOS\UserBundle\Entity\User as BaseUser;
use Doctrine\ORM\Mapping as ORM;

/**
 * @ORM\Entity
 * @ORM\Table(name="member")
 */
class User extends BaseUser
{
    const ROLE_DEFAULT = 'ROLE_MY_USER';
    const ROLE_SUPER_ADMIN = 'ROLE_MY_SUPER_ADMIN';

    /**
     * @ORM\Id
     * @ORM\Column(type="integer")
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    protected $id;

    public function __construct()
    {
        parent::__construct();
        // your own logic
    }
}
```
