### PR TITLE
Fix for User email serialization

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -165,6 +165,8 @@ abstract class User implements UserInterface, GroupableInterface
             $this->credentialsExpired,
             $this->enabled,
             $this->id,
+            $this->email,
+            $this->emailCanonical,
         ));
     }
 
@@ -189,7 +191,9 @@ abstract class User implements UserInterface, GroupableInterface
             $this->locked,
             $this->credentialsExpired,
             $this->enabled,
-            $this->id
+            $this->id,
+            $this->email,
+            $this->emailCanonical
         ) = $data;
     }
 


### PR DESCRIPTION
The user class was missing the email properties in the serialization methods
and when the object was serialized/unserialized, the data was lost.

Fixed by adding in properties to serialization lists.