### PR TITLE
Add missing exception messages of UserChecker

### DIFF
--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -13,6 +13,10 @@ group:
 
 # Security
 "Bad credentials": Invalid username or password
+"User account is locked.": Account is locked
+"User account is disabled.": Account is disabled
+"User account has expired.": Account is expired
+"User credentials have expired.": Credentials have expired
 
 security:
     login:

--- a/Resources/translations/FOSUserBundle.fr.yml
+++ b/Resources/translations/FOSUserBundle.fr.yml
@@ -13,6 +13,10 @@ group:
 
 # Security
 "Bad credentials": Nom d'utilisateur ou mot de passe incorrect
+"User account is locked.": Compte bloqué
+"User account is disabled.": Compte désactivé
+"User account has expired.": Compte expiré
+"User credentials have expired.": Mot de passe expiré
 
 security:
     login:


### PR DESCRIPTION
The component Security checks the account status to authenticate. An
exception is raised if the account status disallow to authenticate the
current user.
