### PR TITLE
Add loginFormAction so that people can use render twig tag more easily

### DIFF
--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -17,7 +17,15 @@ use Symfony\Component\Security\Core\SecurityContext;
 
 class SecurityController extends ContainerAware
 {
-    public function loginAction(Request $request)
+    public function loginAction(Request $request) {
+       return $this->renderLogin('FOSUserBundle:Security:login.html.%s', $this->processForm($request));
+    }
+
+    public function loginFormAction(Request $request) {
+       return $this->renderLogin('FOSUserBundle:Security:login_content.html.%s', $this->processForm($request));
+    }
+
+    protected function processForm(Request $request)
     {
         /** @var $session \Symfony\Component\HttpFoundation\Session\Session */
         $session = $request->getSession();
@@ -43,11 +51,11 @@ class SecurityController extends ContainerAware
             ? $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate')
             : null;
 
-        return $this->renderLogin(array(
+        return array(
             'last_username' => $lastUsername,
             'error'         => $error,
             'csrf_token' => $csrfToken,
-        ));
+        );
     }
 
     /**
@@ -58,9 +66,9 @@ class SecurityController extends ContainerAware
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    protected function renderLogin(array $data)
+    protected function renderLogin($route, array $data)
     {
-        $template = sprintf('FOSUserBundle:Security:login.html.%s', $this->container->getParameter('fos_user.template.engine'));
+        $template = sprintf($route, $this->container->getParameter('fos_user.template.engine'));
 
         return $this->container->get('templating')->renderResponse($template, $data);
     }

--- a/Resources/config/routing/security.xml
+++ b/Resources/config/routing/security.xml
@@ -8,6 +8,10 @@
         <default key="_controller">FOSUserBundle:Security:login</default>
     </route>
 
+    <route id="fos_user_security_loginForm" pattern="/loginForm">
+        <default key="_controller">FOSUserBundle:Security:loginForm</default>
+    </route>
+
     <route id="fos_user_security_check" pattern="/login_check">
         <default key="_controller">FOSUserBundle:Security:check</default>
         <requirement key="_method">POST</requirement>

--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -1,24 +1,5 @@
 {% extends "FOSUserBundle::layout.html.twig" %}
 
-{% trans_default_domain 'FOSUserBundle' %}
-
 {% block fos_user_content %}
-{% if error %}
-    <div>{{ error|trans }}</div>
-{% endif %}
-
-<form action="{{ path("fos_user_security_check") }}" method="post">
-    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
-
-    <label for="username">{{ 'security.login.username'|trans }}</label>
-    <input type="text" id="username" name="_username" value="{{ last_username }}" required="required" />
-
-    <label for="password">{{ 'security.login.password'|trans }}</label>
-    <input type="password" id="password" name="_password" required="required" />
-
-    <input type="checkbox" id="remember_me" name="_remember_me" value="on" />
-    <label for="remember_me">{{ 'security.login.remember_me'|trans }}</label>
-
-    <input type="submit" id="_submit" name="_submit" value="{{ 'security.login.submit'|trans }}" />
-</form>
+{% include "FOSUserBundle:Security:login_content.html.twig" %}
 {% endblock fos_user_content %}

--- a/Resources/views/Security/login_content.html.twig
+++ b/Resources/views/Security/login_content.html.twig
@@ -1,0 +1,20 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% if error %}
+    <div>{{ error|trans }}</div>
+{% endif %}
+
+<form action="{{ path("fos_user_security_check") }}" method="post">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
+
+    <label for="username">{{ 'security.login.username'|trans }}</label>
+    <input type="text" id="username" name="_username" value="{{ last_username }}" required="required" />
+
+    <label for="password">{{ 'security.login.password'|trans }}</label>
+    <input type="password" id="password" name="_password" required="required" />
+
+    <input type="checkbox" id="remember_me" name="_remember_me" value="on" />
+    <label for="remember_me">{{ 'security.login.remember_me'|trans }}</label>
+
+    <input type="submit" id="_submit" name="_submit" value="{{ 'security.login.submit'|trans }}" />
+</form>


### PR DESCRIPTION
I split the loginAction function so that people can easily put the login form code in a modal everywhere on the website for example.

This feature came at first #703 and I hope it will be merge as I think it's a common use case.
@stof, tell me what you think and I'll add docs if you are OK with this one.