### PR TITLE
Fix mistaken field mapping for index

### DIFF
--- a/Resources/config/doctrine/model/Group.couchdb.xml
+++ b/Resources/config/doctrine/model/Group.couchdb.xml
@@ -2,7 +2,7 @@
 <doctrine-mapping>
     <mapped-superclass name="FOS\UserBundle\Model\Group" indexed="true">
 
-        <field name="name" fieldName="name" type="string" indexed="true" />
+        <field name="name" fieldName="name" type="string" index="true" />
         <field name="roles" fieldName="roles" type="mixed" />
 
     </mapped-superclass>

--- a/Resources/config/doctrine/model/User.couchdb.xml
+++ b/Resources/config/doctrine/model/User.couchdb.xml
@@ -3,10 +3,10 @@
 
     <mapped-superclass name="FOS\UserBundle\Model\User" indexed="true">
 
-        <field name="username" fieldName="username" type="string" indexed="true" />
-        <field name="usernameCanonical" fieldName="usernameCanonical" type="string" indexed="true" />
-        <field name="email" fieldName="email" type="string" indexed="true" />
-        <field name="emailCanonical" fieldName="emailCanonical" type="string" indexed="true" />
+        <field name="username" fieldName="username" type="string" index="true" />
+        <field name="usernameCanonical" fieldName="usernameCanonical" type="string" index="true" />
+        <field name="email" fieldName="email" type="string" index="true" />
+        <field name="emailCanonical" fieldName="emailCanonical" type="string" index="true" />
         <field name="enabled" fieldName="enabled" type="mixed" />
         <field name="salt" fieldName="salt" type="string" />
         <field name="password" fieldName="password" type="string" />


### PR DESCRIPTION
Attribute "indexed" on field mappings is ignored. Correct name is "index."

This had been noticed previously in https://github.com/FriendsOfSymfony/FOSUserBundle/pull/681#issuecomment-6695314 but the pull request was closed without committing these changes.
