### PR TITLE
Require ext-mbstring in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
+        "ext-mbstring": "*",
         "symfony/framework-bundle": "~2.3",
         "symfony/twig-bundle": "~2.3",
         "symfony/form": "~2.3",


### PR DESCRIPTION
It's used by `Canonicalizer`, and the extension is not enabled by default in PHP, so the dependency should be declared (see https://coderwall.com/p/xr9xfg).