### PR TITLE
Fix for targetUrl in confirmed.html.twig

### DIFF
--- a/Resources/views/Registration/confirmed.html.twig
+++ b/Resources/views/Registration/confirmed.html.twig
@@ -3,7 +3,7 @@
 {% block fos_user_content %}
     <p>{{ 'registration.confirmed'|trans({'%username%': user.username}, 'FOSUserBundle') }}</p>
     {% if app.session is not empty %}
-        {% set targetUrl = app.session.get('_security.target_path') %}
+        {% set targetUrl = app.session.get('_security.' ~ app.security.token.providerKey ~ '.target_path') %}
         {% if targetUrl is not empty %}<p><a href="{{ targetUrl }}">{{ 'registration.back'|trans({}, 'FOSUserBundle') }}</a></p>{% endif %}
     {% endif %}
 {% endblock fos_user_content %}


### PR DESCRIPTION
Due a change (see below) in the Symfony Security component, the "registration.back" url in the confirmed.twig.html template cannot be displayed anymore.

https://github.com/symfony/symfony/commit/8ffaafa86741a03ecb2f91e3d67802f4c6baf36b#L3L183

This also fixes https://github.com/FriendsOfSymfony/FOSUserBundle/issues/814
