### PR TITLE
Wrong capitalisation in annotation

### DIFF
--- a/Resources/doc/groups.md
+++ b/Resources/doc/groups.md
@@ -68,7 +68,7 @@ class Group extends BaseGroup
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")
-     * @ORM\generatedValue(strategy="AUTO")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
      protected $id;
 }


### PR DESCRIPTION
This caused "php app/console doctrine:schema:update" to fail with this error:

```
[Doctrine\Common\Annotations\AnnotationException]                                                         
  [Semantical Error] The annotation "@Doctrine\ORM\Mapping\generatedValue" in property Belan\DemoBundle\En  
  tity\Group::$id does not exist, or could not be auto-loaded.
```
