### PR TITLE
prefixed fos table names in propel schema with "fos_" because "user" and...

### DIFF
--- a/Resources/config/propel/schema.xml
+++ b/Resources/config/propel/schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <database name="default" namespace="FOS\UserBundle\Propel" defaultIdMethod="native">
 
-    <table name="user">
+    <table name="fos_user" phpName="User">
         <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
         <column name="username" type="varchar" size="255" primaryString="true" />
         <column name="username_canonical" type="varchar" size="255" />
@@ -34,7 +34,7 @@
         </behavior>
     </table>
 
-    <table name="group">
+    <table name="fos_group" phpName="Group">
         <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
         <column name="name" type="varchar" size="255" required="true" primaryString="true" />
         <column name="roles" type="array" />
@@ -44,14 +44,14 @@
         </behavior>
     </table>
 
-    <table name="user_group" isCrossRef="true">
-        <column name="user_id" type="integer" required="true" primaryKey="true" />
-        <column name="group_id" type="integer" required="true" primaryKey="true" />
-        <foreign-key foreignTable="user">
+    <table name="fos_user_group" phpName="UserGroup" isCrossRef="true">
+        <column name="fos_user_id" type="integer" required="true" primaryKey="true" />
+        <column name="fos_group_id" type="integer" required="true" primaryKey="true" />
+        <foreign-key foreignTable="fos_user">
             <reference local="user_id" foreign="id" />
         </foreign-key>
 
-        <foreign-key foreignTable="group">
+        <foreign-key foreignTable="fos_group">
             <reference local="group_id" foreign="id" />
         </foreign-key>
     </table>


### PR DESCRIPTION
... "group" are reserved sql words

the used tables names in the propel schema are reserved sql keywords. this renders the fos user bundle unuseable with postgres (yes, developers which use postgres exist :) ). i have not tested it in depth but as i tried to get fos user bundle up and running with postgres i also tried sqlite which doesn't worked either.

by simple prefixing the table names with "fos_" it works out of the box.

currently we had to use the propel external schema feature to override the default names.

it's not a good practice using reserved keywords as table names.

http://www.postgresql.org/docs/8.2/static/sql-keywords-appendix.html

```
Key Word    PostgreSQL  SQL:2003      SQL:1999  SQL-92
USER    reserved             reserved      reserved     reserved
GROUP   reserved             reserved      reserved     reserved
```

https://dev.mysql.com/doc/refman/5.0/en/reserved-words.html

```
Table 8.2. Reserved Words in MySQL 5.0.96
GROUP
```

escaping with quotes is also a solution but this relies on the ORM/DAL and also can have sideeffects like making the case of the table relevant. see 4.1.1. Identifiers and Key Words http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html    

currently i have a broken test environment, if someone can run the tests for me?
