### PR TITLE
Decouple UserProvider from UserManager

### DIFF
--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -106,9 +106,6 @@ class FOSUserExtension extends Extension
         if (!empty($config['group'])) {
             $this->loadGroups($config['group'], $container, $loader, $config['db_driver']);
         }
-
-        // add configuration, overiding options etc.
-        $loader->load('user_provider.xml');
     }
 
     private function loadProfile(array $config, ContainerBuilder $container, XmlFileLoader $loader)

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -17,7 +17,7 @@
 
         <service id="fos_user.user_checker" alias="security.user_checker" />
 
-        <service id="fos_user.user_provider" class="%fos_user.user_provider.class%">
+        <service id="fos_user.user_provider" class="%fos_user.user_provider.class%" public="false">
             <argument>%fos_user.model.user.class%</argument>
             <argument type="service" id="fos_user.user_manager" />
         </service>

--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -21,14 +21,14 @@ use FOS\UserBundle\Model\UserManagerInterface;
 class UserProvider implements UserProviderInterface
 {
     /**
-     * @var \FOS\UserBundle\Model\UserManagerInterface
+     * @var UserManagerInterface
      */
     protected $userManager;
 
     /**
      * Constructor.
      *
-     * @param \FOS\UserBundle\Model\UserManagerInterface $userManager
+     * @param UserManagerInterface $userManager
      */
     public function __construct($class, UserManagerInterface $userManager)
     {
@@ -37,18 +37,7 @@ class UserProvider implements UserProviderInterface
     }
 
     /**
-     * Returns the user matching the username.
-     *
-     * This method uses the user manager service to find the user
-     * which matches the username or if no one exists throws a
-     * security system relevant exception which results in an
-     * authentication error.
-     *
-     * @param string $username
-     *
-     * @throws \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     *
-     * @return \FOS\UserBundle\Model\UserInterface
+     * {@inheritDoc}
      */
     public function loadUserByUsername($username)
     {
@@ -62,18 +51,7 @@ class UserProvider implements UserProviderInterface
     }
 
     /**
-     * Returns a refreshed instance of the user entity.
-     *
-     * This method checks if the given user is conform with the user interface
-     * and than refreshes its instance from the database.
-     * This is usefull if there are changes made to the user profile and the
-     * session token needs an update.
-     *
-     * @param \FOS\UserBundle\Model\UserInterface $user
-     *
-     * @throws \Symfony\Component\Security\Core\Exception\UnsupportedUserException
-     *
-     * @return \FOS\UserBundle\Model\UserInterface
+     * {@inheritDoc}
      */
     public function refreshUser(SecurityUserInterface $user)
     {


### PR DESCRIPTION
FriendsOfSymfony with UserProvider decoupled from the UserManager.

UserManager still implements the UserProviderinterface for BC
