### PR TITLE
Add alert when the email address provided does not exist

### DIFF
--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -64,7 +64,7 @@ class ResettingController extends ContainerAware
             $user->setConfirmationToken($tokenGenerator->generateToken());
         }
 
-        $this->container->get('session')->set(static::SESSION_EMAIL, $this->getObfuscatedEmail($user));
+        $this->container->get('session')->set(static::SESSION_EMAIL, md5($user->getEmail()));
         $this->container->get('fos_user.mailer')->sendResettingEmailMessage($user);
         $user->setPasswordRequestedAt(new \DateTime());
         $this->container->get('fos_user.user_manager')->updateUser($user);
@@ -143,25 +143,6 @@ class ResettingController extends ContainerAware
             'token' => $token,
             'form' => $form->createView(),
         ));
-    }
-
-    /**
-     * Get the truncated email displayed when requesting the resetting.
-     *
-     * The default implementation only keeps the part following @ in the address.
-     *
-     * @param \FOS\UserBundle\Model\UserInterface $user
-     *
-     * @return string
-     */
-    protected function getObfuscatedEmail(UserInterface $user)
-    {
-        $email = $user->getEmail();
-        if (false !== $pos = strpos($email, '@')) {
-            $email = '...' . substr($email, $pos);
-        }
-
-        return $email;
     }
 
     protected function getEngine()


### PR DESCRIPTION
Add a message to the end user requesting the password renewal to an e-mail does not exist in the base.
Add encode the user email 
Remove the function getObfuscatedEmail
