### PR TITLE
Insert failed events

### DIFF
--- a/Controller/ChangePasswordController.php
+++ b/Controller/ChangePasswordController.php
@@ -76,11 +76,15 @@ class ChangePasswordController extends ContainerAware
 
                 return $response;
             }
+            $event = new FormEvent($form, $request);
+            $dispatcher->dispatch(FOSUserEvents::CHANGE_PASSWORD_FAILED, $event);
         }
-
-        return $this->container->get('templating')->renderResponse(
-            'FOSUserBundle:ChangePassword:changePassword.html.'.$this->container->getParameter('fos_user.template.engine'),
-            array('form' => $form->createView())
-        );
+        if (null === $response = $event->getResponse()) {
+            return $this->container->get('templating')->renderResponse(
+                'FOSUserBundle:ChangePassword:changePassword.html.'.$this->container->getParameter('fos_user.template.engine'),
+                array('form' => $form->createView())
+            );
+        }
+        return $response;
     }
 }

--- a/Controller/GroupController.php
+++ b/Controller/GroupController.php
@@ -93,12 +93,17 @@ class GroupController extends ContainerAware
 
                 return $response;
             }
+            $event = new FormEvent($form, $request);
+            $dispatcher->dispatch(FOSUserEvents::GROUP_EDIT_FAILED, $event);
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:edit.html.'.$this->getEngine(), array(
-            'form'      => $form->createview(),
-            'group_name'  => $group->getName(),
-        ));
+        if (null === $response = $event->getResponse()) {
+            return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:edit.html.'.$this->getEngine(), array(
+                'form'      => $form->createview(),
+                'group_name'  => $group->getName(),
+            ));
+        }
+        return $response;
     }
 
     /**
@@ -138,11 +143,16 @@ class GroupController extends ContainerAware
 
                 return $response;
             }
+            $event = new FormEvent($form, $request);
+            $dispatcher->dispatch(FOSUserEvents::GROUP_CREATE_FAILED, $event);
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:new.html.'.$this->getEngine(), array(
-            'form' => $form->createview(),
-        ));
+        if (null === $response = $event->getResponse()) {
+            return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:new.html.'.$this->getEngine(), array(
+                'form' => $form->createview(),
+            ));
+        }
+        return $response;
     }
 
     /**

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -88,11 +88,16 @@ class ProfileController extends ContainerAware
 
                 return $response;
             }
+            $event = new FormEvent($form, $request);
+            $dispatcher->dispatch(FOSUserEvents::PROFILE_EDIT_FAILED, $event);
         }
 
-        return $this->container->get('templating')->renderResponse(
-            'FOSUserBundle:Profile:edit.html.'.$this->container->getParameter('fos_user.template.engine'),
-            array('form' => $form->createView())
-        );
+        if (null === $response = $event->getResponse()) {
+            return $this->container->get('templating')->renderResponse(
+                'FOSUserBundle:Profile:edit.html.'.$this->container->getParameter('fos_user.template.engine'),
+                array('form' => $form->createView())
+            );
+        }
+        return $response;
     }
 }

--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -66,11 +66,16 @@ class RegistrationController extends ContainerAware
 
                 return $response;
             }
+            $event = new FormEvent($form, $request);
+            $dispatcher->dispatch(FOSUserEvents::REGISTRATION_FAILED, $event);
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Registration:register.html.'.$this->getEngine(), array(
-            'form' => $form->createView(),
-        ));
+        if (null === $response = $event->getResponse()) {
+            return $this->container->get('templating')->renderResponse('FOSUserBundle:Registration:register.html.'.$this->getEngine(), array(
+                'form' => $form->createView(),
+            ));
+        }
+        return $response;
     }
 
     /**

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -136,12 +136,17 @@ class ResettingController extends ContainerAware
 
                 return $response;
             }
+            $event = new FormEvent($form, $request);
+            $dispatcher->dispatch(FOSUserEvents::RESETTING_RESET_FAILED, $event);
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:reset.html.'.$this->getEngine(), array(
-            'token' => $token,
-            'form' => $form->createView(),
-        ));
+        if (null === $response = $event->getResponse()) {
+            return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:reset.html.'.$this->getEngine(), array(
+                'token' => $token,
+                'form' => $form->createView(),
+            ));
+        }
+        return $response;
     }
 
     /**

--- a/FOSUserEvents.php
+++ b/FOSUserEvents.php
@@ -79,7 +79,7 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
      */
     const GROUP_CREATE_FAILED = 'fos_user.group.create.failed';
-
+ 
     /**
      * The GROUP_DELETE_COMPLETED event occurs after deleting the group.
      *

--- a/FOSUserEvents.php
+++ b/FOSUserEvents.php
@@ -39,6 +39,14 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\FilterUserResponseEvent instance.
      */
     const CHANGE_PASSWORD_COMPLETED = 'fos_user.change_password.edit.completed';
+    
+    /**
+     * The CHANGE_PASSWORD_FAILED event occurs when the change password form is not valid.
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
+     */
+    const CHANGE_PASSWORD_FAILED = 'fos_user.change_password.edit.failed';
 
     /**
      * The GROUP_CREATE_INITIALIZE event occurs when the group creation process is initialized.
@@ -63,6 +71,14 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\FilterGroupResponseEvent instance.
      */
     const GROUP_CREATE_COMPLETED = 'fos_user.group.create.completed';
+    
+    /**
+     * The GROUP_CREATE_FAILED event occurs when the group creation form is not valid.
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
+     */
+    const GROUP_CREATE_FAILED = 'fos_user.group.create.failed';
 
     /**
      * The GROUP_DELETE_COMPLETED event occurs after deleting the group.
@@ -71,6 +87,14 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\FilterGroupResponseEvent instance.
      */
     const GROUP_DELETE_COMPLETED = 'fos_user.group.delete.completed';
+    
+    /**
+     * The GROUP_DELETE_FAILED event occurs when the group creation form is not valid.
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
+     */
+    const GROUP_DELETE_FAILED = 'fos_user.group.create.failed';
 
     /**
      * The GROUP_EDIT_INITIALIZE event occurs when the group editing process is initialized.
@@ -95,6 +119,14 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\FilterGroupResponseEvent instance.
      */
     const GROUP_EDIT_COMPLETED = 'fos_user.group.edit.completed';
+    
+    /**
+     * The GROUP_EDIT_FAILED event occurs when the group edit form is not valid.
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
+     */
+    const GROUP_EDIT_FAILED = 'fos_user.group.edit.failed';
 
     /**
      * The PROFILE_EDIT_INITIALIZE event occurs when the profile editing process is initialized.
@@ -119,6 +151,14 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\FilterUserResponseEvent instance.
      */
     const PROFILE_EDIT_COMPLETED = 'fos_user.profile.edit.completed';
+    
+    /**
+     * The PROFILE_EDIT_FAILED event occurs when the profile edit form is not valid.
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
+     */
+    const PROFILE_EDIT_FAILED = 'fos_user.profile.edit.failed';
 
     /**
      * The REGISTRATION_INITIALIZE event occurs when the registration process is initialized.
@@ -143,6 +183,14 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\FilterUserResponseEvent instance.
      */
     const REGISTRATION_COMPLETED = 'fos_user.registration.completed';
+    
+    /**
+     * The REGISTRATION_FAILED event occurs when the registration form is not valid.
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
+     */
+    const REGISTRATION_FAILED = 'fos_user.registration.failed';
 
     /**
      * The REGISTRATION_CONFIRM event occurs just before confirming the account.
@@ -183,6 +231,14 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\FilterUserResponseEvent instance.
      */
     const RESETTING_RESET_COMPLETED = 'fos_user.resetting.reset.completed';
+    
+    /**
+     * The RESETTING_RESET_FAILED event occurs when the resetting form is not valid.
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
+     */
+    const RESETTING_RESET_FAILED = 'fos_user.resetting.reset.failed';
 
     /**
      * The SECURITY_IMPLICIT_LOGIN event occurs when the user is logged in programmatically.

--- a/FOSUserEvents.php
+++ b/FOSUserEvents.php
@@ -87,14 +87,6 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\FilterGroupResponseEvent instance.
      */
     const GROUP_DELETE_COMPLETED = 'fos_user.group.delete.completed';
-    
-    /**
-     * The GROUP_DELETE_FAILED event occurs when the group creation form is not valid.
-     *
-     * This event allows you to set the response instead of using the default one.
-     * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
-     */
-    const GROUP_DELETE_FAILED = 'fos_user.group.create.failed';
 
     /**
      * The GROUP_EDIT_INITIALIZE event occurs when the group editing process is initialized.


### PR DESCRIPTION
My purpose is to create an event "FAILED" to give the possibility to modify the response object even when the form is not valid.

This change can be used for example when you makes it a json object to a form in ajax.
If it is valid hook the *_SUCCESS event, but if it is not valid there was no way to change the answer.
Now with the event *_FAILED this is possible.