### PR TITLE
Clearing the token request date when resetting the password

### DIFF
--- a/Form/Handler/ResettingFormHandler.php
+++ b/Form/Handler/ResettingFormHandler.php
@@ -57,6 +57,7 @@ class ResettingFormHandler
     {
         $user->setPlainPassword($this->getNewPassword());
         $user->setConfirmationToken(null);
+        $user->clearPasswordRequestedAt();
         $user->setEnabled(true);
         $this->userManager->updateUser($user);
     }

--- a/Model/User.php
+++ b/Model/User.php
@@ -641,6 +641,14 @@ abstract class User implements UserInterface, GroupableInterface
     }
 
     /**
+     * Clears the timestamp that the user requested a password reset. 
+     */
+    public function clearPasswordRequestedAt()
+    {
+        $this->passwordRequestedAt = null;
+    }
+
+    /**
      * Gets the timestamp that the user requested a password reset.
      *
      * @return \DateTime

--- a/Tests/Model/UserTest.php
+++ b/Tests/Model/UserTest.php
@@ -45,6 +45,18 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($user->isPasswordRequestNonExpired(5));
     }
 
+    public function testIsPasswordRequestAtCleared()
+    {
+        $user = $this->getUser();
+        $passwordRequestedAt = new \DateTime('-10 seconds');
+
+        $user->setPasswordRequestedAt($passwordRequestedAt);
+        $user->clearPasswordRequestedAt();
+
+        $this->assertFalse($user->isPasswordRequestNonExpired(15));
+        $this->assertFalse($user->isPasswordRequestNonExpired(5));
+    }
+
     public function testTrueHasRole()
     {
         $user = $this->getUser();


### PR DESCRIPTION
Even after a password request token was used, it's request date remained set.
This blocked the user from requesting a password again until the token (that wasn't there anymore) TTL is expired.

This change removes the request date together with the token.
