### PR TITLE
The format is required by FrameworkBundle

### DIFF
--- a/Resources/doc/emails.md
+++ b/Resources/doc/emails.md
@@ -121,11 +121,11 @@ fos_user:
         mailer: fos_user.mailer.twig_swift
     resetting:
         email:
-            template: AcmeDemoBundle:User:resetting.email.twig
+            template: AcmeDemoBundle:User:resetting.email.html.twig
 ```
 
 ``` html+jinja
-{# src/Acme/DemoBundle/Resources/views/User/resetting.email.twig #}
+{# src/Acme/DemoBundle/Resources/views/User/resetting.email.html.twig #}
 
 {% block subject %}Resetting your password{% endblock %}
 


### PR DESCRIPTION
Is the format is missing 

InvalidArgumentException: Template name "MktUserBundle:Registration:email.twig" is not valid (format is "bundle:section:template.format.engine")
