### PR TITLE
Fix for symfony 2.1 flash messages looping in docs #978

### DIFF
--- a/Resources/doc/overriding_templates.md
+++ b/Resources/doc/overriding_templates.md
@@ -36,10 +36,12 @@ Here is the default `layout.html.twig` provided by the FOSUserBundle:
             {% endif %}
         </div>
 
-        {% for key, message in app.session.flashbag.all() %}
-        <div class="{{ key }}">
-            {{ message|trans({}, 'FOSUserBundle') }}
-        </div>
+        {% for type, messages in app.session.flashbag.all() %}
+            {% for key, message in messages %}
+                <div class="flash-{{ type }}">
+                    {{ message|trans({}, 'FOSUserBundle') }}
+                </div>
+            {% endfor %}
         {% endfor %}
 
         <div>


### PR DESCRIPTION
Additional to issue #978 with closing fix 7d1339f716ab25390051163d998b4f01ce5fa671

Updated docs according to symfony 2.1 changes.
