### PR TITLE
Email layout file

### DIFF
--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -43,8 +43,8 @@ registration:
     submit: Registrieren
     flash:
         user_created: Der Benutzer wurde erfolgreich erstellt
-    email: |
-        Willkommen %username%!
+    email.subject: Willkommen %username%!
+    email.body: |
         Hallo %username%!
 
         Besuche bitte folgende Seite, um Dein Benutzerkonto zu bestätigen: %confirmationUrl%
@@ -64,8 +64,8 @@ resetting:
         submit: Passwort ändern
     flash:
         success: Das Passwort wurde erfolgreich zurückgesetzt
-    email: |
-        Passwort zurücksetzen
+    email.subject: Passwort zurücksetzen
+    email.body: |
         Hallo %username%!
 
         Besuche bitte folgende Seite, um Dein Passwort zurückzusetzen: %confirmationUrl%

--- a/Resources/views/Registration/email.txt.twig
+++ b/Resources/views/Registration/email.txt.twig
@@ -1,3 +1,11 @@
-{% autoescape false %}
-{{ 'registration.email'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}
-{% endautoescape %}
+{% extends "FOSUserBundle::layout_email.html.twig" %}
+
+{% block body %}
+    {% autoescape false %}
+        {{ 'registration.email.body'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}
+    {% endautoescape %}
+{% endblock body %}
+
+{% block subject -%}
+        {{ 'registration.email.subject'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}
+{% endblock subject %}

--- a/Resources/views/Resetting/email.txt.twig
+++ b/Resources/views/Resetting/email.txt.twig
@@ -1,3 +1,11 @@
-{% autoescape false %}
-{{ 'resetting.email'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}
-{% endautoescape %}
+{% extends "FOSUserBundle::layout_email.html.twig" %}
+
+{% block body %}
+    {% autoescape false %}
+        {{ 'resetting.email.body'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}
+    {% endautoescape %}
+{% endblock body %}
+
+{% block subject -%}
+        {{ 'resetting.email.subject'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}
+{% endblock subject %}

--- a/Resources/views/layout_email.html.twig
+++ b/Resources/views/layout_email.html.twig
@@ -1,0 +1,4 @@
+{% block subject %}
+{% endblock subject %}
+{% block body %}
+{% endblock body %}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: yes
Todo: change all translation files

At the moment it is not possible to set a email layout (to add mail footer and header).

I have allready changed the template files. But i also must change all translation files. So before i start will this PR accepted?
