### PR TITLE
Translated "User account is locked." error message

### DIFF
--- a/Resources/translations/FOSUserBundle.pl.yml
+++ b/Resources/translations/FOSUserBundle.pl.yml
@@ -13,6 +13,7 @@ group:
 
 # Security
 "Bad credentials": Nieprawidłowa nazwa użytkownika lub hasło
+"User account is locked.": Konto użytkownika jest zablokowane
 
 security:
     login:


### PR DESCRIPTION
This message is shown when user with enabled = 0 tries to log in.
