### PR TITLE
Added xml version of services.yml to the docs

### DIFF
--- a/Resources/doc/logging_by_username_or_email.md
+++ b/Resources/doc/logging_by_username_or_email.md
@@ -64,6 +64,13 @@ services:
         arguments: ["@fos_user.user_manager"]
 ```
 
+```xml
+<!-- src/Acme/UserBundle/Resources/config/services.xml -->
+<service id="acme_user.my_provider" class="Acme\UserBundle\Security\Provider\MyProvider" public="false">
+    <argument type="service" id="fos_user.user_manager" />
+</service>
+```
+
 You can now configure SecurityBundle to use your own service as the user
 provider instead of using the `fos_user.user_manager` service:
 


### PR DESCRIPTION
I think this should be added for people who have trouble to convert the services.yml to services.xml. Especially people who are new to symfony can have a hard time doing this.
