### PR TITLE
Make it easier to include templates (e.g. the login form) from other templates with {% render ... %}

### DIFF
--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -11,13 +11,24 @@
 
 namespace FOS\UserBundle\Controller;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\Security\Core\SecurityContext;
 
 class SecurityController extends ContainerAware
 {
-    public function loginAction()
+
+    /**
+     * 
+     *
+     * @Template()
+     */
+    public function loginFormAction()
     {
+        /**
+         * Copy of FOSUserBundle:Security:loginAction
+         */ 
+
         $request = $this->container->get('request');
         /* @var $request \Symfony\Component\HttpFoundation\Request */
         $session = $request->getSession();
@@ -42,11 +53,18 @@ class SecurityController extends ContainerAware
 
         $csrfToken = $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate');
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Security:login.html.'.$this->container->getParameter('fos_user.template.engine'), array(
+        return array(
             'last_username' => $lastUsername,
             'error'         => $error,
             'csrf_token' => $csrfToken,
-        ));
+        );
+    }
+
+    public function loginAction()
+    {
+        $parameters = $this->loginFormAction();
+
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Security:login.html.'.$this->container->getParameter('fos_user.template.engine'), $parameters);
     }
 
     public function checkAction()

--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -5,18 +5,6 @@
     <div>{{ error|trans({}, 'FOSUserBundle') }}</div>
 {% endif %}
 
-<form action="{{ path("fos_user_security_check") }}" method="post">
-    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
+{% include 'FOSUserBundle:Security:loginForm.html.twig' %}
 
-    <label for="username">{{ 'security.login.username'|trans({}, 'FOSUserBundle') }}</label>
-    <input type="text" id="username" name="_username" value="{{ last_username }}" />
-
-    <label for="password">{{ 'security.login.password'|trans({}, 'FOSUserBundle') }}</label>
-    <input type="password" id="password" name="_password" />
-
-    <input type="checkbox" id="remember_me" name="_remember_me" value="on" />
-    <label for="remember_me">{{ 'security.login.remember_me'|trans({}, 'FOSUserBundle') }}</label>
-
-    <input type="submit" id="_submit" name="_submit" value="{{ 'security.login.submit'|trans({}, 'FOSUserBundle') }}" />
-</form>
 {% endblock fos_user_content %}

--- a/Resources/views/Security/loginForm.html.twig
+++ b/Resources/views/Security/loginForm.html.twig
@@ -1,0 +1,19 @@
+
+	{% if error %}
+	    <div>{{ error|trans({}, 'FOSUserBundle') }}</div>
+	{% endif %}
+
+	<form action="{{ path("fos_user_security_check") }}" method="post">
+	    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
+
+	    <label for="username">{{ 'security.login.username'|trans({}, 'FOSUserBundle') }}</label>
+	    <input type="text" id="username" name="_username" value="{{ last_username }}" />
+
+	    <label for="password">{{ 'security.login.password'|trans({}, 'FOSUserBundle') }}</label>
+	    <input type="password" id="password" name="_password" />
+
+	    <input type="checkbox" id="remember_me" name="_remember_me" value="on" />
+	    <label for="remember_me">{{ 'security.login.remember_me'|trans({}, 'FOSUserBundle') }}</label>
+
+	    <input type="submit" id="_submit" name="_submit" value="{{ 'security.login.submit'|trans({}, 'FOSUserBundle') }}" />
+	</form>


### PR DESCRIPTION
Thought that it could be helpful to split the loginAction method into two - one calling the layout.html.twig - one just displaying the plain form.

This makes it very easy - without extending the SecurityController - to include the login form globally by putting {% render 'FOSUser:Security:loginForm %} into e.g. the layout.html.twig
