### PR TITLE
Documentation: added to note on authentication method compatibility the inability to support http_digest

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -286,9 +286,15 @@ provider for the firewall to use as part of the authentication process.
 **Note:**
 
 > Although we have used the form login mechanism in this example, the FOSUserBundle
-> user provider is compatible with many other authentication methods as well. Please
-> read the Symfony2 Security component documention for more information on the
-> other types of authentication methods.
+> user provider is compatible with many other authentication methods as well.
+>
+> The FOSUserBundle cannot be used with the http_digest authentication method. HTTP
+> digest authentication relies on server-side plaintext passwords; the
+> FOSUserBundle salts and hashes passwords making the plaintext password
+> irretrievable.
+> 
+> Please read the Symfony2 Security component documention for more information on
+> the other types of authentication methods.
 
 The `access_control` section is where you specify the credentials necessary for
 users trying to access specific parts of your application. The bundle requires


### PR DESCRIPTION
FOSUserBundle cannot support the http_digest authentication method. HTTP digest relies on plaintext passwords being stored.

I tried to use FOSUserBundle with http_digest and took a while tracking down the cause of it not working.

Updating the documentation may help others from trying to attempt the impossible.
