### PR TITLE
Typo in canonicalizer configuration doc

### DIFF
--- a/Resources/doc/canonicalizer.md
+++ b/Resources/doc/canonicalizer.md
@@ -20,7 +20,7 @@ and register it as a service:
 
 ``` yaml
 # app/config/config.yml
-service:
+services:
     my_canonicalizer:
         class: Acme\UserBundle\Util\CustomCanonicalizer
         public: false


### PR DESCRIPTION
"services" should be "service".
