### PR TITLE
Small change in documentation of Logging by Username or Email

### DIFF
--- a/Resources/doc/logging_by_username_or_email.md
+++ b/Resources/doc/logging_by_username_or_email.md
@@ -82,6 +82,10 @@ security:
             # ...
 ```
 
+**Note:**
+
+> The provider key under your firewall is optional. If left out, the first provider is used automatically.
+
 ## Extending the UserManager class
 
 The other solution is to replace the default `UserManagerInterface` implementation


### PR DESCRIPTION
Since I noticed some poeple (including me, see #476) forget to specify the provider in the firewall configuration. So I thought it might be a good idea to include in the doc.
