### PR TITLE
Adding User account is disabled in french translation

### DIFF
--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -13,6 +13,7 @@ group:
 
 # Security
 "Bad credentials": Invalid username or password
+"User account is disabled.": User account is disabled.
 
 security:
     login:

--- a/Resources/translations/FOSUserBundle.fr.yml
+++ b/Resources/translations/FOSUserBundle.fr.yml
@@ -13,6 +13,7 @@ group:
 
 # Security
 "Bad credentials": Nom d'utilisateur ou mot de passe incorrect
+"User account is disabled.": Le compte utilisateur est désactivé.
 
 security:
     login:


### PR DESCRIPTION
Well, there s translation in spanish and russian for this Symfony bundle error, so here is the french translation
