### PR TITLE
Minor Fix, when calling ..../app_dev.php/group/new

### DIFF
--- a/Form/Type/GroupFormType.php
+++ b/Form/Type/GroupFormType.php
@@ -31,7 +31,7 @@ class GroupFormType extends AbstractType
         $builder->add('name');
     }
 
-    public function getDefaultOptions()
+    public function getDefaultOptions(array $options)
     {
         return array(
             'data_class' => $this->class,


### PR DESCRIPTION
When calling http://yoursite.com/app_dev.php/group/new to create a new group.
you would get the error
 Fatal error: Declaration of FOS\UserBundle\Form\Type\GroupFormType::getDefaultOptions() must be compatible with that of Symfony\Component\Form\FormTypeInterface::getDefaultOptions() in C:\Program Files (x86)\Zend\Apache2\htdocs\mysite\vendor\bundles\FOS\UserBundle\Form\Type\GroupFormType.php on line 18
