### PR TITLE
[docs] using getFlashBag() in favor of getFlashes()

### DIFF
--- a/Resources/doc/overriding_templates.md
+++ b/Resources/doc/overriding_templates.md
@@ -36,7 +36,7 @@ Here is the default `layout.html.twig` provided by the FOSUserBundle:
             {% endif %}
         </div>
 
-        {% for key, message in app.session.getFlashes() %}
+        {% for key, message in app.session.getFlashBag() %}
         <div class="{{ key }}">
             {{ message|trans({}, 'FOSUserBundle') }}
         </div>


### PR DESCRIPTION
I've tried using the 1.3.x branch using the latest symfony and found the documentation is confusing - there's no such method getFlashes() anymore.
