### PR TITLE
change mongodb type for roles to be collection instead of hash

### DIFF
--- a/Resources/config/doctrine/Group.mongodb.xml
+++ b/Resources/config/doctrine/Group.mongodb.xml
@@ -8,7 +8,7 @@
 
         <field name="name" fieldName="name" type="string" />
 
-        <field name="roles" fieldName="roles" type="hash" />
+        <field name="roles" fieldName="roles" type="collection" />
 
         <indexes>
             <index unique="true" dropDups="true">

--- a/Resources/config/doctrine/User.mongodb.xml
+++ b/Resources/config/doctrine/User.mongodb.xml
@@ -32,7 +32,7 @@
 
         <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="date" />
 
-        <field name="roles" fieldName="roles" type="hash" />
+        <field name="roles" fieldName="roles" type="collection" />
 
         <indexes>
             <index unique="true" dropDups="true">


### PR DESCRIPTION
After this change https://github.com/doctrine/mongodb-odm/pull/472 the roles are being stored in mongo as an object instead of an array which breaks queries like this

```
$this->createQueryBuilder()->field('roles')->in(array('ROLE_ADMIN'));
```

Changing the type to collection stores them as an array.
