### PR TITLE
Removed trailing slash on access control admin path in installation docs

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -306,7 +306,7 @@ security:
         - { path: ^/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin/, role: ROLE_ADMIN }
+        - { path: ^/admin, role: ROLE_ADMIN }
 ```
 
 Under the `providers` section, you are making the bundle's packaged user provider


### PR DESCRIPTION
There was an unnecessary trailing slash after admin in the installation docs. 

This allowed unauthenticated viewers to access /admin

Unauthenticated users would still be prevented from viewing /admin/*