### PR TITLE
[TwigSwiftMailer] htmlBody is now set as body instead of part

### DIFF
--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -69,7 +69,7 @@ class TwigSwiftMailer implements MailerInterface
             ->setTo($toEmail);
 
         if (!empty($htmlBody)) {
-            $message->setBody($htmlBody)
+            $message->setBody($htmlBody, 'text/html')
                 ->addPart($textBody, 'text/plain');
         } else {
             $message->setBody($textBody);


### PR DESCRIPTION
When you have a body_html and a body_text the plain version is added as the body and the html version is added as a html part. 
This is the wrong order for html email. 

See SwiftMailer docs: http://swiftmailer.org/docs/messages.html#setting-the-body-content
