### PR TITLE
Allow the listeners for REGISTRATION_INITIALIZE to provide an alternate user at registration time

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -43,7 +43,9 @@ class RegistrationController extends ContainerAware
         $user = $userManager->createUser();
         $user->setEnabled(true);
 
-        $dispatcher->dispatch(FOSUserEvents::REGISTRATION_INITIALIZE, new UserEvent($user, $request));
+        $event = new UserEvent($user, $request);
+        $dispatcher->dispatch(FOSUserEvents::REGISTRATION_INITIALIZE, $event);
+        $user = $event->getUser();
 
         $form = $formFactory->createForm();
         $form->setData($user);

--- a/Event/UserEvent.php
+++ b/Event/UserEvent.php
@@ -35,6 +35,14 @@ class UserEvent extends Event
     }
 
     /**
+     * @var UserInterface $user
+     */
+    public function setUser(UserInterface $user)
+    {
+        $this->user = $user;
+    }
+
+    /**
      * @return Request
      */
     public function getRequest()


### PR DESCRIPTION
Hello,

I am creating an application in which users can invite and interact with people outside of the platform.

This requires me to create "hollow" users who exist in the system without being able to login until they registered.

However, I cannot use a listener to retrieve, populate and enable this hollow user upon registration because the user is not taken back from the UserEvent in the controller.

Sure I could override the entire controller, but it looks like an awful amount of code to duplicate for almost nothing.

Furthermore, the intended usage of listeners (as mentioned in the doc) is to provide hooks for additional logic, which fits exactly my use case.

If you could tell me what you think of this suggestion and how it could be improved if interesting at all?

Regards.

PS: This was possible before 95d57add6cdd7c535a3471bc750d3ea15e347ecf by overriding the #process method in the form handler...