### PR TITLE
Default route in documentation for change-password

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -402,7 +402,7 @@ fos_user_resetting:
 
 fos_user_change_password:
     resource: "@FOSUserBundle/Resources/config/routing/change_password.xml"
-    prefix: /change-password
+    prefix: /profile
 ```
 
 Or if you prefer XML:
@@ -413,7 +413,7 @@ Or if you prefer XML:
 <import resource="@FOSUserBundle/Resources/config/routing/profile.xml" prefix="/profile" />
 <import resource="@FOSUserBundle/Resources/config/routing/registration.xml" prefix="/register" />
 <import resource="@FOSUserBundle/Resources/config/routing/resetting.xml" prefix="/resetting" />
-<import resource="@FOSUserBundle/Resources/config/routing/change_password.xml" prefix="/change-password" />
+<import resource="@FOSUserBundle/Resources/config/routing/change_password.xml" prefix="/profile" />
 ```
 
 **Note:**


### PR DESCRIPTION
After following documentation I ended up with route for changing password like this:

```
/change-password/change-password
```

This pull request change default route to

```
/profile/change-password
```

which follows convention

```
/profile
/profile/edit
```
