### PR TITLE
Remove quotes as they are invalid syntax

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -45,7 +45,7 @@ Installation is a quick (I promise!) 7 step process:
 Add FOSUserBundle by running the command:
 
 ``` bash
-$ php composer.phar require friendsofsymfony/user-bundle ~2.0@dev
+$ php composer.phar require friendsofsymfony/user-bundle "~2.0@dev"
 ```
 
 Composer will install the bundle to your project's `vendor/friendsofsymfony` directory.


### PR DESCRIPTION
When using Composer, the quotes result in the error message

```
[UnexpectedValueException]
Could not parse version constraint '~2.0@dev': Invalid version string "'~2.0@dev'"
```

I know this is minor, but copy-paste convenience :)
