### PR TITLE
Fixed Type Error in Attribute "length"

### DIFF
--- a/Resources/doc/overriding_forms.md
+++ b/Resources/doc/overriding_forms.md
@@ -35,7 +35,7 @@ class User extends BaseUser
     protected $id;
 
     /**
-     * @ORM\Column(type="string", length="255")
+     * @ORM\Column(type="string", length=255)
      *
      * @Assert\NotBlank(message="Please enter your name.", groups={"Registration", "Profile"})
      * @Assert\MinLength(limit="3", message="The name is too short.", groups={"Registration", "Profile"})


### PR DESCRIPTION
[Type Error] Attribute "length" of @ORM\Column declared on property Acme\UserBundle\Entity\User::$name expects a(n) integer, but got string.
