### PR TITLE
refresh user instance after serialization (e.g. openid login)

### DIFF
--- a/Security/InteractiveLoginListener.php
+++ b/Security/InteractiveLoginListener.php
@@ -29,6 +29,10 @@ class InteractiveLoginListener
     {
         $user = $event->getAuthenticationToken()->getUser();
 
+        if ($user->getId() === null) {
+            $user = $this->userManager->findUserByUsername($user->getUsername());
+        }
+
         if ($user instanceof UserInterface) {
             $user->setLastLogin(new DateTime());
             $this->userManager->updateUser($user);


### PR DESCRIPTION
This fixes problems with detached Doctrine entities (e.g. after object serialization on OpenId) - needed this to get https://github.com/formapro/FpOpenIdBundle work together with FOSUserBundle.
