### PR TITLE
fixed type hinting of Mailer

### DIFF
--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -12,7 +12,7 @@
 namespace FOS\UserBundle\Mailer;
 
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Mailer\MailerInterface;
 
@@ -26,7 +26,7 @@ class Mailer implements MailerInterface
     protected $templating;
     protected $parameters;
 
-    public function __construct($mailer, RouterInterface $router, EngineInterface $templating, array $parameters)
+    public function __construct($mailer, UrlGeneratorInterface  $router, EngineInterface $templating, array $parameters)
     {
         $this->mailer = $mailer;
         $this->router = $router;


### PR DESCRIPTION
The default mailer uses the `RoutingInterface` while the `TwigMailer` uses the `UrlGeneratorInterface`.
This PR makes them more uniform.
