### PR TITLE
[Form] Rename UsernameToUserTransformer to UserToUsernameTransformer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Changelog
 
 * Removed the user-level algorithm. Use FOSAdvancedEncoderBundle instead if you need such feature.
 * Fixed resetting password clearing the token but not the token expiration. Github issue #501
+* Renamed UsernameToUsernameTransformer to UserToUsernameTransformer and changed its service ID to `fos_user.user_to_username_transformer`.
 
 ### 1.1.0  (2011-12-15)
 

--- a/Form/DataTransformer/UserToUsernameTransformer.php
+++ b/Form/DataTransformer/UserToUsernameTransformer.php
@@ -2,17 +2,17 @@
 
 namespace FOS\UserBundle\Form\DataTransformer;
 
-use Symfony\Component\Form\DataTransformerInterface;
-use FOS\UserBundle\Model\UserManagerInterface;
 use FOS\UserBundle\Model\UserInterface;
+use FOS\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /**
- * Transforms between a UserInterface and a username
+ * Transforms between a UserInterface instance and a username string.
  *
  * @author Thibault Duplessis <thibault.duplessis@gmail.com>
  */
-class UsernameToUserTransformer implements DataTransformerInterface
+class UserToUsernameTransformer implements DataTransformerInterface
 {
     /**
      * @var UserManagerInterface
@@ -25,17 +25,20 @@ class UsernameToUserTransformer implements DataTransformerInterface
     }
 
     /**
-     * Transforms a UserInterface instance to a username string
+     * Transforms a UserInterface instance into a username string.
      *
-     * @param mixed $value a UserInterface instance
+     * @param mixed $value UserInterface instance
      *
-     * @return string the username
+     * @return string Username
+     *
+     * @throws UnexpectedTypeException if the given value is not a UserInterface instance
      */
     public function transform($value)
     {
         if (null === $value) {
             return null;
         }
+
         if (!$value instanceof UserInterface) {
             throw new UnexpectedTypeException($value, 'FOS\UserBundle\Model\UserInterface');
         }
@@ -44,17 +47,20 @@ class UsernameToUserTransformer implements DataTransformerInterface
     }
 
     /**
-     * Transforms a username to a UserInterface instance
+     * Transforms a username string into a UserInterface instance.
      *
-     * @param string $value username
+     * @param string $value Username
      *
-     * @return UserInterface the corresponding user instance
+     * @return UserInterface the corresponding UserInterface instance
+     *
+     * @throws UnexpectedTypeException if the given value is not a string
      */
     public function reverseTransform($value)
     {
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return null;
         }
+
         if (!is_string($value)) {
             throw new UnexpectedTypeException($value, 'string');
         }

--- a/Form/Type/UsernameFormType.php
+++ b/Form/Type/UsernameFormType.php
@@ -2,42 +2,53 @@
 
 namespace FOS\UserBundle\Form\Type;
 
+use FOS\UserBundle\Form\DataTransformer\UserToUsernameTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilder;
-use FOS\UserBundle\Form\DataTransformer\UsernameToUserTransformer;
 
 /**
- * Takes a username as input,
- * exposes a User instance
+ * Form type for representing a UserInterface instance by its username string.
  *
  * @author Thibault Duplessis <thibault.duplessis@gmail.com>
  */
 class UsernameFormType extends AbstractType
 {
     /**
-     * @var UsernameToUserTransformer
+     * @var UserToUsernameTransformer
      */
     protected $usernameTransformer;
 
-    public function __construct(UsernameToUserTransformer $usernameTransformer)
+    /**
+     * Constructor.
+     *
+     * @param UserToUsernameTransformer $usernameTransformer
+     */
+    public function __construct(UserToUsernameTransformer $usernameTransformer)
     {
         $this->usernameTransformer = $usernameTransformer;
     }
 
+    /**
+     * @see Symfony\Component\Form\AbstractType::buildForm()
+     */
     public function buildForm(FormBuilder $builder, array $options)
     {
         parent::buildForm($builder, $options);
 
-        $builder
-            ->resetClientTransformers()
-            ->appendClientTransformer($this->usernameTransformer);
+        $builder->prependClientTransformer($this->usernameTransformer);
     }
 
+    /**
+     * @see Symfony\Component\Form\AbstractType::getParent()
+     */
     public function getParent(array $options)
     {
         return 'text';
     }
 
+    /**
+     * @see Symfony\Component\Form\FormTypeInterface::getName()
+     */
     public function getName()
     {
         return 'fos_user_username';

--- a/Resources/config/username_form_type.xml
+++ b/Resources/config/username_form_type.xml
@@ -8,10 +8,10 @@
 
         <service id="fos_user.username_form_type" class="FOS\UserBundle\Form\Type\UsernameFormType">
             <tag name="form.type" alias="fos_user_username" />
-            <argument type="service" id="fos_user.username_to_user_transformer" />
+            <argument type="service" id="fos_user.user_to_username_transformer" />
         </service>
 
-        <service id="fos_user.username_to_user_transformer" class="FOS\UserBundle\Form\DataTransformer\UsernameToUserTransformer" public="false">
+        <service id="fos_user.user_to_username_transformer" class="FOS\UserBundle\Form\DataTransformer\UserToUsernameTransformer" public="false">
             <argument type="service" id="fos_user.user_manager" />
         </service>
 


### PR DESCRIPTION
This change was suggested by @bschussek in symfony/symfony#3016.

Additionally, this commit reverts 6cbe4da32a58d9f8e4fc656dc22aea56c432d89d in favor of prepending our transformer in UsernameFormType.
