### PR TITLE
Add extension point for loginAction

### DIFF
--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -42,11 +42,25 @@ class SecurityController extends ContainerAware
 
         $csrfToken = $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate');
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Security:login.html.'.$this->container->getParameter('fos_user.template.engine'), array(
+        return $this->renderLogin(array(
             'last_username' => $lastUsername,
             'error'         => $error,
             'csrf_token' => $csrfToken,
         ));
+    }
+
+    /**
+     * Renders the login template with the given parameters. Overwrite this function in
+     * an extended controller to provide additional data for the login template.
+     *
+     * @param array $data
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function renderLogin(array $data)
+    {
+        $template = sprintf('FOSUserBundle:Security:login.html.%s', $this->container->getParameter('fos_user.template.engine'));
+
+        return $this->container->get('templating')->renderResponse($template, $data);
     }
 
     public function checkAction()


### PR DESCRIPTION
I've found I want to extend the SecurityController to add more things to the login page, rather than using subrequests to handle it.

I dont really want to copy the entire loginAction though, it adds additional maintenance requirements and may introduce security issues.

Not sure if Stof thinks this is a good idea, but felt sending a PR would create some discussion.
