### PR TITLE
use GetResponseUserEvent on registration init

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -43,7 +43,12 @@ class RegistrationController extends ContainerAware
         $user = $userManager->createUser();
         $user->setEnabled(true);
 
-        $dispatcher->dispatch(FOSUserEvents::REGISTRATION_INITIALIZE, new UserEvent($user, $request));
+        $event = new GetResponseUserEvent($user, $request);
+        $dispatcher->dispatch(FOSUserEvents::REGISTRATION_INITIALIZE, $event);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
 
         $form = $formFactory->createForm();
         $form->setData($user);


### PR DESCRIPTION
The [ChangePasswordController](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/e060f8c51abefbb1e0fce2fb18de45474c8a3504/Controller/ChangePasswordController.php#L45-L50) uses the `GetResponseUserEvent` to allow custom responses when initializing change password process; just like the other controllers.

However the [RegistrationController](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/e060f8c51abefbb1e0fce2fb18de45474c8a3504/Controller/RegistrationController.php#L46) isn't utilizing this type of event right now, is there any special reason behind this?
