### PR TITLE
support bundle alias notation

### DIFF
--- a/DependencyInjection/Compiler/RegisterMappingsPass.php
+++ b/DependencyInjection/Compiler/RegisterMappingsPass.php
@@ -33,18 +33,27 @@ class RegisterMappingsPass implements CompilerPassInterface
     private $namespaces;
     private $enabledParameter;
     private $fallbackManagerParameter;
+    private $configurationPattern;
+    private $registerAliasMethodName;
+    private $aliasMap;
 
-    public function __construct($driver, $driverPattern, $namespaces, $enabledParameter, $fallbackManagerParameter)
+    public function __construct($driver, $driverPattern, $namespaces, $enabledParameter, $fallbackManagerParameter, $configurationPattern = '', $registerAliasMethodName = '', array $aliasMap = array())
     {
         $this->driver = $driver;
         $this->driverPattern = $driverPattern;
         $this->namespaces = $namespaces;
         $this->enabledParameter = $enabledParameter;
         $this->fallbackManagerParameter = $fallbackManagerParameter;
+        if (count($aliasMap) && (!$configurationPattern || !$registerAliasMethodName)) {
+            throw new \InvalidArgumentException('configurationPattern and registerAliasMethodName are required to register namespace alias');
+        }
+        $this->configurationPattern = $configurationPattern;
+        $this->registerAliasMethodName = $registerAliasMethodName;
+        $this->aliasMap = $aliasMap;
     }
 
     /**
-     * Register mappings with the metadata drivers.
+     * Register mappings and aliases with the metadata drivers.
      *
      * @param ContainerBuilder $container
      */
@@ -55,9 +64,21 @@ class RegisterMappingsPass implements CompilerPassInterface
         }
 
         $chainDriverDefService = $this->getChainDriverServiceName($container);
+        // Definition for a Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain
         $chainDriverDef = $container->getDefinition($chainDriverDefService);
         foreach ($this->namespaces as $namespace) {
             $chainDriverDef->addMethodCall('addDriver', array($this->driver, $namespace));
+        }
+
+        if (!count($this->aliasMap)) {
+            return;
+        }
+
+        $configurationServiceName = $this->getConfigurationServiceName($container);
+        // Definition of the Doctrine\...\Configuration class specific to the Doctrine flavour.
+        $configurationServiceDefinition = $container->getDefinition($configurationServiceName);
+        foreach ($this->aliasMap as $alias => $namespace) {
+           $configurationServiceDefinition->addMethodCall($this->registerAliasMethodName, array($alias, $namespace));
         }
     }
 
@@ -75,30 +96,30 @@ class RegisterMappingsPass implements CompilerPassInterface
         throw new ParameterNotFoundException('None of the managerParameters resulted in a valid name');
     }
 
-    public static function createOrmMappingDriver(array $mappings)
+    public static function createOrmMappingDriver(array $mappings, array $aliasMap = array())
     {
         $arguments = array($mappings, '.orm.xml');
         $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
         $driver = new Definition('Doctrine\ORM\Mapping\Driver\XmlDriver', array($locator));
 
-        return new RegisterMappingsPass($driver, 'doctrine.orm.%s_metadata_driver', $mappings, 'fos_user.backend_type_orm', 'doctrine.default_entity_manager');
+        return new RegisterMappingsPass($driver, 'doctrine.orm.%s_metadata_driver', $mappings, 'fos_user.backend_type_orm', 'doctrine.default_entity_manager', 'doctrine.orm.%s_configuration', 'addEntityNamespace', $aliasMap);
     }
 
-    public static function createMongoDBMappingDriver($mappings)
+    public static function createMongoDBMappingDriver($mappings, array $aliasMap = array())
     {
         $arguments = array($mappings, '.mongodb.xml');
         $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
         $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver', array($locator));
 
-        return new RegisterMappingsPass($driver, 'doctrine_mongodb.odm.%s_metadata_driver', $mappings, 'fos_user.backend_type_mongodb', 'doctrine_mongodb.odm.default_document_manager');
+        return new RegisterMappingsPass($driver, 'doctrine_mongodb.odm.%s_metadata_driver', $mappings, 'fos_user.backend_type_mongodb', 'doctrine_mongodb.odm.default_document_manager', 'doctrine_mongodb.odm.%s_configuration', 'addDocumentNamespace', $aliasMap);
     }
 
-    public static function createCouchDBMappingDriver($mappings)
+    public static function createCouchDBMappingDriver($mappings, array $aliasMap = array())
     {
         $arguments = array($mappings, '.couchdb.xml');
         $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
         $driver = new Definition('Doctrine\ODM\CouchDB\Mapping\Driver\XmlDriver', array($locator));
 
-        return new RegisterMappingsPass($driver, 'doctrine_couchdb.odm.%s_metadata_driver', $mappings, 'fos_user.backend_type_couchdb', 'doctrine_couchdb.default_document_manager');
+        return new RegisterMappingsPass($driver, 'doctrine_couchdb.odm.%s_metadata_driver', $mappings, 'fos_user.backend_type_couchdb', 'doctrine_couchdb.default_document_manager', 'doctrine_couchdb.odm.%s_configuration', 'addDocumentNamespace', $aliasMap);
     }
 }


### PR DESCRIPTION
Implement https://github.com/symfony/symfony/pull/10853 so that `FOSUserBundle:User` works again.

I guess this is a rare case, as people will extend the user class and then have doctrine do the alias for their extending class. But for consistency, it makes sense to do this.
