### PR TITLE
Fix spanish translation

### DIFF
--- a/Resources/translations/FOSUserBundle.es.yml
+++ b/Resources/translations/FOSUserBundle.es.yml
@@ -68,7 +68,7 @@ resetting:
     flash:
         success: La contraseña se ha cambiado con éxito
     email:
-        subject: Bienvenido %username%!
+        subject: Restablecer Contraseña
         message : |
             Hola %username%!
 


### PR DESCRIPTION
Looks like resetting.email.subject string in the spanish translation file has been copy/pasted from registration.email.subject, therefore the string is wrong as it translates to "Welcome user" instead of "Reset password".
