### PR TITLE
extend the right class

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -130,7 +130,7 @@ start:
 
 namespace Acme\UserBundle\Entity;
 
-use FOS\UserBundle\Model\User as BaseUser;
+use FOS\UserBundle\Entity\User as BaseUser;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -168,7 +168,7 @@ If you use yml to configure Doctrine you must add two files. The Entity and the 
 
 namespace Acme\UserBundle\Entity;
 
-use FOS\UserBundle\Model\User as BaseUser;
+use FOS\UserBundle\Entity\User as BaseUser;
 
 /**
  * User
@@ -206,7 +206,7 @@ this to start:
 
 namespace Acme\UserBundle\Document;
 
-use FOS\UserBundle\Model\User as BaseUser;
+use FOS\UserBundle\Document\User as BaseUser;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
 
 /**
@@ -239,7 +239,7 @@ this to start:
 
 namespace Acme\UserBundle\CouchDocument;
 
-use FOS\UserBundle\Model\User as BaseUser;
+use FOS\UserBundle\Document\User as BaseUser;
 use Doctrine\ODM\CouchDB\Mapping\Annotations as CouchDB;
 
 /**


### PR DESCRIPTION
Within Doctrine ORM the extend (BaseUser) needs to be the one within the Entity folder, if not only the id field will be generated within table (i think but, i am not sure, if its true for documents too)
