### PR TITLE
Fix error when create user class with propel

### DIFF
--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -24,6 +24,7 @@
 
         <service id="fos_user.user_provider.username" class="FOS\UserBundle\Security\UserProvider" public="false">
             <argument type="service" id="fos_user.user_manager" />
+            <argument>%fos_user.model.user.class%</argument>
         </service>
 
         <service id="fos_user.user_provider.username_email" class="FOS\UserBundle\Security\EmailUserProvider" public="false">

--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -18,7 +18,6 @@ use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 use FOS\UserBundle\Model\User;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
-use FOS\UserBundle\Propel\User as PropelUser;
 
 class UserProvider implements UserProviderInterface
 {
@@ -28,13 +27,19 @@ class UserProvider implements UserProviderInterface
     protected $userManager;
 
     /**
+     * @var Class of propelUser
+     */
+    protected $classPropelUser;
+
+    /**
      * Constructor.
      *
      * @param UserManagerInterface $userManager
      */
-    public function __construct(UserManagerInterface $userManager)
+    public function __construct(UserManagerInterface $userManager, $classPropelUser = 'FOS\UserBundle\Propel\User')
     {
         $this->userManager = $userManager;
+        $this->classPropelUser = $classPropelUser;
     }
 
     /**
@@ -56,7 +61,7 @@ class UserProvider implements UserProviderInterface
      */
     public function refreshUser(SecurityUserInterface $user)
     {
-        if (!$user instanceof User && !$user instanceof PropelUser) {
+        if (!$user instanceof User && !$user instanceof $this->classPropelUser) {
             throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
         }
 


### PR DESCRIPTION
When create my user class with propel I have an error : 

'There is no user provider for user Acme\UserBundle\Model\User' 

Because I have defined in my config.yml a new fos_user.user_class

complete : https://github.com/FriendsOfSymfony/FOSUserBundle/pull/760
