### PR TITLE
Switch to stable dependencies on Travis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
             "homepage": "https://github.com/friendsofsymfony/FOSUserBundle/contributors"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.1",
@@ -27,9 +26,9 @@
     },
     "require-dev": {
         "twig/twig": "~1.5",
-        "doctrine/doctrine-bundle": "*",
-        "swiftmailer/swiftmailer": "~4.3",
-        "willdurand/propel-typehintable-behavior": "dev-master",
+        "doctrine/doctrine-bundle": "~1.3",
+        "swiftmailer/swiftmailer": "~4.3|~5",
+        "willdurand/propel-typehintable-behavior": "~1.0",
         "symfony/yaml": "~2.1",
         "symfony/validator": "~2.1"
     },


### PR DESCRIPTION
This will avoid getting Symfony 2.7 packages
