### PR TITLE
Don't authenticate locked or disabled users.

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use FOS\UserBundle\Model\UserInterface;
 
 /**
@@ -117,6 +118,13 @@ class RegistrationController extends ContainerAware
      */
     protected function authenticateUser(UserInterface $user)
     {
+        try {
+            $this->container->get('security.user_checker')->checkPostAuth($user);
+        } catch (AccountStatusException $e) {
+            // Don't authenticate locked, disabled or expired users
+            return;
+        }
+
         $providerKey = $this->container->getParameter('fos_user.firewall_name');
         $token = new UsernamePasswordToken($user, null, $providerKey, $user->getRoles());
 

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use FOS\UserBundle\Model\UserInterface;
 
 /**
@@ -121,6 +122,13 @@ class ResettingController extends ContainerAware
      */
     protected function authenticateUser(UserInterface $user)
     {
+        try {
+            $this->container->get('security.user_checker')->checkPostAuth($user);
+        } catch (AccountStatusException $e) {
+            // Don't authenticate locked, disabled or expired users
+            return;
+        }
+
         $providerKey = $this->container->getParameter('fos_user.firewall_name');
         $token = new UsernamePasswordToken($user, null, $providerKey, $user->getRoles());
 


### PR DESCRIPTION
This is a fix for #464

Currently, I only avoid authenticating the user. Should we also forbid resetting the password in such case ?
