### PR TITLE
Made  property accessible in subclasses

### DIFF
--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 
 class ChangePasswordFormType extends AbstractType
 {
-    private $class;
+    protected $class;
 
     /**
      * @param string $class The User class name

--- a/Form/Type/GroupFormType.php
+++ b/Form/Type/GroupFormType.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class GroupFormType extends AbstractType
 {
-    private $class;
+    protected $class;
 
     /**
      * @param string $class The Group class name

--- a/Form/Type/ProfileFormType.php
+++ b/Form/Type/ProfileFormType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 
 class ProfileFormType extends AbstractType
 {
-    private $class;
+    protected $class;
 
     /**
      * @param string $class The User class name

--- a/Form/Type/RegistrationFormType.php
+++ b/Form/Type/RegistrationFormType.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class RegistrationFormType extends AbstractType
 {
-    private $class;
+    protected $class;
 
     /**
      * @param string $class The User class name

--- a/Form/Type/ResettingFormType.php
+++ b/Form/Type/ResettingFormType.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class ResettingFormType extends AbstractType
 {
-    private $class;
+    protected $class;
 
     /**
      * @param string $class The User class name


### PR DESCRIPTION
[The documentation](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Resources/doc/overriding_forms.md) encourages subclassing the existing forms and this makes life a lot easier. However, if you want to change the default options of a class, for example to add `cascade_validation`, you need to reimplement the `$class` variable and the `__construct()` method. Just because `$class` is private and used in `setDefaultOptions()`.

I made it protected so you can re-use the property when subclassing.
