### PR TITLE
Refactored the update of the hashed password and canonical fields 

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -29,6 +29,7 @@ return Symfony\CS\Config\Config::create()
         'ordered_use',
         'php_unit_construct',
         'php_unit_strict',
+        '-phpdoc_no_empty_return',
     ))
     ->setUsingCache(true)
     ->finder($finder)

--- a/Doctrine/CouchDB/UserListener.php
+++ b/Doctrine/CouchDB/UserListener.php
@@ -15,29 +15,18 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\CouchDB\Event;
 use Doctrine\ODM\CouchDB\Event\LifecycleEventArgs;
 use FOS\UserBundle\Model\UserInterface;
-use FOS\UserBundle\Model\UserManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use FOS\UserBundle\Util\CanonicalFieldsUpdater;
+use FOS\UserBundle\Util\PasswordUpdaterInterface;
 
 class UserListener implements EventSubscriber
 {
-    /**
-     * @var UserManagerInterface
-     */
-    private $userManager;
+    private $passwordUpdater;
+    private $canonicalFieldsUpdater;
 
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
-     * Constructor.
-     *
-     * @param ContainerInterface $container
-     */
-    public function __construct(ContainerInterface $container)
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater)
     {
-        $this->container = $container;
+        $this->passwordUpdater = $passwordUpdater;
+        $this->canonicalFieldsUpdater = $canonicalFieldsUpdater;
     }
 
     /**
@@ -80,11 +69,7 @@ class UserListener implements EventSubscriber
      */
     private function updateUserFields(UserInterface $user)
     {
-        if (null === $this->userManager) {
-            $this->userManager = $this->container->get('fos_user.user_manager');
-        }
-
-        $this->userManager->updateCanonicalFields($user);
-        $this->userManager->updatePassword($user);
+        $this->canonicalFieldsUpdater->updateCanonicalFields($user);
+        $this->passwordUpdater->hashPassword($user);
     }
 }

--- a/Doctrine/UserManager.php
+++ b/Doctrine/UserManager.php
@@ -15,8 +15,8 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManager as BaseUserManager;
-use FOS\UserBundle\Util\CanonicalizerInterface;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use FOS\UserBundle\Util\CanonicalFieldsUpdater;
+use FOS\UserBundle\Util\PasswordUpdaterInterface;
 
 class UserManager extends BaseUserManager
 {
@@ -38,15 +38,14 @@ class UserManager extends BaseUserManager
     /**
      * Constructor.
      *
-     * @param EncoderFactoryInterface $encoderFactory
-     * @param CanonicalizerInterface  $usernameCanonicalizer
-     * @param CanonicalizerInterface  $emailCanonicalizer
-     * @param ObjectManager           $om
-     * @param string                  $class
+     * @param PasswordUpdaterInterface $passwordUpdater
+     * @param CanonicalFieldsUpdater   $canonicalFieldsUpdater
+     * @param ObjectManager            $om
+     * @param string                   $class
      */
-    public function __construct(EncoderFactoryInterface $encoderFactory, CanonicalizerInterface $usernameCanonicalizer, CanonicalizerInterface $emailCanonicalizer, ObjectManager $om, $class)
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater, ObjectManager $om, $class)
     {
-        parent::__construct($encoderFactory, $usernameCanonicalizer, $emailCanonicalizer);
+        parent::__construct($passwordUpdater, $canonicalFieldsUpdater);
 
         $this->objectManager = $om;
         $this->repository = $om->getRepository($class);

--- a/Propel/UserManager.php
+++ b/Propel/UserManager.php
@@ -13,8 +13,8 @@ namespace FOS\UserBundle\Propel;
 
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManager as BaseUserManager;
-use FOS\UserBundle\Util\CanonicalizerInterface;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use FOS\UserBundle\Util\CanonicalFieldsUpdater;
+use FOS\UserBundle\Util\PasswordUpdaterInterface;
 
 class UserManager extends BaseUserManager
 {
@@ -26,14 +26,13 @@ class UserManager extends BaseUserManager
     /**
      * Constructor.
      *
-     * @param EncoderFactoryInterface $encoderFactory
-     * @param CanonicalizerInterface  $usernameCanonicalizer
-     * @param CanonicalizerInterface  $emailCanonicalizer
-     * @param string                  $class
+     * @param PasswordUpdaterInterface $passwordUpdater
+     * @param CanonicalFieldsUpdater   $canonicalFieldsUpdater
+     * @param string                   $class
      */
-    public function __construct(EncoderFactoryInterface $encoderFactory, CanonicalizerInterface $usernameCanonicalizer, CanonicalizerInterface $emailCanonicalizer, $class)
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater, $class)
     {
-        parent::__construct($encoderFactory, $usernameCanonicalizer, $emailCanonicalizer);
+        parent::__construct($passwordUpdater, $canonicalFieldsUpdater);
 
         $this->class = $class;
     }

--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -6,9 +6,8 @@
 
     <services>
         <service id="fos_user.user_manager.default" class="FOS\UserBundle\Doctrine\UserManager" public="false">
-            <argument type="service" id="security.encoder_factory" />
-            <argument type="service" id="fos_user.util.username_canonicalizer" />
-            <argument type="service" id="fos_user.util.email_canonicalizer" />
+            <argument type="service" id="fos_user.util.password_updater" />
+            <argument type="service" id="fos_user.util.canonical_fields_updater" />
             <argument type="service" id="fos_user.object_manager" />
             <argument>%fos_user.model.user.class%</argument>
         </service>
@@ -19,7 +18,8 @@
         </service>
 
         <service id="fos_user.user_listener" class="FOS\UserBundle\Doctrine\UserListener" public="false">
-            <argument type="service" id="service_container" />
+            <argument type="service" id="fos_user.util.password_updater" />
+            <argument type="service" id="fos_user.util.canonical_fields_updater" />
         </service>
     </services>
 

--- a/Resources/config/propel.xml
+++ b/Resources/config/propel.xml
@@ -6,9 +6,8 @@
 
     <services>
         <service id="fos_user.user_manager.default" class="FOS\UserBundle\Propel\UserManager" public="false">
-            <argument type="service" id="security.encoder_factory" />
-            <argument type="service" id="fos_user.util.username_canonicalizer" />
-            <argument type="service" id="fos_user.util.email_canonicalizer" />
+            <argument type="service" id="fos_user.util.password_updater" />
+            <argument type="service" id="fos_user.util.canonical_fields_updater" />
             <argument>%fos_user.model.user.class%</argument>
         </service>
     </services>

--- a/Resources/config/util.xml
+++ b/Resources/config/util.xml
@@ -18,6 +18,16 @@
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
+        <service id="fos_user.util.password_updater" class="FOS\UserBundle\Util\PasswordUpdater" public="false">
+            <argument type="service" id="security.encoder_factory" />
+        </service>
+
+        <service id="fos_user.util.canonical_fields_updater" class="FOS\UserBundle\Util\CanonicalFieldsUpdater" public="false">
+            <argument type="service" id="fos_user.util.username_canonicalizer" />
+            <argument type="service" id="fos_user.util.email_canonicalizer" />
+        </service>
+
+
     </services>
 
 </container>

--- a/Resources/config/validator.xml
+++ b/Resources/config/validator.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="fos_user.validator.initializer" class="FOS\UserBundle\Validator\Initializer" public="false">
             <tag name="validator.initializer" />
-            <argument type="service" id="fos_user.user_manager" />
+            <argument type="service" id="fos_user.util.canonical_fields_updater" />
         </service>
     </services>
 

--- a/Tests/Doctrine/UserManagerTest.php
+++ b/Tests/Doctrine/UserManagerTest.php
@@ -31,8 +31,10 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Doctrine Common has to be installed for this test to run.');
         }
 
-        $c = $this->getMockBuilder('FOS\UserBundle\Util\CanonicalizerInterface')->getMock();
-        $ef = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
+        $passwordUpdater = $this->getMockBuilder('FOS\UserBundle\Util\PasswordUpdaterInterface')->getMock();
+        $fieldsUpdater = $this->getMockBuilder('FOS\UserBundle\Util\CanonicalFieldsUpdater')
+            ->disableOriginalConstructor()
+            ->getMock();
         $class = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadata')->getMock();
         $this->om = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
         $this->repository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')->getMock();
@@ -49,7 +51,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getName')
             ->will($this->returnValue(static::USER_CLASS));
 
-        $this->userManager = $this->createUserManager($ef, $c, $this->om, static::USER_CLASS);
+        $this->userManager = new UserManager($passwordUpdater, $fieldsUpdater, $this->om, static::USER_CLASS);
     }
 
     public function testDeleteUser()
@@ -88,19 +90,6 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $this->om->expects($this->once())->method('flush');
 
         $this->userManager->updateUser($user);
-    }
-
-    /**
-     * @param $encoderFactory
-     * @param $canonicalizer
-     * @param $objectManager
-     * @param $userClass
-     *
-     * @return UserManager
-     */
-    protected function createUserManager($encoderFactory, $canonicalizer, $objectManager, $userClass)
-    {
-        return new UserManager($encoderFactory, $canonicalizer, $canonicalizer, $objectManager, $userClass);
     }
 
     /**

--- a/Tests/Util/CanonicalFieldsUpdaterTest.php
+++ b/Tests/Util/CanonicalFieldsUpdaterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Tests\Util;
+
+use FOS\UserBundle\Tests\TestUser;
+use FOS\UserBundle\Util\CanonicalFieldsUpdater;
+
+class CanonicalFieldsUpdaterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CanonicalFieldsUpdater
+     */
+    private $updater;
+    private $usernameCanonicalizer;
+    private $emailCanonicalizer;
+
+    protected function setUp()
+    {
+        $this->usernameCanonicalizer = $this->getMockCanonicalizer();
+        $this->emailCanonicalizer = $this->getMockCanonicalizer();
+
+        $this->updater = new CanonicalFieldsUpdater($this->usernameCanonicalizer, $this->emailCanonicalizer);
+    }
+
+    public function testUpdateCanonicalFields()
+    {
+        $user = new TestUser();
+        $user->setUsername('Username');
+        $user->setEmail('User@Example.com');
+
+        $this->usernameCanonicalizer->expects($this->once())
+            ->method('canonicalize')
+            ->with('Username')
+            ->will($this->returnCallback('strtolower'));
+
+        $this->emailCanonicalizer->expects($this->once())
+            ->method('canonicalize')
+            ->with('User@Example.com')
+            ->will($this->returnCallback('strtolower'));
+
+        $this->updater->updateCanonicalFields($user);
+        $this->assertSame('username', $user->getUsernameCanonical());
+        $this->assertSame('user@example.com', $user->getEmailCanonical());
+    }
+
+    private function getMockCanonicalizer()
+    {
+        return $this->getMockBuilder('FOS\UserBundle\Util\CanonicalizerInterface')->getMock();
+    }
+}

--- a/Tests/Util/PasswordUpdaterTest.php
+++ b/Tests/Util/PasswordUpdaterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Tests\Util;
+
+use FOS\UserBundle\Tests\TestUser;
+use FOS\UserBundle\Util\PasswordUpdater;
+
+class PasswordUpdaterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PasswordUpdater
+     */
+    private $updater;
+    private $encoderFactory;
+
+    protected function setUp()
+    {
+        $this->encoderFactory = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
+
+        $this->updater = new PasswordUpdater($this->encoderFactory);
+    }
+
+    public function testUpdatePassword()
+    {
+        $encoder = $this->getMockPasswordEncoder();
+        $user = new TestUser();
+        $user->setPlainPassword('password');
+
+        $this->encoderFactory->expects($this->once())
+            ->method('getEncoder')
+            ->will($this->returnValue($encoder));
+
+        $encoder->expects($this->once())
+            ->method('encodePassword')
+            ->with('password', $user->getSalt())
+            ->will($this->returnValue('encodedPassword'));
+
+        $this->updater->hashPassword($user);
+        $this->assertSame('encodedPassword', $user->getPassword(), '->updatePassword() sets encoded password');
+        $this->assertNull($user->getPlainPassword(), '->updatePassword() erases credentials');
+    }
+
+    public function testDoesNotUpdateWithoutPlainPassword()
+    {
+        $user = new TestUser();
+        $user->setPassword('hash');
+
+        $user->setPlainPassword('');
+
+        $this->updater->hashPassword($user);
+        $this->assertSame('hash', $user->getPassword());
+    }
+
+    private function getMockPasswordEncoder()
+    {
+        return $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')->getMock();
+    }
+}

--- a/Util/CanonicalFieldsUpdater.php
+++ b/Util/CanonicalFieldsUpdater.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Util;
+
+use FOS\UserBundle\Model\UserInterface;
+
+/**
+ * Class updating the canonical fields of the user.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class CanonicalFieldsUpdater
+{
+    private $usernameCanonicalizer;
+    private $emailCanonicalizer;
+
+    public function __construct(CanonicalizerInterface $usernameCanonicalizer, CanonicalizerInterface $emailCanonicalizer)
+    {
+        $this->usernameCanonicalizer = $usernameCanonicalizer;
+        $this->emailCanonicalizer = $emailCanonicalizer;
+    }
+
+    public function updateCanonicalFields(UserInterface $user)
+    {
+        $user->setUsernameCanonical($this->canonicalizeUsername($user->getUsername()));
+        $user->setEmailCanonical($this->canonicalizeEmail($user->getEmail()));
+    }
+
+    /**
+     * Canonicalizes an email.
+     *
+     * @param string|null $email
+     *
+     * @return string|null
+     */
+    public function canonicalizeEmail($email)
+    {
+        return $this->emailCanonicalizer->canonicalize($email);
+    }
+
+    /**
+     * Canonicalizes a username.
+     *
+     * @param string|null $username
+     *
+     * @return string|null
+     */
+    public function canonicalizeUsername($username)
+    {
+        return $this->usernameCanonicalizer->canonicalize($username);
+    }
+}

--- a/Util/PasswordUpdater.php
+++ b/Util/PasswordUpdater.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Util;
+
+use FOS\UserBundle\Model\UserInterface;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+
+/**
+ * Class updating the hashed password in the user when there is a new password.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class PasswordUpdater implements PasswordUpdaterInterface
+{
+    private $encoderFactory;
+
+    public function __construct(EncoderFactoryInterface $encoderFactory)
+    {
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    public function hashPassword(UserInterface $user)
+    {
+        $plainPassword = $user->getPlainPassword();
+
+        if (0 === strlen($plainPassword)) {
+            return;
+        }
+
+        $encoder = $this->encoderFactory->getEncoder($user);
+        $hashedPassword = $encoder->encodePassword($plainPassword, $user->getSalt());
+        $user->setPassword($hashedPassword);
+        $user->eraseCredentials();
+    }
+}

--- a/Util/PasswordUpdaterInterface.php
+++ b/Util/PasswordUpdaterInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Util;
+
+use FOS\UserBundle\Model\UserInterface;
+
+/**
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+interface PasswordUpdaterInterface
+{
+    /**
+     * Updates the hashed password in the user when there is a new password.
+     *
+     * The implement should be a no-op in case there is no new password (it should not erase the
+     * existing hash with a wrong one).
+     *
+     * @param UserInterface $user
+     *
+     * @return void
+     */
+    public function hashPassword(UserInterface $user);
+}

--- a/Validator/Initializer.php
+++ b/Validator/Initializer.php
@@ -12,7 +12,7 @@
 namespace FOS\UserBundle\Validator;
 
 use FOS\UserBundle\Model\UserInterface;
-use FOS\UserBundle\Model\UserManagerInterface;
+use FOS\UserBundle\Util\CanonicalFieldsUpdater;
 use Symfony\Component\Validator\ObjectInitializerInterface;
 
 /**
@@ -22,19 +22,11 @@ use Symfony\Component\Validator\ObjectInitializerInterface;
  */
 class Initializer implements ObjectInitializerInterface
 {
-    /**
-     * @var UserManagerInterface
-     */
-    private $userManager;
+    private $canonicalFieldsUpdater;
 
-    /**
-     * Initializer constructor.
-     *
-     * @param UserManagerInterface $userManager
-     */
-    public function __construct(UserManagerInterface $userManager)
+    public function __construct(CanonicalFieldsUpdater $canonicalFieldsUpdater)
     {
-        $this->userManager = $userManager;
+        $this->canonicalFieldsUpdater = $canonicalFieldsUpdater;
     }
 
     /**
@@ -43,7 +35,7 @@ class Initializer implements ObjectInitializerInterface
     public function initialize($object)
     {
         if ($object instanceof UserInterface) {
-            $this->userManager->updateCanonicalFields($object);
+            $this->canonicalFieldsUpdater->updateCanonicalFields($object);
         }
     }
 }


### PR DESCRIPTION
The responsibility of updating these fields is moved to dedicated services instead of being in the UserManager, allowing to inject them in the Doctrine listener and the validator initializer without any issue about circular dependencies.

~~This PR currently includes #1612 as they would conflict together otherwise. I will need to be rebased once the other PR is merged.~~

This is a BC break for people extending the user manager (or instantiating the existing one themselves, but this would be weird) as the constructor signature has changed.