### PR TITLE
Using parameter lookup for service class

### DIFF
--- a/Resources/config/email_confirmation.xml
+++ b/Resources/config/email_confirmation.xml
@@ -4,8 +4,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="fos_user.listener.email_confirmation.class">FOS\UserBundle\EventListener\EmailConfirmationListener</parameter>
+    </parameters>
+
     <services>
-        <service id="fos_user.listener.email_confirmation" class="FOS\UserBundle\EventListener\EmailConfirmationListener">
+        <service id="fos_user.listener.email_confirmation" class="%fos_user.listener.email_confirmation.class%">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="fos_user.mailer" />
             <argument type="service" id="fos_user.util.token_generator" />


### PR DESCRIPTION
By using the class as a parameter it allows users to override the actual email-listener if needed (which I do, in this case)
