### PR TITLE
Update ResettingController.php

### DIFF
--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -115,25 +115,25 @@ class ResettingController extends ContainerAware
         $form = $formFactory->createForm();
         $form->setData($user);
 
-        if ('POST' === $request->getMethod()) {
-            $form->bind($request);
+        
+        $form->handleRequest($request);
 
-            if ($form->isValid()) {
-                $event = new FormEvent($form, $request);
-                $dispatcher->dispatch(FOSUserEvents::RESETTING_RESET_SUCCESS, $event);
+        if ($form->isValid()) {
+            $event = new FormEvent($form, $request);
+            $dispatcher->dispatch(FOSUserEvents::RESETTING_RESET_SUCCESS, $event);
 
-                $userManager->updateUser($user);
+            $userManager->updateUser($user);
 
-                if (null === $response = $event->getResponse()) {
-                    $url = $this->container->get('router')->generate('fos_user_profile_show');
-                    $response = new RedirectResponse($url);
-                }
-
-                $dispatcher->dispatch(FOSUserEvents::RESETTING_RESET_COMPLETED, new FilterUserResponseEvent($user, $request, $response));
-
-                return $response;
+            if (null === $response = $event->getResponse()) {
+                $url = $this->container->get('router')->generate('fos_user_profile_show');
+                $response = new RedirectResponse($url);
             }
+
+            $dispatcher->dispatch(FOSUserEvents::RESETTING_RESET_COMPLETED, new FilterUserResponseEvent($user, $request, $response));
+
+            return $response;
         }
+        
 
         return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:reset.html.'.$this->getEngine(), array(
             'token' => $token,


### PR DESCRIPTION
http://symfony.com/doc/current/cookbook/form/direct_submit.html

"The handleRequest() method was introduced in Symfony 2.3."
"Before Symfony 2.3, the submit() method was known as bind()."

"Passing the Request directly to submit() still works, but is deprecated and will be removed in Symfony 3.0. You should use the method handleRequest() instead."
