### PR TITLE
fix annotation entity example

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -130,7 +130,7 @@ start:
 
 namespace Acme\UserBundle\Entity;
 
-use FOS\UserBundle\Model\User as BaseUser;
+use FOS\UserBundle\Entity\User as BaseUser;
 use Doctrine\ORM\Mapping as ORM;
 
 /**


### PR DESCRIPTION
`use FOS\UserBundle\Model\User as BaseUser;` leads to a user class with only id in it
