### PR TITLE
The maximum length of an email address is 254 characters

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -67,7 +67,7 @@
                 </option>
             </constraint>
             <constraint name="MaxLength">
-                <option name="limit">255</option>
+                <option name="limit">254</option>
                 <option name="message">fos_user.email.long</option>
                 <option name="groups">
                     <value>Registration</value>


### PR DESCRIPTION
See: http://stackoverflow.com/questions/386294/maximum-length-of-a-valid-email-address

![](http://troll.me/images/futurama-fry/not-sure-if-semantic-argument-or-pedantic-trolling.jpg)
