### PR TITLE
German translation all in same formality

### DIFF
--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -39,7 +39,7 @@ change_password:
 
 # Registration
 registration:
-    check_email: Eine E-Mail wurde an %email% gesendet. Sie enthält einen Link, den Du anklicken musst, um Dein Benutzerkonto zu bestätigen.
+    check_email: Eine E-Mail wurde an %email% gesendet. Sie enthält einen Link, den Sie anklicken müssen, um Ihr Benutzerkonto zu bestätigen.
     confirmed: Glückwunsch %username%, Dein Benutzerkonto ist jetzt bestätigt.
     back: Zurück zur ursprünglichen Seite.
     submit: Registrieren
@@ -58,7 +58,7 @@ registration:
 # Password resetting
 resetting:
     password_already_requested: Für diesen Benutzer wurde in den vergangenen 24 Stunden bereits ein neues Passwort beantragt.
-    check_email: Eine E-Mail wurde an %email% gesendet. Sie enthält einen Link, den Du anklicken musst, um Dein Passwort zurückzusetzen.
+    check_email: Eine E-Mail wurde an %email% gesendet. Sie enthält einen Link, den Sie anklicken müssen, um Ihr Passwort zurückzusetzen.
     request:
         invalid_username: Der Benutzername oder die E-Mail-Adresse "%username%" existiert nicht.
         username: "Benutzername oder E-Mail-Adresse:"


### PR DESCRIPTION
The original file uses formal and non-formal in the same sentence. Proposed change is to have both formal (Sie), but either way is fine.
