### PR TITLE
Fixed flashbag output in layout.html.twig

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -15,10 +15,12 @@
             {% endif %}
         </div>
 
-        {% for key, message in app.session.flashbag.all() %}
-        <div class="{{ key }}">
-            {{ message|trans({}, 'FOSUserBundle') }}
-        </div>
+        {% for type, messages in app.session.flashbag.all() %}
+            {% for key, message in messages %}
+                <div class="flash-{{ type }}">
+                    {{ message|trans({}, 'FOSUserBundle') }}
+                </div>
+            {% endfor %}
         {% endfor %}
 
         <div>


### PR DESCRIPTION
Since Symfony 2.1, messages are grouped by type. Added a second for-loop to iterate types.
fixes #978
