### PR TITLE
Rendering registration template was moved to a separate method

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -70,9 +70,24 @@ class RegistrationController extends Controller
             return $response;
         }
 
-        return $this->render('FOSUserBundle:Registration:register.html.twig', array(
+        return $this->renderRegistration(array(
             'form' => $form->createView(),
         ));
+    }
+
+    /**
+     * Renders the registration template with the given parameters. Overwrite this function in
+     * an extended controller to provide additional data for the login template.
+     *
+     * @param array $data
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function renderRegistration(array $data)
+    {
+        $template = 'FOSUserBundle:Registration:register.html.twig';
+
+        return $this->container->get('templating')->renderResponse($template, $data);
     }
 
     /**


### PR DESCRIPTION
It will help when you need to replace only template display (same way as login).

My points:

I had it and others in app/Resouces before.

But then I had to extend logic of the UserBundle. When I need to have more form fields and do more with data in the action in addition to parent.

In this case I created a controller extending from FOSUserBundle one. Once I've added my custom action Symfony won't take app/Resource template anymore, it throws 'Unable to find template "AcmeDemoBundle:Security:login.html.twig".

1. To override only template rendering part instead of copy-pasting whole method. So the use case: 
```
<?php

namespace Acme\UserBundle\Controller;

use FOS\UserBundle\Controller\SecurityController as BaseSecurityController;
use Symfony\Component\HttpFoundation\Request;

class SecurityController extends BaseSecurityController
{
    public function loginAction(Request $request)
    {
        $response = parent::loginAction($request);

        // your custom code here ...

        return $response;
    }

    protected function renderLogin(array $data)
    {
        $template = sprintf('AcmeUserBundle:Security:login.html.%s', $this->container->getParameter('fos_user.template.engine'));

        return $this->container->get('templating')->renderResponse($template, $data);
    }
}
```
I think it's better then copying all the code of a function.

2. I can share my custom bundle with other apps. via externals (vendors). If it will be in app/Resource it is not possible to make it external.

3. To keep templates more bundle-oriented (when using the FOSUserBundle went further than overriding one template).

4. Persistence. This way is already used in RegistrationController (method 'renderRegistration'), why not to push a good idea forward? :)