### PR TITLE
Fixed custom user class bug with UserProvider

### DIFF
--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -56,7 +56,7 @@ class UserProvider implements UserProviderInterface
      */
     public function refreshUser(SecurityUserInterface $user)
     {
-        if (!$user instanceof User && !$user instanceof PropelUser) {
+        if (!$user instanceof User && !$user instanceof PropelUser && !$user instanceof UserInterface) {
             throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
         }
 


### PR DESCRIPTION
If you copy the User model and create a new one like `class Person implements UserInterface` it doesnt work with the current UserProvider.

I rewrited the whole User class and implemented the UserInterface.
The difference is that my table contains not so much informations like the base user class.
I rewrited the UserManager so that the methods `findUserByEmail`, `findUserByUsername` and `findUserByConfirmationToken` work.
But after a login i got the message that `There is no user provider for user...`.

The problem is that it would work fine if this commit would be accepted.

I could rewrite the UserProvider, too. But why? The UserProvider is nice and usable for me except the part with the direct UserModel check...

Maybe you could add a example how to override the doctrine mapping completly.
I could extend your BaseUser but i cant use your mapping...
If i copy the User.orm.xml from `/vendor/friendsofsymfony/user-bundle/Resources/config/doctrine/model/User.orm.xml` to `/src/Acme/UserBundle/Resources/config/doctrine/model/User.orm.xml` it doesnt work... The bundles parent is `FOSUserBundle`.

Your idea with `Doctrine Inheritance Mapping` doesnt work, too. I dont know how to do?
Your BaseUser is a mapped super class... And i cant remove columns with that inheritance ...

Maybe there is another solution... But i would keep the UserProvider from you instead override them.