### PR TITLE
Using Model instead of Entity namespace

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -130,7 +130,7 @@ start:
 
 namespace Acme\UserBundle\Entity;
 
-use FOS\UserBundle\Model\User as BaseUser;
+use FOS\UserBundle\Entity\User as BaseUser;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -168,7 +168,7 @@ If you use yml to configure Doctrine you must add two files. The Entity and the 
 
 namespace Acme\UserBundle\Entity;
 
-use FOS\UserBundle\Model\User as BaseUser;
+use FOS\UserBundle\Entity\User as BaseUser;
 
 /**
  * User


### PR DESCRIPTION
If Model namespace is extended instead of Entity, DoctrineORM doesn't generate DB columns inherited from BaseUser class.
