### PR TITLE
replaced deprecated setMessage and changed path to passwordProperty

### DIFF
--- a/Validator/PasswordValidator.php
+++ b/Validator/PasswordValidator.php
@@ -45,7 +45,7 @@ class PasswordValidator extends ConstraintValidator
         $user = null === $constraint->userProperty ? $object : $object->{$constraint->userProperty};
         $encoder = $this->encoderFactory->getEncoder($user);
         if (!$encoder->isPasswordValid($user->getPassword(), $raw, $user->getSalt())) {
-            $this->setMessage($constraint->message);
+            $this->context->addViolationAtSubPath($constraint->passwordProperty, $constraint->message);
 
             return false;
         }


### PR DESCRIPTION
Removed the depcreated setMessage method and changed the propery path so the error is displayed correctly at the password field and not on top of the form.
