### PR TITLE
Made check-email route for registration consistent with that of resetting in regards to direct access or refresh

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -79,6 +79,11 @@ class RegistrationController extends ContainerAware
     public function checkEmailAction()
     {
         $email = $this->container->get('session')->get('fos_user_send_confirmation_email/email');
+        
+        if (empty($email)) {
+            return new RedirectResponse($this->container->get('router')->generate('fos_user_registration_register'));
+        }
+        
         $this->container->get('session')->remove('fos_user_send_confirmation_email/email');
         $user = $this->container->get('fos_user.user_manager')->findUserByEmail($email);
 


### PR DESCRIPTION
When a user refreshes (or directly hits) the check-email route for registration, they are now redirected to the start of the registration process rather than being shown a 404.

Relates to issue #1024 