### PR TITLE
Add mbstring extension to requires in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
+        "ext-mbstring": "*",
         "symfony/framework-bundle": "~2.1",
         "symfony/form": "~2.1",
         "symfony/security-bundle": "~2.1"


### PR DESCRIPTION
Pretty self explanatory? :)

Let composer generate a warning in english instead of php throwing an exception.
