### PR TITLE
Inconsistent copy in registration

### DIFF
--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -33,7 +33,7 @@ registration.email: |
     Welcome %username%!
     Hello %username%!
 
-    To finish validating your account - please visit %confirmationUrl%
+    To finish activating your account - please visit %confirmationUrl%
 
     Regards,
     the Team.


### PR DESCRIPTION
The first message to users mentions activating ones account. Then the email speaks of validation and finally the message when done says confirmation. This commit fixes that inconsistency by only communicating "activation".
