### PR TITLE
fix "There is no user provider for user .." with custom Propel class

### DIFF
--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -18,7 +18,6 @@ use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 use FOS\UserBundle\Model\User;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
-use FOS\UserBundle\Propel\User as PropelUser;
 
 class UserProvider implements UserProviderInterface
 {
@@ -56,7 +55,7 @@ class UserProvider implements UserProviderInterface
      */
     public function refreshUser(SecurityUserInterface $user)
     {
-        if (!$user instanceof User && !$user instanceof PropelUser) {
+        if (!$user instanceof User && !$this->supportsClass(get_class($user))) {
             throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
         }
 

--- a/Tests/Security/UserProviderTest.php
+++ b/Tests/Security/UserProviderTest.php
@@ -87,4 +87,21 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->userProvider->refreshUser($user);
     }
+
+    public function testRefreshPropelClassFromUserManager()
+    {
+        $user = $this->getMockForAbstractClass('FOS\UserBundle\Tests\TestCustomUser', array(), 'UserRefreshClassFromUserManager');
+        $user->setId(42);
+
+        $this->userManager->expects($this->atLeastOnce())
+            ->method('getClass')
+            ->will($this->returnValue('UserRefreshClassFromUserManager'));
+
+        $this->userManager->expects($this->once())
+            ->method('findUserBy')
+            ->with(array('id' => 42))
+            ->will($this->returnValue($user));
+
+        $this->assertSame($user, $this->userProvider->refreshUser($user));
+    }
 }

--- a/Tests/TestCustomUser.php
+++ b/Tests/TestCustomUser.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Tests;
+
+use FOS\UserBundle\Model\UserInterface;
+
+abstract class TestCustomUser implements UserInterface
+{
+    protected $id;
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
This fixes an exception thrown when using a custom Propel user class:

``` yaml
fos_user:
    db_driver: propel
    firewall_name: main
    user_class: Sternenbund\Model\User\User
```
