### PR TITLE
Use the UserInterface not the object for checking

### DIFF
--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -15,7 +15,6 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
-use FOS\UserBundle\Model\User;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
 use FOS\UserBundle\Propel\User as PropelUser;
@@ -56,7 +55,7 @@ class UserProvider implements UserProviderInterface
      */
     public function refreshUser(SecurityUserInterface $user)
     {
-        if (!$user instanceof User && !$user instanceof PropelUser) {
+        if (!$user instanceof UserInterface && !$user instanceof PropelUser) {
             throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
         }
 


### PR DESCRIPTION
This commit fixes a "There is no user provider for user" exception when not using `FOS\UserBundle\Model\User`
