### PR TITLE
Set getDefaultOptions() comptatible with FormTypeInterface::getDefaultOptions(array $options)

### DIFF
--- a/Form/Type/RegistrationFormType.php
+++ b/Form/Type/RegistrationFormType.php
@@ -33,13 +33,15 @@ class RegistrationFormType extends AbstractType
             ->add('email', 'email')
             ->add('plainPassword', 'repeated', array('type' => 'password'));
     }
-
-    public function getDefaultOptions()
+   
+    public function getDefaultOptions(array $options)
     {
-        return array(
+        $default = array(
             'data_class' => $this->class,
             'intention'  => 'registration',
         );
+        
+        return array_merge($default, $options);
     }
 
     public function getName()


### PR DESCRIPTION
Fix fatal error:

Declaration of FOS\UserBundle\Form\Type\RegistrationFormType::getDefaultOptions() must be compatible with that of Symfony\Component\Form\FormTypeInterface::getDefaultOptions()
