### PR TITLE
[Typo] Fixed a Yaml parsing error in documentation

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -239,7 +239,7 @@ security:
             id: fos_user.user_manager
 
     encoders:
-        "FOS\UserBundle\Model\UserInterface": sha512
+        FOS\UserBundle\Model\UserInterface: sha512
 
     firewalls:
         main:


### PR DESCRIPTION
Yaml syntax with antislash must be:

```
FOS\UserBundle\Model\UserInterface: sha512
```

or:

```
"FOS\\UserBundle\\Model\\UserInterface": sha512
```
