### PR TITLE
Modify class verification on UserProvider when refresh user to check interface instead of implemented standard classes for custom driver use.

### DIFF
--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -56,7 +56,7 @@ class UserProvider implements UserProviderInterface
      */
     public function refreshUser(SecurityUserInterface $user)
     {
-        if (!$user instanceof User && !$user instanceof PropelUser) {
+        if (!$user instanceof UserInterface) {
             throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
         }
 

--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -57,7 +57,7 @@ class UserProvider implements UserProviderInterface
     public function refreshUser(SecurityUserInterface $user)
     {
         if (!$user instanceof UserInterface) {
-            throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
+            throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\UserInterface, but got "%s".', get_class($user)));
         }
 
         if (null === $reloadedUser = $this->userManager->findUserBy(array('id' => $user->getId()))) {


### PR DESCRIPTION
If we made a custom driver as https://github.com/fferriere/PommFosUserBundle we have an error on UserProvider because there is a check on User and PropelUser class instead of on interface.