### PR TITLE
Inject remember_me services into LoginManager (support symfony 2.3 and higher)

### DIFF
--- a/DependencyInjection/Compiler/InjectRememberMeServicesPass.php
+++ b/DependencyInjection/Compiler/InjectRememberMeServicesPass.php
@@ -29,7 +29,7 @@ class InjectRememberMeServicesPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
 
-        $rememberMeServices = [];
+        $rememberMeServices = array();
         foreach ($container->getDefinitions() as $id => $definition) {
             if (0 !== strpos($id, 'security.authentication.rememberme.services.')) {
                 continue;

--- a/DependencyInjection/Compiler/InjectRememberMeServicesPass.php
+++ b/DependencyInjection/Compiler/InjectRememberMeServicesPass.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Registers the additional validators according to the storage
+ *
+ * @author Vasily Khayrulin <sirianru@gmail.com>
+ */
+class InjectRememberMeServicesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+
+        $rememberMeServices = [];
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (0 !== strpos($id, 'security.authentication.rememberme.services.')) {
+                continue;
+            }
+            if ($definition->isAbstract()) {
+                continue;
+            }
+            $firewallName = $definition->getArgument(2);
+            $rememberMeServices[$firewallName] = new Reference($id);
+        }
+
+        $loginManager = $container->getDefinition('fos_user.security.login_manager');
+        $loginManager->replaceArgument(4, $rememberMeServices);
+    }
+}

--- a/FOSUserBundle.php
+++ b/FOSUserBundle.php
@@ -11,6 +11,7 @@
 
 namespace FOS\UserBundle;
 
+use FOS\UserBundle\DependencyInjection\Compiler\InjectRememberMeServicesPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use FOS\UserBundle\DependencyInjection\Compiler\ValidationPass;
@@ -29,6 +30,7 @@ class FOSUserBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new ValidationPass());
+        $container->addCompilerPass(new InjectRememberMeServicesPass());
 
         $this->addRegisterMappingsPass($container);
     }

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -16,10 +16,10 @@
         </service>
 
         <service id="fos_user.security.login_manager" class="%fos_user.security.login_manager.class%">
-        	<argument type="service" id="security.context" />
-        	<argument type="service" id="security.user_checker" />
-        	<argument type="service" id="security.authentication.session_strategy" />
-        	<argument type="service" id="service_container" />
+            <argument type="service" id="security.context" />
+            <argument type="service" id="security.user_checker" />
+            <argument type="service" id="security.authentication.session_strategy" />
+            <argument type="service" id="service_container" />
             <argument type="collection" />
         </service>
 

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -20,6 +20,7 @@
         	<argument type="service" id="security.user_checker" />
         	<argument type="service" id="security.authentication.session_strategy" />
         	<argument type="service" id="service_container" />
+            <argument type="collection" />
         </service>
 
         <service id="fos_user.user_provider.username" class="FOS\UserBundle\Security\UserProvider" public="false">

--- a/Security/LoginManager.php
+++ b/Security/LoginManager.php
@@ -32,6 +32,7 @@ class LoginManager implements LoginManagerInterface
     private $userChecker;
     private $sessionStrategy;
     private $container;
+
     /**
      * @var AbstractRememberMeServices[]
      */

--- a/Security/LoginManager.php
+++ b/Security/LoginManager.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 
@@ -31,15 +32,21 @@ class LoginManager implements LoginManagerInterface
     private $userChecker;
     private $sessionStrategy;
     private $container;
+    /**
+     * @var AbstractRememberMeServices[]
+     */
+    private $rememberMeServices;
 
     public function __construct(SecurityContextInterface $context, UserCheckerInterface $userChecker,
                                 SessionAuthenticationStrategyInterface $sessionStrategy,
-                                ContainerInterface $container)
+                                ContainerInterface $container,
+                                $rememberMeServices)
     {
         $this->securityContext = $context;
         $this->userChecker = $userChecker;
         $this->sessionStrategy = $sessionStrategy;
         $this->container = $container;
+        $this->rememberMeServices = $rememberMeServices;
     }
 
     final public function loginUser($firewallName, UserInterface $user, Response $response = null)
@@ -51,14 +58,8 @@ class LoginManager implements LoginManagerInterface
         if ($this->container->isScopeActive('request')) {
             $this->sessionStrategy->onAuthentication($this->container->get('request'), $token);
 
-            if (null !== $response) {
-                $rememberMeServices = null;
-                if ($this->container->has('security.authentication.rememberme.services.persistent.'.$firewallName)) {
-                    $rememberMeServices = $this->container->get('security.authentication.rememberme.services.persistent.'.$firewallName);
-                } elseif ($this->container->has('security.authentication.rememberme.services.simplehash.'.$firewallName)) {
-                    $rememberMeServices = $this->container->get('security.authentication.rememberme.services.simplehash.'.$firewallName);
-                }
-
+            if (null !== $response && isset($this->rememberMeServices[$firewallName])) {
+                $rememberMeServices = $this->rememberMeServices[$firewallName];
                 if ($rememberMeServices instanceof RememberMeServicesInterface) {
                     $rememberMeServices->loginSuccess($this->container->get('request'), $response, $token);
                 }


### PR DESCRIPTION
Fix Remember me problem with Symfony 2.3.x (https://github.com/FriendsOfSymfony/FOSUserBundle/issues/1221, https://github.com/FriendsOfSymfony/FOSUserBundle/issues/747).
It would be better if remember_me services has some tag (link issue https://github.com/symfony/symfony/issues/3137)