### PR TITLE
Change "repeat password"  in polish translation 

### DIFF
--- a/Resources/translations/FOSUserBundle.pl.yml
+++ b/Resources/translations/FOSUserBundle.pl.yml
@@ -90,10 +90,10 @@ fos_user_profile_form_current: "Obecne hasło:"
 fos_user_registration_form_username: "Nazwa użytkownika:"
 fos_user_registration_form_email: "E-mail:"
 fos_user_registration_form_plainPassword_first: "Hasło:"
-fos_user_registration_form_plainPassword_second: "Powtórz Hasło:"
+fos_user_registration_form_plainPassword_second: "Powtórz hasło:"
 
 fos_user_resetting_form_new_first: "Nowe hasło:"
-fos_user_resetting_form_new_second: "Powtórz Hasło:"
+fos_user_resetting_form_new_second: "Powtórz hasło:"
 
 fos_user_change_password_form_new_first: "Nowe hasło:"
 fos_user_change_password_form_new_second: "Powtórz hasło:"


### PR DESCRIPTION
I have noticed that word  "weryfikacja"  confuses user (they look for captcha), i propose "Powtórz hasło" like it is for example in  onet.pl registration form https://konto.onet.pl/register-email.html?app_id=107

maybe this should be consulted with @jacobmaster (he authored previous change)
