### PR TITLE
fixed UserProvider::refreshUser() not checking the class

### DIFF
--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -60,6 +60,10 @@ class UserProvider implements UserProviderInterface
             throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
         }
 
+        if (!$this->supportsClass(get_class($user))) {
+            throw new UnsupportedUserException(sprintf('Expected an instance of %s, but got "%s".', $this->userManager->getClass(), get_class($user)));
+        }
+
         if (null === $reloadedUser = $this->userManager->findUserBy(array('id' => $user->getId()))) {
             throw new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $user->getId()));
         }

--- a/Tests/Security/EmailUserProviderTest.php
+++ b/Tests/Security/EmailUserProviderTest.php
@@ -62,6 +62,10 @@ class EmailUserProviderTest extends \PHPUnit_Framework_TestCase
             ->with(array('id' => '123'))
             ->will($this->returnValue($refreshedUser));
 
+        $this->userManager->expects($this->atLeastOnce())
+            ->method('getClass')
+            ->will($this->returnValue(get_class($user)));
+
         $this->assertSame($refreshedUser, $this->userProvider->refreshUser($user));
     }
 

--- a/Tests/Security/UserProviderTest.php
+++ b/Tests/Security/UserProviderTest.php
@@ -62,6 +62,10 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->with(array('id' => '123'))
             ->will($this->returnValue($refreshedUser));
 
+        $this->userManager->expects($this->atLeastOnce())
+            ->method('getClass')
+            ->will($this->returnValue(get_class($user)));
+
         $this->assertSame($refreshedUser, $this->userProvider->refreshUser($user));
     }
 
@@ -75,6 +79,10 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->method('findUserBy')
             ->will($this->returnValue(null));
 
+        $this->userManager->expects($this->atLeastOnce())
+            ->method('getClass')
+            ->will($this->returnValue(get_class($user)));
+
         $this->userProvider->refreshUser($user);
     }
 
@@ -84,7 +92,25 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
     public function testRefreshInvalidUser()
     {
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $this->userManager->expects($this->any())
+            ->method('getClass')
+            ->will($this->returnValue(get_class($user)));
 
         $this->userProvider->refreshUser($user);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\UnsupportedUserException
+     */
+    public function testRefreshInvalidUserClass()
+    {
+        $user = $this->getMock('FOS\UserBundle\Model\User');
+        $providedUser = $this->getMock('FOS\UserBundle\Tests\TestUser');
+
+        $this->userManager->expects($this->atLeastOnce())
+            ->method('getClass')
+            ->will($this->returnValue(get_class($user)));
+
+        $this->userProvider->refreshUser($providedUser);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | (not sure) |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This PR fixes an issue that the user-provider always refreshes the user if the `User` class or Propel-model is given, but the class inheritance is actually not met.

If you have two user-classes which both extend the `FosUserBundle\Model\User` it will refresh the wrong user.
