### PR TITLE
Check only UserInterface instead of User or PropelUser

### DIFF
--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -56,8 +56,8 @@ class UserProvider implements UserProviderInterface
      */
     public function refreshUser(SecurityUserInterface $user)
     {
-        if (!$user instanceof User && !$user instanceof PropelUser) {
-            throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
+        if (!$user instanceof UserInterface) {
+            throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\UserInterface, but got "%s".', get_class($user)));
         }
 
         if (!$this->supportsClass(get_class($user))) {


### PR DESCRIPTION
These change allows to have custom implementation of UserInterface without need for another user provider. 
