### PR TITLE
updated swiftmailer/swiftmailer version specification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "twig/twig": "~1.5",
         "doctrine/doctrine-bundle": "*",
-        "swiftmailer/swiftmailer": "~4.3",
+        "swiftmailer/swiftmailer": ">=4.3, <6.0",
         "willdurand/propel-typehintable-behavior": "dev-master",
         "symfony/yaml": "~2.1",
         "symfony/validator": "~2.1"


### PR DESCRIPTION
Version 5.0.0 of SwiftMailer has been released, which is a non-breaking change - so modifying the require-dev specification to allow <6.0.
