### PR TITLE
ProfileType: moved adding 'current_password' to protected field to allow override

### DIFF
--- a/Form/Type/ProfileFormType.php
+++ b/Form/Type/ProfileFormType.php
@@ -31,21 +31,8 @@ class ProfileFormType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (class_exists('Symfony\Component\Security\Core\Validator\Constraints\UserPassword')) {
-            $constraint = new UserPassword();
-        } else {
-            // Symfony 2.1 support with the old constraint class
-            $constraint = new OldUserPassword();
-        }
-
         $this->buildUserForm($builder, $options);
-
-        $builder->add('current_password', 'password', array(
-            'label' => 'form.current_password',
-            'translation_domain' => 'FOSUserBundle',
-            'mapped' => false,
-            'constraints' => $constraint,
-        ));
+        $this->addCurrentPasswordToForm($builder);
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
@@ -73,5 +60,25 @@ class ProfileFormType extends AbstractType
             ->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
             ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'))
         ;
+    }
+
+    /**
+     * @param FormBuilderInterface $builder
+     */
+    protected function addCurrentPasswordToForm(FormBuilderInterface $builder)
+    {
+        if (class_exists('Symfony\Component\Security\Core\Validator\Constraints\UserPassword')) {
+            $constraint = new UserPassword();
+        } else {
+            // Symfony 2.1 support with the old constraint class
+            $constraint = new OldUserPassword();
+        }
+
+        $builder->add('current_password', 'password', array(
+            'label' => 'form.current_password',
+            'translation_domain' => 'FOSUserBundle',
+            'mapped' => false,
+            'constraints' => $constraint,
+        ));
     }
 }


### PR DESCRIPTION
The `ProfileType` form type adds a 'current_password' field by default, but that might not always be desired. This PR makes it easier to override the field by extracting the code into a protected method.

So, instead of overriding the whole `buildForm()` method, a subclass can include just this:

```
    protected function addCurrentPasswordToForm(FormBuilderInterface $builder)
    {
    }
```
