### PR TITLE
Fixed german translation

### DIFF
--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -40,7 +40,7 @@ change_password:
 # Registration
 registration:
     check_email: Eine E-Mail wurde an %email% gesendet. Sie enthält einen Link, den Sie anklicken müssen, um Ihr Benutzerkonto zu bestätigen.
-    confirmed: Glückwunsch %username%, Dein Benutzerkonto ist jetzt bestätigt.
+    confirmed: Glückwunsch %username%, Ihr Benutzerkonto ist jetzt bestätigt.
     back: Zurück zur ursprünglichen Seite.
     submit: Registrieren
     flash:


### PR DESCRIPTION
Regarding #1395 and #1398. 

There was no mixture of formal and non-formal forms before #1395 but as this was changed now, the formal form should be used everywhere.
