### PR TITLE
Fix parsing error for the Japanese translation

### DIFF
--- a/Resources/translations/FOSUserBundle.ja.yml
+++ b/Resources/translations/FOSUserBundle.ja.yml
@@ -60,7 +60,7 @@ resetting:
     password_already_requested: このユーザーのパスワードは 24 時間以内ですでにリクエストされています。
     check_email: %email% 宛にメールを送信しました。メールに記載された確認 URL にアクセスして、アカウントを有効化してください。
     request:
-        invalid_username: "%username%" というユーザー名またはメールアドレスは存在しません。
+        invalid_username: "\"%username%\" というユーザー名またはメールアドレスは存在しません。"
         username: "ユーザー名かメールアドレス:"
         submit: パスワードのリセット
     reset:


### PR DESCRIPTION
Because of Japanese grammar the "%username%" was moved to the start of the sentence for that specific translations but it is not valid in YAML as it starts with double quotes and then add more content outside the quotes. This was throwing an exception when using Japanese and the FOS Bundle.

I added quotes and escaped the original ones.
