### PR TITLE
Update email.txt.twig

### DIFF
--- a/Resources/views/Resetting/email.txt.twig
+++ b/Resources/views/Resetting/email.txt.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'FOSUserBundle' %}
 {% block subject %}
 {% autoescape false %}
-{{ 'resetting.email.subject'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
+{{ 'resetting.email.subject'|trans }}
 {% endautoescape %}
 {% endblock %}
 {% block body_text %}


### PR DESCRIPTION
resetting.email.subject doesn't require the variables '%username%' and '%confirmationUrl%'.
