### PR TITLE
Fixed User::getRoles()

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -280,7 +280,9 @@ abstract class User implements UserInterface, GroupableInterface
         }
 
         // we need to make sure to have at least one role
-        $roles[] = static::ROLE_DEFAULT;
+        if (empty($roles)) {
+            $roles[] = static::ROLE_DEFAULT;
+        }
 
         return array_unique($roles);
     }

--- a/Tests/Model/UserTest.php
+++ b/Tests/Model/UserTest.php
@@ -77,6 +77,17 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $user->addRole($newrole);
         $this->assertTrue($user->hasRole($newrole));
     }
+    
+    public function testGetRolesAddDefaultRole()
+    {
+        $user = $this->getUser();
+        $defaultrole = User::ROLE_DEFAULT;
+        $this->assertTrue(in_array($defaultrole, $user->getRoles()));
+        $newrole = 'ROLE_X';
+        $user->addRole($newrole);
+        $this->assertTrue($user->hasRole($newrole));
+        $this->assertFalse($user->hasRole($defaultrole));        
+    }
 
     /**
      * @return User


### PR DESCRIPTION
Default role is added in User::getRoles() only when there are no roles assigned to user
