### PR TITLE
Improved German translation

### DIFF
--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -91,6 +91,6 @@ form:
     email: "E-Mail-Adresse:"
     current_password: "Derzeitiges Passwort:"
     password: "Passwort:"
-    password_confirmation: "Bestätigung:"
+    password_confirmation: "Passwort bestätigen:"
     new_password: "Neues Passwort:"
-    new_password_confirmation: "Bestätigung:"
+    new_password_confirmation: "Neues Passwort bestätigen:"


### PR DESCRIPTION
"Verification" was translated as "Bestätigung" which confuses users. It's better to use the equivalent of "Verify password" or "Confirm password" to make things clear.
