### PR TITLE
unique index for confirmation_token field

### DIFF
--- a/Resources/config/doctrine/model/User.orm.xml
+++ b/Resources/config/doctrine/model/User.orm.xml
@@ -28,7 +28,7 @@
 
         <field name="expiresAt" column="expires_at" type="datetime" nullable="true" />
 
-        <field name="confirmationToken" column="confirmation_token" type="string" nullable="true" />
+        <field name="confirmationToken" column="confirmation_token" type="string" nullable="true" unique="true" />
 
         <field name="passwordRequestedAt" column="password_requested_at" type="datetime" nullable="true" />
 


### PR DESCRIPTION
When there are lots of users (in my case 1.5 mils) registration confirmation and password reset requests take several seconds.