### PR TITLE
Set 'fos_user_security_check' to support 'POST' requests only

### DIFF
--- a/Resources/config/routing/security.xml
+++ b/Resources/config/routing/security.xml
@@ -8,7 +8,7 @@
         <default key="_controller">FOSUserBundle:Security:login</default>
     </route>
 
-    <route id="fos_user_security_check" pattern="/login_check">
+    <route id="fos_user_security_check" pattern="/login_check" methods="POST">
         <default key="_controller">FOSUserBundle:Security:check</default>
         <requirement key="_method">POST</requirement>
     </route>


### PR DESCRIPTION
Calling `fos_user_security_check` with `GET` leads to the error at https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Controller/SecurityController.php#L70 . Restricting the page to `POST` will intercept the request on the router level, thereby preventing the error message.
