### PR TITLE
Properly initialize "groups"-property

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -130,6 +130,7 @@ abstract class User implements UserInterface, GroupableInterface
         $this->expired = false;
         $this->roles = array();
         $this->credentialsExpired = false;
+        $this->groups = new ArrayCollection();
     }
 
     public function addRole($role)
@@ -545,7 +546,7 @@ abstract class User implements UserInterface, GroupableInterface
      */
     public function getGroups()
     {
-        return $this->groups ?: $this->groups = new ArrayCollection();
+        return $this->groups;
     }
 
     public function getGroupNames()


### PR DESCRIPTION
`groups`-property initialized in `getGroups()` before, but if I create an instance and then call(for example) `addGroup()` it fails. Instead initialize in constructor.
