### PR TITLE
corrected bad type hinting

### DIFF
--- a/Propel/UserManager.php
+++ b/Propel/UserManager.php
@@ -214,7 +214,7 @@ class UserManager extends BaseUserManager
         return \PropelQuery::from($this->modelClass);
     }
 
-    protected function proxyfy(User $user)
+    protected function proxyfy($user)
     {
         $proxyClass = $this->getClass();
         $proxy = new $proxyClass($user);

--- a/Propel/UserProxy.php
+++ b/Propel/UserProxy.php
@@ -19,7 +19,7 @@ class UserProxy extends FosUser
 {
     protected $user;
 
-    public function __construct(User $user)
+    public function __construct($user)
     {
         $this->user = $user;
         if ($user->isNew()) {


### PR DESCRIPTION
Am I totally wrong or do the only way to override default Propel entity is either to remove type hinting or provide yet another interface, like `PropelUserInterface` ?
