### PR TITLE
Route can pass template parameter to renderLogin

### DIFF
--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\SecurityContext;
 
 class SecurityController extends ContainerAware
 {
-    public function loginAction(Request $request)
+    public function loginAction(Request $request, $template = 'FOSUserBundle:Security:login.html.%s')
     {
         /** @var $session \Symfony\Component\HttpFoundation\Session\Session */
         $session = $request->getSession();
@@ -43,11 +43,13 @@ class SecurityController extends ContainerAware
             ? $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate')
             : null;
 
-        return $this->renderLogin(array(
+        $parameters = array(
             'last_username' => $lastUsername,
             'error'         => $error,
-            'csrf_token' => $csrfToken,
-        ));
+            'csrf_token'    => $csrfToken,
+        );
+
+        return $this->renderLogin($parameters, $template);
     }
 
     /**
@@ -55,12 +57,13 @@ class SecurityController extends ContainerAware
      * an extended controller to provide additional data for the login template.
      *
      * @param array $data
+     * @param string $template
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    protected function renderLogin(array $data)
+    protected function renderLogin(array $data, $template)
     {
-        $template = sprintf('FOSUserBundle:Security:login.html.%s', $this->container->getParameter('fos_user.template.engine'));
+        $template = sprintf($template, $this->container->getParameter('fos_user.template.engine'));
 
         return $this->container->get('templating')->renderResponse($template, $data);
     }

--- a/Resources/doc/overriding_templates.md
+++ b/Resources/doc/overriding_templates.md
@@ -138,6 +138,36 @@ to take effect, even in a development environment.
 Overriding all of the other templates provided by the FOSUserBundle can be done
 in a similar fashion using either of the two methods shown in this document.
 
+**c) Create new route with template parameter**
+
+In case that you want to place your login tempaltes in bundle, but you don't want to
+set parent bundle for your own bundle you can define route with template parameter.
+
+It's easy to do just add following route to your `routing.yml`:
+
+``` yaml
+admin.login:
+    pattern: /login
+    defaults: { _controller: FOSUserBundle:Security:login, template: AcmeBundle:Security:login.html.twig }
+```
+
+Template you use depends only on you, but you can extend already existing
+`FOSUserBundle:Security:login` template. To do so just create following template:
+
+``` html+jinja
+{% extends FOSUserBundle:Security:login.html.twig  %}
+
+{% block fos_user_content %}
+    {{ <h1>My own login template header...</h1> }}
+    {{ parent() }}
+{% endblock}
+```
+
+This method can be also used to define differnt templates for different login pages without
+any need to extend any controller or reimplementing the login process. All you have to do
+is to add more routes with different templates and then use this as login pages
+in security settings.
+
 ### Configuring A Templating Engine Other Than Twig
 
 You can configure a templating engine other than Twig using the bundle's configuration.


### PR DESCRIPTION
I know there is already one pull request for this #1053, but it haven't moved forward for 3months.

I am creating new one with correct variable name and documentation update, because there wasn't much activity in the already existing one.

This change allows developers to create more login pages without the need to extend FOSUserBundle or SecurityController. The only thing developers have to do is to add new route and change their security settings accordingly to take the new route into account.