### PR TITLE
Removed the $options argument from the getDefaultOptions method signatures

### DIFF
--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -22,7 +22,7 @@ class ChangePasswordFormType extends AbstractType
         $builder->add('new', 'repeated', array('type' => 'password'));
     }
 
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         return array(
             'data_class' => 'FOS\UserBundle\Form\Model\ChangePassword',

--- a/Form/Type/GroupFormType.php
+++ b/Form/Type/GroupFormType.php
@@ -31,7 +31,7 @@ class GroupFormType extends AbstractType
         $builder->add('name');
     }
 
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         return array(
             'data_class' => $this->class,

--- a/Form/Type/ProfileFormType.php
+++ b/Form/Type/ProfileFormType.php
@@ -37,7 +37,7 @@ class ProfileFormType extends AbstractType
         ;
     }
 
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         return array(
             'data_class' => 'FOS\UserBundle\Form\Model\CheckPassword',

--- a/Form/Type/RegistrationFormType.php
+++ b/Form/Type/RegistrationFormType.php
@@ -34,7 +34,7 @@ class RegistrationFormType extends AbstractType
             ->add('plainPassword', 'repeated', array('type' => 'password'));
     }
 
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         return array(
             'data_class' => $this->class,

--- a/Form/Type/ResettingFormType.php
+++ b/Form/Type/ResettingFormType.php
@@ -21,7 +21,7 @@ class ResettingFormType extends AbstractType
         $builder->add('new', 'repeated', array('type' => 'password'));
     }
 
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         return array(
             'data_class' => 'FOS\UserBundle\Form\Model\ResetPassword',


### PR DESCRIPTION
Updates the getDefaultOptions method signature in the form types to be compatible with the latest changes to Symfony/Component/Form/FormTypeInterface
