### PR TITLE
Allow User to Redefine FlashListener Class

### DIFF
--- a/Resources/config/listeners.xml
+++ b/Resources/config/listeners.xml
@@ -4,6 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="fos_user.listener.flash.class">FOS\UserBundle\EventListener\FlashListener</parameter>
+    </parameters>
+
     <services>
         <service id="fos_user.listener.authentication" class="FOS\UserBundle\EventListener\AuthenticationListener">
             <tag name="kernel.event_subscriber" />
@@ -11,7 +15,7 @@
             <argument>%fos_user.firewall_name%</argument>
         </service>
 
-        <service id="fos_user.listener.flash" class="FOS\UserBundle\EventListener\FlashListener">
+        <service id="fos_user.listener.flash" class="%fos_user.listener.flash.class%">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="session" />
             <argument type="service" id="translator" />


### PR DESCRIPTION
The FlashListener Class should be able to be defined by a user. If the user adds addtional events or function, he might want to extend FlashListener Class and inject it into the application. The hard coded class in the current FOSUserBundle prevents this. 
