### PR TITLE
Added the spanish translation for "User account is disabled.".

### DIFF
--- a/Resources/translations/FOSUserBundle.es.yml
+++ b/Resources/translations/FOSUserBundle.es.yml
@@ -13,6 +13,7 @@ group:
 
 # Security
 "Bad credentials": Nombre de usuario o Contraseña inválido
+"User account is disabled.": Cuenta deshabilitada
 
 security:
     login:


### PR DESCRIPTION
Added the spanish translation for "User account is disabled.".

What do you think about removing the dot (as in "Bad Credentials")?
