### PR TITLE
Moved registration success event until after update success.

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -53,9 +53,10 @@ class RegistrationController extends ContainerAware
 
             if ($form->isValid()) {
                 $event = new FormEvent($form, $request);
-                $dispatcher->dispatch(FOSUserEvents::REGISTRATION_SUCCESS, $event);
 
                 $userManager->updateUser($user);
+                
+                $dispatcher->dispatch(FOSUserEvents::REGISTRATION_SUCCESS, $event);
 
                 if (null === $response = $event->getResponse()) {
                     $url = $this->container->get('router')->generate('fos_user_registration_confirmed');


### PR DESCRIPTION
Given a registration whereby the database call to update the user fails, the register success event was originally firing regardless causing things such as the confirmation email to be sent even when the registration actually failed.
