### PR TITLE
Updating the configuration_reference.md

### DIFF
--- a/Resources/doc/configuration_reference.md
+++ b/Resources/doc/configuration_reference.md
@@ -45,7 +45,6 @@ fos_user:
             template:   FOSUserBundle:Resetting:email.txt.twig
         form:
             type:               fos_user_resetting
-            handler:            fos_user.resetting.form.handler.default
             name:               fos_user_resetting_form
             validation_groups:  [ResetPassword, Default]
     service:


### PR DESCRIPTION
In the resetting node this line must be removed 
handler:            fos_user.resetting.form.handler.default
the handler is not anymore used
