### PR TITLE
Trailing slashes in routes

### DIFF
--- a/Resources/config/routing/change_password.xml
+++ b/Resources/config/routing/change_password.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_change_password" pattern="/change-password">
+    <route id="fos_user_change_password" pattern="/change-password/">
         <default key="_controller">FOSUserBundle:ChangePassword:changePassword</default>
         <requirement key="_method">GET|POST</requirement>
     </route>

--- a/Resources/config/routing/group.xml
+++ b/Resources/config/routing/group.xml
@@ -4,25 +4,25 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_group_list" pattern="/list">
+    <route id="fos_user_group_list" pattern="/list/">
         <default key="_controller">FOSUserBundle:Group:list</default>
         <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_group_new" pattern="/new">
+    <route id="fos_user_group_new" pattern="/new/">
         <default key="_controller">FOSUserBundle:Group:new</default>
     </route>
 
-    <route id="fos_user_group_show" pattern="/{groupname}">
+    <route id="fos_user_group_show" pattern="/{groupname}/">
         <default key="_controller">FOSUserBundle:Group:show</default>
         <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_group_edit" pattern="/{groupname}/edit">
+    <route id="fos_user_group_edit" pattern="/{groupname}/edit/">
         <default key="_controller">FOSUserBundle:Group:edit</default>
     </route>
 
-    <route id="fos_user_group_delete" pattern="/{groupname}/delete">
+    <route id="fos_user_group_delete" pattern="/{groupname}/delete/">
         <default key="_controller">FOSUserBundle:Group:delete</default>
         <requirement key="_method">GET</requirement>
     </route>

--- a/Resources/config/routing/profile.xml
+++ b/Resources/config/routing/profile.xml
@@ -9,7 +9,7 @@
         <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_profile_edit" pattern="/edit">
+    <route id="fos_user_profile_edit" pattern="/edit/">
         <default key="_controller">FOSUserBundle:Profile:edit</default>
     </route>
 

--- a/Resources/config/routing/registration.xml
+++ b/Resources/config/routing/registration.xml
@@ -8,17 +8,17 @@
         <default key="_controller">FOSUserBundle:Registration:register</default>
     </route>
 
-    <route id="fos_user_registration_check_email" pattern="/check-email">
+    <route id="fos_user_registration_check_email" pattern="/check-email/">
         <default key="_controller">FOSUserBundle:Registration:checkEmail</default>
         <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_registration_confirm" pattern="/confirm/{token}">
+    <route id="fos_user_registration_confirm" pattern="/confirm/{token}/">
         <default key="_controller">FOSUserBundle:Registration:confirm</default>
         <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_registration_confirmed" pattern="/confirmed">
+    <route id="fos_user_registration_confirmed" pattern="/confirmed/">
         <default key="_controller">FOSUserBundle:Registration:confirmed</default>
         <requirement key="_method">GET</requirement>
     </route>

--- a/Resources/config/routing/resetting.xml
+++ b/Resources/config/routing/resetting.xml
@@ -4,22 +4,22 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_resetting_request" pattern="/request">
+    <route id="fos_user_resetting_request" pattern="/request/">
         <default key="_controller">FOSUserBundle:Resetting:request</default>
         <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_resetting_send_email" pattern="/send-email">
+    <route id="fos_user_resetting_send_email" pattern="/send-email/">
         <default key="_controller">FOSUserBundle:Resetting:sendEmail</default>
         <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="fos_user_resetting_check_email" pattern="/check-email">
+    <route id="fos_user_resetting_check_email" pattern="/check-email/">
         <default key="_controller">FOSUserBundle:Resetting:checkEmail</default>
         <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_resetting_reset" pattern="/reset/{token}">
+    <route id="fos_user_resetting_reset" pattern="/reset/{token}/">
         <default key="_controller">FOSUserBundle:Resetting:reset</default>
         <requirement key="_method">GET|POST</requirement>
     </route>

--- a/Resources/config/routing/security.xml
+++ b/Resources/config/routing/security.xml
@@ -4,15 +4,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_security_login" pattern="/login">
+    <route id="fos_user_security_login" pattern="/login/">
         <default key="_controller">FOSUserBundle:Security:login</default>
     </route>
 
-    <route id="fos_user_security_check" pattern="/login_check">
+    <route id="fos_user_security_check" pattern="/login_check/">
         <default key="_controller">FOSUserBundle:Security:check</default>
     </route>
 
-    <route id="fos_user_security_logout" pattern="/logout">
+    <route id="fos_user_security_logout" pattern="/logout/">
         <default key="_controller">FOSUserBundle:Security:logout</default>
     </route>
 


### PR DESCRIPTION
Added trailing slashes to all routes.

I don't see a reason why there should be a difference between, for example, /login and /login/. Most of the people rewrite it in .htaccess anyway.
