### PR TITLE
ignore all vendor libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,5 @@ catalog.xml
 Propel/om/*
 Propel/map/*
 
-vendor/doctrine
-vendor/doctrine-common
-vendor/doctrine-dbal
-vendor/doctrine-mongodb
-vendor/doctrine-mongodb-odm
-vendor/symfony
+vendor/*
+!vendor/vendors.php


### PR DESCRIPTION
It just happened to me that the "doctrine-couchdb" vendor was not listed in the ignore. This change ignores everything but the `vendors.php` script.
