### PR TITLE
Fix dependency on form.csrf_provider

### DIFF
--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -39,7 +39,9 @@ class SecurityController extends ContainerAware
         // last username entered by the user
         $lastUsername = (null === $session) ? '' : $session->get(SecurityContext::LAST_USERNAME);
 
-        $csrfToken = $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate');
+        $csrfToken = $this->container->has('form.csrf_provider')
+            ? $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate')
+            : null;
 
         return $this->renderLogin(array(
             'last_username' => $lastUsername,


### PR DESCRIPTION
When CSRF protection is disabled in the main Symfony framework configuration, an exception will be thrown in Security:login because the form.csrf_provider service is not available. This patch fixes that.
