### PR TITLE
Fix User serialization

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -149,7 +149,11 @@ abstract class User implements UserInterface, GroupableInterface
     /**
      * Serializes the user.
      *
-     * The serialized data have to contain the fields used by the equals method and the username.
+     * The serialized data have to contain the fields used during check for
+     * changes and the id.
+     *
+     * The check for changes is implemented in
+     * Symfony\Component\Security\Core\Authentication\Token\AbstractToken#hasUserChanged
      *
      * @return string
      */

--- a/Model/User.php
+++ b/Model/User.php
@@ -165,6 +165,8 @@ abstract class User implements UserInterface, GroupableInterface
             $this->credentialsExpired,
             $this->enabled,
             $this->id,
+            $this->expiresAt,
+            $this->credentialsExpireAt,
         ));
     }
 
@@ -189,7 +191,9 @@ abstract class User implements UserInterface, GroupableInterface
             $this->locked,
             $this->credentialsExpired,
             $this->enabled,
-            $this->id
+            $this->id,
+            $this->expiresAt,
+            $this->credentialsExpireAt
         ) = $data;
     }
 


### PR DESCRIPTION
`serialize` and `unserialize` MUST contain the fields used by the equals method and the username (and since e1f5b11ba77bb24f2d47054e7ea41e0ba8c1e2a2, the id) .
    
The equals method (implemented in [AbstractToken#hasUserChanged] (https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php#L237-280) since https://github.com/symfony/symfony/pull/2927) calls `isAccountNonExpired`and `isCredentialsNonExpired` which use `expiresAt` and `credentialsExpireAt`respectively.

These two attributes were missing from the serialization, preventing it from fulfilling its contract.

This PR also includes a phpdocs fix for `serialize` since the comment on the method had fallen far out of date over time.