### PR TITLE
Fixed broken reference to UserPassword constraint in use statement

### DIFF
--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -11,7 +11,7 @@
 
 namespace FOS\UserBundle\Form\Type;
 
-use Symfony\Bundle\SecurityBundle\Validator\Constraint\UserPassword;
+use Symfony\Component\Security\Core\Validator\Constraint\UserPassword;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Form\AbstractType;


### PR DESCRIPTION
I expect this bug/typo to be due to changes from sf2 and sf2.1.

Please include in master.

/ Jesper
