### PR TITLE
Set lastConnection date when user confirm account creation

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -87,6 +87,7 @@ class RegistrationController extends ContainerAware
 
         $user->setConfirmationToken(null);
         $user->setEnabled(true);
+        $user->setLastLogin(new \DateTime());
 
         $this->container->get('fos_user.user_manager')->updateUser($user);
         $this->authenticateUser($user);


### PR DESCRIPTION
Set lastConnection date when user confirm account creation and be connected.

A new pull-request to replace a wrong one : https://github.com/FriendsOfSymfony/FOSUserBundle/pull/414
