### PR TITLE
fix issue where unserialized objects do not work

### DIFF
--- a/Propel/User.php
+++ b/Propel/User.php
@@ -48,6 +48,7 @@ class User extends BaseUser implements UserInterface, GroupableInterface
                 $this->locked,
                 $this->credentials_expired,
                 $this->enabled,
+                $this->_new,
             )
         );
     }
@@ -57,6 +58,12 @@ class User extends BaseUser implements UserInterface, GroupableInterface
      */
     public function unserialize($serialized)
     {
+        $data = unserialize($serialized);
+
+        // add a few extra elements in the array to ensure that we have enough keys when unserializing
+        // older data which does not include all properties.
+        $data = array_merge($data, array_fill(0, 1, null));
+
         list(
             $this->id,
             $this->username,
@@ -65,8 +72,9 @@ class User extends BaseUser implements UserInterface, GroupableInterface
             $this->expired,
             $this->locked,
             $this->credentials_expired,
-            $this->enabled
-        ) = unserialize($serialized);
+            $this->enabled,
+            $this->_new
+        ) = $data;
     }
 
     /**

--- a/Tests/Propel/UserTest.php
+++ b/Tests/Propel/UserTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Propel;
+
+class UserTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Propel')) {
+            $this->markTestSkipped('Propel not installed');
+        }
+    }
+
+    public function testSerialize()
+    {
+        $group = new Group();
+        $group->setName('Developers');
+
+        $user = new User();
+        $user->setEmail('foobar@example.com');
+        $user->setPassword('123456');
+        $user->addGroup($group);
+        $user->save();
+
+        $userId = $user->getId();
+        $this->assertInternalType('int', $userId);
+
+        $serialized = serialize($user);
+        UserPeer::clearInstancePool();
+        $this->assertCount(0, UserPeer::$instances);
+
+        $unserialized = unserialize($serialized);
+        $fetchedUser = UserQuery::create()->findOneById($userId);
+
+        $this->assertInstanceOf('FOS\UserBundle\Propel\User', $unserialized);
+        $this->assertCount(1, UserPeer::$instances);
+        $this->assertTrue($fetchedUser->equals($unserialized));
+
+        $this->assertCount(1, $unserialized->getGroups());
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -22,5 +22,6 @@ if (class_exists('Propel')) {
     $builder = new \PropelQuickBuilder();
     $builder->getConfig()->setBuildProperty('behavior.typehintable.class', $class->getFileName());
     $builder->setSchema(file_get_contents(__DIR__.'/../Resources/config/propel/schema.xml'));
-    $builder->buildClasses();
+    $builder->setClassTargets(array('tablemap', 'peer', 'object', 'query'));
+    $builder->build();
 }


### PR DESCRIPTION
This fixes an issue, where objects are not correctly present, e.g. when switching users while having instance pooling activated.

**The un-/serialize will break backward compatibility with old sessions.**
