### PR TITLE
sonata-admin integration

### DIFF
--- a/Admin/GroupAdmin.php
+++ b/Admin/GroupAdmin.php
@@ -1,0 +1,34 @@
+<?php
+namespace FOS\UserBundle\Admin;
+
+use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+
+class GroupAdmin extends Admin
+{
+    public function getNewInstance()
+    {
+        $class = $this->getClass();
+
+        return new $class('', array());
+    }
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper->addIdentifier('name')->add('roles');
+    }
+
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper->add('name');
+    }
+
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->add('name')
+            ->add('roles', 'collection', array('allow_add' => true, 'allow_delete' => true, 'options' => array('label' => false)));
+    }
+}

--- a/Admin/UserAdmin.php
+++ b/Admin/UserAdmin.php
@@ -1,0 +1,94 @@
+<?php
+namespace FOS\UserBundle\Admin;
+
+use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+
+use FOS\UserBundle\Model\UserManagerInterface;
+
+class UserAdmin extends Admin
+{
+    /**
+     * @var UserManagerInterface
+     */
+    protected $userManager;
+
+    /**
+     * @param UserManagerInterface $userManager
+     */
+    public function setUserManager (UserManagerInterface $userManager)
+    {
+        $this->userManager = $userManager;
+    }
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('username')
+            ->add('email')
+            ->add('groups')
+            # FIXME looks ugly...
+            #->add('roles', 'array')
+            ->add('enabled', null, array('editable' => true))
+            ->add('locked', null, array('editable' => true));
+    }
+
+    protected function configureDatagridFilters(DatagridMapper $filterMapper)
+    {
+        $filterMapper
+            ->add('username')
+            ->add('locked')
+            ->add('email')
+            # FIXME would be cool :)
+            #->add('roles')
+            ->add('groups', null, array(), null, array('property' => 'name'));
+    }
+
+    protected function configureShowFields(ShowMapper $showMapper)
+    {
+        $showMapper
+            ->with('General')
+                ->add('username')
+                ->add('email')
+            ->end()
+            /* FIXME not implemented yet in SonataAdmin (it seems. At least without Group::__toString())
+            ->with('Groups')
+                ->add('groups', null, ['associated_tostring' => 'getName'])
+            ->end()*/;
+    }
+
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('General')
+                ->add('username')
+                ->add('email')
+                ->add('plainPassword', 'text', array('required' => false, 'help' => 'Leave empty to keep it unchanged'))
+                ->add('roles', 'collection', array('allow_add' => true, 'allow_delete' => true, 'options' => array('label' => false)))
+            ->end()
+            ->with('Groups')
+                ->add('groups', 'sonata_type_model', array('required' => false, 'expanded' => true, 'multiple' => true, 'property' => 'name'))
+            ->end();
+
+        if (!$this->getSubject() || !$this->getSubject()->hasRole('ROLE_SUPER_ADMIN')) {
+            $formMapper
+                ->with('Management')
+                    ->add('locked', null, array('required' => false))
+                    ->add('expired', null, array('required' => false))
+                    ->add('enabled', null, array('required' => false))
+                    ->add('credentialsExpired', null, array('required' => false))
+                ->end();
+        }
+    }
+
+    public function preUpdate($user)
+    {
+        $this->userManager->updateCanonicalFields($user);
+        $this->userManager->updatePassword($user);
+
+        return parent::preUpdate($user);
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -60,6 +60,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('sender_name')->defaultValue('webmaster')->cannotBeEmpty()->end()
                     ->end()
                 ->end()
+                ->scalarNode('use_sonata_admin')->defaultValue('auto')->end()
             ->end()
             // Using the custom driver requires changing the manager services
             ->validate()

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -97,6 +97,9 @@ class FOSUserExtension extends Extension
         if (!empty($config['group'])) {
             $this->loadGroups($config['group'], $container, $loader, $config['db_driver']);
         }
+        if ($config['use_sonata_admin']) {
+            $this->loadSonata($config, $container, $loader, $config['db_driver'], !empty($config['group']));
+        }
     }
 
     private function loadProfile(array $config, ContainerBuilder $container, XmlFileLoader $loader)
@@ -173,6 +176,33 @@ class FOSUserExtension extends Extension
             ),
             'form' => 'fos_user.group.form.%s',
         ));
+    }
+
+    private function loadSonata (array $config, ContainerBuilder $container, XmlFileLoader $loader, $dbDriver, $useGroups)
+    {
+
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (!in_array($dbDriver, array('mongodb', 'orm'))) {
+            return;
+        }
+
+        if ($dbDriver == 'auto') {
+            if (isset($bundles['SonataUserBundle'])) {
+                return;
+            }
+            if ($dbDriver == 'mongodb' and !isset($bundles['SonataDoctrineMongoDBAdminBundle'])) {
+                return;
+            }
+            if ($dbDriver == 'orm' and !isset($bundles['SonataDoctrineORMAdminBundle'])) {
+                return;
+            }
+        }
+
+        $loader->load(sprintf('admin/%s.user.xml', $config['db_driver']));
+        if ($useGroups) {
+            $loader->load(sprintf('admin/%s.group.xml', $config['db_driver']));
+        }
     }
 
     protected function remapParameters(array $config, ContainerBuilder $container, array $map)

--- a/Resources/config/admin/mongodb.group.xml
+++ b/Resources/config/admin/mongodb.group.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_user.admin.group.class">FOS\UserBundle\Admin\GroupAdmin</parameter>
+    </parameters>
+
+    <services>
+        <service id="crunch_user.admin.group" class="%fos_user.admin.group.class%">
+            <tag name="sonata.admin" manager_type="doctrine_mongodb" group="dashboard.fos_user" label_catalogue="FOSUserBundle" label="dashboard.label_groups" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument />
+            <argument>%fos_user.model.group.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+            <call method="setTranslationDomain">
+                <argument>FOSUserBundle</argument>
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/admin/mongodb.user.xml
+++ b/Resources/config/admin/mongodb.user.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_user.admin.user.class">FOS\UserBundle\Admin\UserAdmin</parameter>
+    </parameters>
+
+    <services>
+        <service id="crunch_user.admin.user" class="%fos_user.admin.user.class%">
+            <tag name="sonata.admin" manager_type="doctrine_mongodb" group="dashboard.fos_user" label_catalogue="FOSUserBundle" label="dashboard.label_users" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <argument />
+            <argument>%fos_user.model.user.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+            <call method="setUserManager">
+                <argument type="service" id="fos_user.user_manager" />
+            </call>
+            <call method="setTranslationDomain">
+                <argument>FOSUserBundle</argument>
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/admin/orm.group.xml
+++ b/Resources/config/admin/orm.group.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_user.admin.group.class">FOS\UserBundle\Admin\GroupAdmin</parameter>
+    </parameters>
+
+    <services>
+        <service id="crunch_user.admin.group" class="%fos_user.admin.group.class%">
+            <tag name="sonata.admin" manager_type="orm" group="dashboard.fos_user" label_catalogue="FOSUserBundle" label="dashboard.label_groups" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument />
+            <argument>%fos_user.model.group.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+            <call method="setTranslationDomain">
+                <argument>FOSUserBundle</argument>
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/admin/orm.user.xml
+++ b/Resources/config/admin/orm.user.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_user.admin.user.class">FOS\UserBundle\Admin\UserAdmin</parameter>
+    </parameters>
+
+    <services>
+        <service id="crunch_user.admin.user" class="%fos_user.admin.user.class%">
+            <tag name="sonata.admin" manager_type="orm" group="dashboard.fos_user" label_catalogue="FOSUserBundle" label="dashboard.label_users" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument />
+            <argument>%fos_user.model.user.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+            <call method="setUserManager">
+                <argument type="service" id="fos_user.user_manager" />
+            </call>
+            <call method="setTranslationDomain">
+                <argument>FOSUserBundle</argument>
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -94,3 +94,33 @@ form:
     password_confirmation: "Passwort bestätigen:"
     new_password: "Neues Passwort:"
     new_password_confirmation: "Neues Passwort bestätigen:"
+
+# Admin dashboard labels
+dashboard:
+    fos_user: Benutzerverwaltung
+    label_users: Benutzer
+    label_groups: Gruppen
+
+# Admin list labels
+list:
+    label_username: Benutzername
+    label_email: Email
+    label_groups: Gruppen
+    label_enabled: Aktiviert
+    label_locked: Gesperrt
+
+# Admin form labels
+form:
+    label_username: Benutzername
+    label_email: Email
+    label_plain_password: Passwort (sichtbar)
+    label_roles: Rollen
+    label_groups: Gruppen
+    label_locked: Gesperrt
+    label_expired: Abgelaufen
+    label_enabled: Aktiviert
+    label_credentials_expired: Zugangsdaten abgelaufen
+
+# Admin breadcrumb
+breadcrumb:
+    link_user_list: Benutzer

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -94,3 +94,33 @@ form:
     password_confirmation: "Verification:"
     new_password: "New password:"
     new_password_confirmation: "Verification:"
+
+# Admin dashboard labels
+dashboard:
+    fos_user: "User Management"
+    label_users: Users
+    label_groups: Groups
+
+# Admin list labels
+list:
+    label_username: Username
+    label_email: Email
+    label_groups: Groups
+    label_enabled: Enabled
+    label_locked: Locked
+
+# Admin form labels
+form:
+    label_username: Username
+    label_email: Email
+    label_plain_password: Plaintext password
+    label_roles: Roles
+    label_groups: Groups
+    label_locked: Locked
+    label_expired: Expired
+    label_enabled: Enabled
+    label_credentials_expired: Credentials expired
+
+# Admin breadcrumb
+breadcrumb:
+    link_user_list: Users

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "symfony/validator": "~2.1"
     },
     "suggest": {
-        "willdurand/propel-typehintable-behavior": "Needed when using the propel implementation"
+        "willdurand/propel-typehintable-behavior": "Needed when using the propel implementation",
+        "sonata-project/admin-bundle": "Administration platform for orm and mongodb driver"
     },
     "autoload": {
         "psr-0": { "FOS\\UserBundle": "" }


### PR DESCRIPTION
Two admin classes for `Group` and `User`.

```
fos_user:
    use_sonata_admin: auto # true, false
```

Yes, I know, that there is also the `SonataUserBundle`, but it "does too much" and it isn't compatible to `FOSUserBundle` 2 anyway. So I ended with my two custom `Admin`-classes and thought, that it may fit into `FOSUserBundle` directly. It is completely optional.

Sidenote: I was able to provide the translations for english and germany only :wink: 
