### PR TITLE
Adding route to the login url

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -261,7 +261,10 @@ security:
                 provider: fos_userbundle
                 csrf_provider: form.csrf_provider
                 login_path: fos_user_security_login
-            logout:       true
+                check_path: fos_user_security_check
+            logout:
+                path: fos_user_security_logout
+                target: /
             anonymous:    true
 
     access_control:


### PR DESCRIPTION
The default route could be prefixed so the default_path (/login) can't work. In order to resolve this issue the route should be enforced in the configuration of the form_login.
