### PR TITLE
Fix a typo to get the username of user objet

### DIFF
--- a/Resources/views/Registration/confirmed.html.twig
+++ b/Resources/views/Registration/confirmed.html.twig
@@ -1,7 +1,7 @@
 {% extends "FOSUserBundle::layout.html.twig" %}
 
 {% block fos_user_content %}
-    <p>{{ 'registration.confirmed'|trans({'%username%': user.username}, 'FOSUserBundle') }}</p>
+    <p>{{ 'registration.confirmed'|trans({'%username%': user.Username}, 'FOSUserBundle') }}</p>
     {% if app.session is not empty %}
         {% set targetUrl = app.session.get('_security.' ~ app.security.token.providerKey ~ '.target_path') %}
         {% if targetUrl is not empty %}<p><a href="{{ targetUrl }}">{{ 'registration.back'|trans({}, 'FOSUserBundle') }}</a></p>{% endif %}


### PR DESCRIPTION
To solve this error:
`An exception has been thrown during the rendering of a template ("Notice: Array to string conversion in /var/www/investigation/framework-standard-edition/vendor/symfony/symfony/src/Symfony/Component/Translation/Translator.php line 130") in "FOSUserBundle:Registration:confirmed.html.twig".`
