### PR TITLE
added Valid constraint on CheckPassword user property

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -109,6 +109,9 @@
                 <value>Profile</value>
             </option>
         </constraint>
+        <property name="user">
+            <constraint name="Valid" />
+        </property>
     </class>
 
     <class name="FOS\UserBundle\Form\Model\ChangePassword">


### PR DESCRIPTION
When extending the User with custom fields and put constraints on them with validation group "Profile" these won' t be validated because the user property of FOS\UserBundle\Form\Model\CheckPassword has no Valid constraint.

This PR fixes that.
