### PR TITLE
Removed the option to switch to a different templating engine

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Changelog
 * The minimum requirement for Symfony has been bumped to 2.3 (older versions are already EOLed).
 * [BC break] The ``FOSUserBundle:Security:login.html.twig`` template now receives an AuthenticationException in the ``error``
   variable rather than an error message.
+* [BC break] The templating engine configuration has been removed, as well as the related code.
 
 ### 2.0.0-alpha1 (2014-09-26)
 

--- a/Controller/ChangePasswordController.php
+++ b/Controller/ChangePasswordController.php
@@ -77,7 +77,7 @@ class ChangePasswordController extends Controller
         }
 
         return $this->container->get('templating')->renderResponse(
-            'FOSUserBundle:ChangePassword:changePassword.html.'.$this->container->getParameter('fos_user.template.engine'),
+            'FOSUserBundle:ChangePassword:changePassword.html.twig',
             array('form' => $form->createView())
         );
     }

--- a/Controller/GroupController.php
+++ b/Controller/GroupController.php
@@ -36,7 +36,7 @@ class GroupController extends Controller
     {
         $groups = $this->container->get('fos_user.group_manager')->findGroups();
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:list.html.'.$this->getEngine(), array('groups' => $groups));
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:list.html.twig', array('groups' => $groups));
     }
 
     /**
@@ -46,7 +46,7 @@ class GroupController extends Controller
     {
         $group = $this->findGroupBy('name', $groupName);
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:show.html.'.$this->getEngine(), array('group' => $group));
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:show.html.twig', array('group' => $group));
     }
 
     /**
@@ -93,7 +93,7 @@ class GroupController extends Controller
             return $response;
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:edit.html.'.$this->getEngine(), array(
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:edit.html.twig', array(
             'form'      => $form->createview(),
             'group_name'  => $group->getName(),
         ));
@@ -136,7 +136,7 @@ class GroupController extends Controller
             return $response;
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:new.html.'.$this->getEngine(), array(
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Group:new.html.twig', array(
             'form' => $form->createview(),
         ));
     }
@@ -178,10 +178,5 @@ class GroupController extends Controller
         }
 
         return $group;
-    }
-
-    protected function getEngine()
-    {
-        return $this->container->getParameter('fos_user.template.engine');
     }
 }

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -38,7 +38,7 @@ class ProfileController extends Controller
             throw new AccessDeniedException('This user does not have access to this section.');
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Profile:show.html.'.$this->container->getParameter('fos_user.template.engine'), array('user' => $user));
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Profile:show.html.twig', array('user' => $user));
     }
 
     /**
@@ -89,7 +89,7 @@ class ProfileController extends Controller
         }
 
         return $this->container->get('templating')->renderResponse(
-            'FOSUserBundle:Profile:edit.html.'.$this->container->getParameter('fos_user.template.engine'),
+            'FOSUserBundle:Profile:edit.html.twig',
             array('form' => $form->createView())
         );
     }

--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -70,7 +70,7 @@ class RegistrationController extends Controller
             return $response;
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Registration:register.html.'.$this->getEngine(), array(
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Registration:register.html.twig', array(
             'form' => $form->createView(),
         ));
     }
@@ -88,7 +88,7 @@ class RegistrationController extends Controller
             throw new NotFoundHttpException(sprintf('The user with email "%s" does not exist', $email));
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Registration:checkEmail.html.'.$this->getEngine(), array(
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Registration:checkEmail.html.twig', array(
             'user' => $user,
         ));
     }
@@ -138,13 +138,8 @@ class RegistrationController extends Controller
             throw new AccessDeniedException('This user does not have access to this section.');
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Registration:confirmed.html.'.$this->getEngine(), array(
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Registration:confirmed.html.twig', array(
             'user' => $user,
         ));
-    }
-
-    protected function getEngine()
-    {
-        return $this->container->getParameter('fos_user.template.engine');
     }
 }

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -34,7 +34,7 @@ class ResettingController extends Controller
      */
     public function requestAction()
     {
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:request.html.'.$this->getEngine());
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:request.html.twig');
     }
 
     /**
@@ -48,11 +48,11 @@ class ResettingController extends Controller
         $user = $this->container->get('fos_user.user_manager')->findUserByUsernameOrEmail($username);
 
         if (null === $user) {
-            return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:request.html.'.$this->getEngine(), array('invalid_username' => $username));
+            return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:request.html.twig', array('invalid_username' => $username));
         }
 
         if ($user->isPasswordRequestNonExpired($this->container->getParameter('fos_user.resetting.token_ttl'))) {
-            return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:passwordAlreadyRequested.html.'.$this->getEngine());
+            return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:passwordAlreadyRequested.html.twig');
         }
 
         if (null === $user->getConfirmationToken()) {
@@ -82,7 +82,7 @@ class ResettingController extends Controller
             return new RedirectResponse($this->container->get('router')->generate('fos_user_resetting_request'));
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:checkEmail.html.'.$this->getEngine(), array(
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:checkEmail.html.twig', array(
             'email' => $email,
         ));
     }
@@ -133,7 +133,7 @@ class ResettingController extends Controller
             return $response;
         }
 
-        return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:reset.html.'.$this->getEngine(), array(
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Resetting:reset.html.twig', array(
             'token' => $token,
             'form' => $form->createView(),
         ));
@@ -156,10 +156,5 @@ class ResettingController extends Controller
         }
 
         return $email;
-    }
-
-    protected function getEngine()
-    {
-        return $this->container->getParameter('fos_user.template.engine');
     }
 }

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -61,9 +61,7 @@ class SecurityController extends Controller
      */
     protected function renderLogin(array $data)
     {
-        $template = sprintf('FOSUserBundle:Security:login.html.%s', $this->container->getParameter('fos_user.template.engine'));
-
-        return $this->container->get('templating')->renderResponse($template, $data);
+        return $this->container->get('templating')->renderResponse('FOSUserBundle:Security:login.html.twig', $data);
     }
 
     public function checkAction()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -77,7 +77,6 @@ class Configuration implements ConfigurationInterface
         $this->addRegistrationSection($rootNode);
         $this->addResettingSection($rootNode);
         $this->addServiceSection($rootNode);
-        $this->addTemplateSection($rootNode);
         $this->addGroupSection($rootNode);
 
         return $treeBuilder;
@@ -221,19 +220,6 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('username_canonicalizer')->defaultValue('fos_user.util.canonicalizer.default')->end()
                             ->scalarNode('user_manager')->defaultValue('fos_user.user_manager.default')->end()
                         ->end()
-                    ->end()
-                ->end()
-            ->end();
-    }
-
-    private function addTemplateSection(ArrayNodeDefinition $node)
-    {
-        $node
-            ->children()
-                ->arrayNode('template')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->scalarNode('engine')->defaultValue('twig')->end()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -79,7 +79,6 @@ class FOSUserExtension extends Extension
                 'model_manager_name' => 'fos_user.model_manager_name',
                 'user_class' => 'fos_user.model.user.class',
             ),
-            'template'  => 'fos_user.template.%s',
         ));
 
         if (!empty($config['profile'])) {

--- a/Resources/doc/configuration_reference.md
+++ b/Resources/doc/configuration_reference.md
@@ -53,8 +53,6 @@ fos_user:
         username_canonicalizer: fos_user.util.canonicalizer.default
         token_generator:        fos_user.util.token_generator.default
         user_manager:           fos_user.user_manager.default
-    template:
-        engine: twig
     group:
         group_class:    ~ # Required when using groups
         group_manager:  fos_user.group_manager.default

--- a/Resources/doc/overriding_templates.md
+++ b/Resources/doc/overriding_templates.md
@@ -137,20 +137,3 @@ to take effect, even in a development environment.
 
 Overriding all of the other templates provided by the FOSUserBundle can be done
 in a similar fashion using either of the two methods shown in this document.
-
-### Configuring A Templating Engine Other Than Twig
-
-You can configure a templating engine other than Twig using the bundle's configuration.
-Below is an example configuration for using the PHP templating engine.
-
-``` yaml
-fos_user:
-    # ...
-    template:
-        engine: php
-```
-
-The FOSUserBundle only provides default templates for the Twig templating engine,
-so you will have to create all of the templates that you are using. The names and
-locations will be the same except that the file extension will be `.php` instead of
-`.twig`

--- a/Tests/DependencyInjection/FOSUserExtensionTest.php
+++ b/Tests/DependencyInjection/FOSUserExtensionTest.php
@@ -262,20 +262,6 @@ class FOSUserExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter(1800, 'fos_user.resetting.token_ttl');
     }
 
-    public function testUserLoadTemplateConfigWithDefaults()
-    {
-        $this->createEmptyConfiguration();
-
-        $this->assertParameter('twig', 'fos_user.template.engine');
-    }
-
-    public function testUserLoadTemplateConfig()
-    {
-        $this->createFullConfiguration();
-
-        $this->assertParameter('php', 'fos_user.template.engine');
-    }
-
     public function testUserLoadUtilServiceWithDefaults()
     {
         $this->createEmptyConfiguration();
@@ -392,8 +378,6 @@ service:
     email_canonicalizer: acme_my.email_canonicalizer
     username_canonicalizer: acme_my.username_canonicalizer
     user_manager: acme_my.user_manager
-template:
-    engine: php
 group:
     group_class: Acme\MyBundle\Entity\Group
     form:

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.3",
+        "symfony/twig-bundle": "~2.3",
         "symfony/form": "~2.3",
         "symfony/security-bundle": "~2.3"
     },
     "require-dev": {
-        "twig/twig": "~1.5",
         "doctrine/doctrine-bundle": "*",
         "swiftmailer/swiftmailer": ">=4.3, <6.0",
         "willdurand/propel-typehintable-behavior": "dev-master",


### PR DESCRIPTION
This option was introduced in the early days of the Symfony development when Twig was not yet the recommended engine, to let users remove the dependency on Twig at the expense of rewriting all templates for their engine.
Making the code ugly and inconsistent with the Symfony ecosystem to implement a feature which is barely usable is not worth it.
