### PR TITLE
Fix polish translation

### DIFF
--- a/Resources/translations/FOSUserBundle.pl.yml
+++ b/Resources/translations/FOSUserBundle.pl.yml
@@ -13,6 +13,7 @@ group:
 
 # Security
 "Bad credentials": Nieprawidłowa nazwa użytkownika lub hasło
+"User account is locked.": Konto użytkownika jest zablokowane
 "User account is disabled.": Konto użytkownika jest nieaktywne
 
 security:


### PR DESCRIPTION
Added missing ""User account is disabled." translation,
~~Removed not present in EN translation "User account is locked."~~
