### PR TITLE
Use verb rather than noun

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -126,7 +126,7 @@ class RegistrationController extends ContainerAware
     protected function authenticateUser(UserInterface $user, Response $response)
     {
         try {
-            $this->container->get('fos_user.security.login_manager')->loginUser(
+            $this->container->get('fos_user.security.login_manager')->logInUser(
                 $this->container->getParameter('fos_user.firewall_name'),
                 $user,
                 $response);

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -129,7 +129,7 @@ class ResettingController extends ContainerAware
     protected function authenticateUser(UserInterface $user, Response $response)
     {
         try {
-            $this->container->get('fos_user.security.login_manager')->loginUser(
+            $this->container->get('fos_user.security.login_manager')->logInUser(
                 $this->container->getParameter('fos_user.firewall_name'),
                 $user,
                 $response);

--- a/Resources/doc/command_line_tools.md
+++ b/Resources/doc/command_line_tools.md
@@ -50,7 +50,7 @@ $ php app/console fos:user:create adminuser --super-admin
 ```
 
 If you specify the `--inactive` option, then the user that you create will no be
-able to login until he is activated.
+able to log in until he is activated.
 
 ``` bash
 $ php app/console fos:user:create testuser --inactive

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -437,7 +437,7 @@ $ php app/console propel:build
 > To create SQL, run the command `propel:build --insert-sql` or use migration
 > commands if you have an existing schema in your database.
 
-You now can login at `http://app.com/app_dev.php/login`!
+You now can log in at `http://app.com/app_dev.php/login`!
 
 ### Next Steps
 

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -19,7 +19,7 @@ security:
         username: "Username:"
         password: "Password:"
         remember_me: Remember me
-        submit: Login
+        submit: Log in
 
 # Profile
 profile:
@@ -79,8 +79,8 @@ resetting:
 
 # Global strings
 layout:
-    logout: Logout
-    login: Login
+    logout: Log out
+    login: Log in
     register: Register
     logged_in_as: Logged in as %username%
 

--- a/Security/LoginManager.php
+++ b/Security/LoginManager.php
@@ -42,7 +42,7 @@ class LoginManager implements LoginManagerInterface
         $this->container = $container;
     }
 
-    final public function loginUser($firewallName, UserInterface $user, Response $response = null)
+    final public function logInUser($firewallName, UserInterface $user, Response $response = null)
     {
         $this->userChecker->checkPostAuth($user);
 

--- a/Security/LoginManagerInterface.php
+++ b/Security/LoginManagerInterface.php
@@ -23,5 +23,5 @@ interface LoginManagerInterface
      *
      * @return void
      */
-    public function loginUser($firewallName, UserInterface $user, Response $response = null);
+    public function logInUser($firewallName, UserInterface $user, Response $response = null);
 }


### PR DESCRIPTION
'Login' is a noun/adjective, 'Log in' is the verb. This corrects the cases where a verb should be used.