### PR TITLE
Added comment to confirmation

### DIFF
--- a/Resources/doc/configuration_reference.md
+++ b/Resources/doc/configuration_reference.md
@@ -32,7 +32,7 @@ fos_user:
             from_email: # Use this node only if you don't want the global email address for the confirmation email
                 address:        ...
                 sender_name:    ...
-            enabled:    false
+            enabled:    false # change to true for required email confirmation
             template:   FOSUserBundle:Registration:email.txt.twig
         form:
             type:               fos_user_registration


### PR DESCRIPTION
Email confirmation is a common enough desire for any web app that I felt like a comment would be useful in the reference to make it a little more obvious how to enable it. You can see [here](http://www.osmialowski.co.uk/troubleshooting-1-symfony-2-fosuserbundle-confirmation-email-issues#comment-69) that I'm not the first person that had to do a little digging to find it.
