### PR TITLE
Allow changing form template by setting compound to false in default options

### DIFF
--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -50,6 +50,7 @@ class ChangePasswordFormType extends AbstractType
         $resolver->setDefaults(array(
             'data_class' => $this->class,
             'intention'  => 'change_password',
+            'compound' => false
         ));
     }
 

--- a/Form/Type/GroupFormType.php
+++ b/Form/Type/GroupFormType.php
@@ -37,6 +37,7 @@ class GroupFormType extends AbstractType
         $resolver->setDefaults(array(
             'data_class' => $this->class,
             'intention'  => 'group',
+            'compound' => false
         ));
     }
 

--- a/Form/Type/ProfileFormType.php
+++ b/Form/Type/ProfileFormType.php
@@ -45,6 +45,7 @@ class ProfileFormType extends AbstractType
         $resolver->setDefaults(array(
             'data_class' => $this->class,
             'intention'  => 'profile',
+            'compound' => false
         ));
     }
 

--- a/Form/Type/RegistrationFormType.php
+++ b/Form/Type/RegistrationFormType.php
@@ -47,6 +47,7 @@ class RegistrationFormType extends AbstractType
         $resolver->setDefaults(array(
             'data_class' => $this->class,
             'intention'  => 'registration',
+            'compound' => false
         ));
     }
 

--- a/Form/Type/ResettingFormType.php
+++ b/Form/Type/ResettingFormType.php
@@ -43,6 +43,7 @@ class ResettingFormType extends AbstractType
         $resolver->setDefaults(array(
             'data_class' => $this->class,
             'intention'  => 'resetting',
+            'compound' => false
         ));
     }
 


### PR DESCRIPTION
Currently if I extend a FOSUserBundle Form Type I can't modify the form template as well as Symfony will throw an error: `Variable "compound" does not exist in form_div_layout.html.twig at line 224`. An example of wanting to modify the form is to [add an asterisk to required form fields](http://symfony.com/doc/2.1/cookbook/form/form_customization.html#adding-a-required-asterisk-to-field-labels) to indicate it is required.

The fix for this is documented in the [Symfony 2.1 changelog](https://github.com/symfony/symfony/blob/master/UPGRADE-2.1.md) which is to set `compound` to false in the `setDefaultOptions` method:

``` php
public function setDefaultOptions(OptionsResolverInterface $resolver)
{
    $resolver->setDefaults(array(
        'compound' => false,
    ));
}
```

However if I do this on my custom form type it will throw a different error: `You cannot add children to a simple form. Maybe you should set the option "compound" to true?`. So this change must be made on the FosUserBundle form types.
