### PR TITLE
Fixed "'Logged in as ...' displays invalid username during Profile Editi...

### DIFF
--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -87,9 +87,9 @@ class ProfileController extends ContainerAware
                 $dispatcher->dispatch(FOSUserEvents::PROFILE_EDIT_COMPLETED, new FilterUserResponseEvent($user, $request, $response));
 
                 return $response;
-            } else {
-                $this->container->get('fos_user.user_manager')->reloadUser($user);
             }
+            
+            $this->container->get('fos_user.user_manager')->reloadUser($user);
         }
 
         return $this->container->get('templating')->renderResponse(

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -87,6 +87,8 @@ class ProfileController extends ContainerAware
                 $dispatcher->dispatch(FOSUserEvents::PROFILE_EDIT_COMPLETED, new FilterUserResponseEvent($user, $request, $response));
 
                 return $response;
+            } else {
+                $this->container->get('fos_user.user_manager')->reloadUser($user);
             }
         }
 


### PR DESCRIPTION
...ng"

This is Pull Request for ""Logged in as ..." displays invalid username during Profile Editing" https://github.com/FriendsOfSymfony/FOSUserBundle/issues/926, when user from 'security.context' is changed and that's how it's restored in case of form error.