### PR TITLE
Changed line 439, typo fix "Step 4".

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -436,7 +436,7 @@ Or if you prefer XML:
 
 Now that the bundle is configured, the last thing you need to do is update your
 database schema because you have added a new entity, the `User` class which you
-created in Step 2.
+created in Step 4.
 
 For ORM run the following command.
 


### PR DESCRIPTION
Maybe it's better to configure the FOSUserBundle (Step 6) before create the User Class (Step 4) so you can generate the new UserBundle via "php app/console generate:bundle --namespace=Acme/UserBundle" without errors coming from FOSUserBundle missing configuration in config.yml.
