### PR TITLE
Fix "Method not allowed" Error

### DIFF
--- a/Resources/config/routing/resetting.xml
+++ b/Resources/config/routing/resetting.xml
@@ -11,7 +11,7 @@
 
     <route id="fos_user_resetting_send_email" pattern="/send-email">
         <default key="_controller">FOSUserBundle:Resetting:sendEmail</default>
-        <requirement key="_method">POST</requirement>
+        <requirement key="_method">POST|GET</requirement>
     </route>
 
     <route id="fos_user_resetting_check_email" pattern="/check-email">


### PR DESCRIPTION
Hi,

when you try to reset the password of a user, but supply an invalid username, an error is thrown saying that the method "GET" is not allowed.

It seems to me that this change fixes the problem.

Best regards,
Don Busi
