### PR TITLE
Give generateToken() the notion of a max length

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -756,9 +756,10 @@ abstract class User implements UserInterface, GroupableInterface
     /**
      * Generates a token.
      *
+     * @param int $maxLength
      * @return string
      */
-    protected function generateToken()
+    protected function generateToken($maxLength = null)
     {
         $bytes = false;
         if (function_exists('openssl_random_pseudo_bytes') && 0 !== stripos(PHP_OS, 'win')) {
@@ -774,6 +775,8 @@ abstract class User implements UserInterface, GroupableInterface
             $bytes = hash('sha256', uniqid(mt_rand(), true), true);
         }
 
-        return base_convert(bin2hex($bytes), 16, 36);
+        $wholeToken = base_convert(bin2hex($bytes), 16, 36);
+
+        return null === $maxLength ? $wholeToken : substr($wholeToken, 0, $maxLength);
     }
 }

--- a/Tests/Model/GenerateTokenTestUser.php
+++ b/Tests/Model/GenerateTokenTestUser.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Tests\Model;
+
+use FOS\UserBundle\Model\User;
+
+class GenerateTokenTestUser extends User
+{
+    public function testGenerateToken($maxLength = null)
+    {
+        return $this->generateToken($maxLength);
+    }
+}

--- a/Tests/Model/UserTest.php
+++ b/Tests/Model/UserTest.php
@@ -123,6 +123,21 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($confirmationToken, $user->getConfirmationToken());
     }
 
+    public function testGenerateToken()
+    {
+        $user = new GenerateTokenTestUser();
+
+        $token1 = $user->testGenerateToken();
+        $token2 = $user->testGenerateToken(10);
+        $token3 = $user->testGenerateToken(100);
+
+        $this->assertGreaterThanOrEqual(49, strlen($token1));
+        $this->assertLessThanOrEqual(50, strlen($token1));
+        $this->assertEquals(10, strlen($token2));
+        $this->assertGreaterThanOrEqual(49, strlen($token3));
+        $this->assertLessThanOrEqual(50, strlen($token3));
+    }
+
     protected function getUser()
     {
         return $this->getMockForAbstractClass('FOS\UserBundle\Model\User');


### PR DESCRIPTION
This feature could be useful for a project that needs user related tokens to be generated but might not want a string that is as long as the strings `generateToken` returns natively.
