### PR TITLE
Add ForceLoginOnPasswordChange option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -54,6 +54,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('use_listener')->defaultTrue()->end()
                 ->booleanNode('use_flash_notifications')->defaultTrue()->end()
                 ->booleanNode('use_username_form_type')->defaultTrue()->end()
+                ->booleanNode('force_login_on_password_change')->defaultFalse()->end()
                 ->arrayNode('from_email')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -72,6 +72,10 @@ class FOSUserExtension extends Extension
             $loader->load('username_form_type.xml');
         }
 
+        if ($config['force_login_on_password_change']) {
+            $this->setForceLoginOnPasswordChange($container);
+        }
+
         $this->remapParametersNamespaces($config, $container, array(
             ''          => array(
                 'db_driver' => 'fos_user.storage',
@@ -205,6 +209,14 @@ class FOSUserExtension extends Extension
                     $container->setParameter(sprintf($map, $name), $value);
                 }
             }
+        }
+    }
+
+    protected function setForceLoginOnPasswordChange(ContainerBuilder $container)
+    {
+        foreach ($container->findTaggedServiceIds('fos_user.user_provider') as $id => $tags) {
+            $userProvider = $container->getDefinition($id);
+            $userProvider->addMethodCall('setForceLoginOnPasswordChange', array('true'));
         }
     }
 }

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -24,10 +24,12 @@
 
         <service id="fos_user.user_provider.username" class="FOS\UserBundle\Security\UserProvider" public="false">
             <argument type="service" id="fos_user.user_manager" />
+	    <tag name="fos_user.user_provider" />
         </service>
 
         <service id="fos_user.user_provider.username_email" class="FOS\UserBundle\Security\EmailUserProvider" public="false">
             <argument type="service" id="fos_user.user_manager" />
+	    <tag name="fos_user.user_provider" />
         </service>
     </services>
 

--- a/Resources/doc/configuration_reference.md
+++ b/Resources/doc/configuration_reference.md
@@ -11,6 +11,7 @@ fos_user:
     user_class:             ~ # Required
     use_listener:           true
     use_username_form_type: true
+    force_login_on_password_change: false # change to true to force logins on other sessions if user password changes
     model_manager_name:     null  # change it to the name of your entity/document manager if you don't want to use the default one.
     from_email:
         address:        webmaster@example.com

--- a/Tests/DependencyInjection/FOSUserExtensionTest.php
+++ b/Tests/DependencyInjection/FOSUserExtensionTest.php
@@ -336,6 +336,7 @@ db_driver: orm
 firewall_name: fos_user
 use_listener: true
 use_flash_notifications: false
+force_login_on_password_change: true
 user_class: Acme\MyBundle\Entity\User
 model_manager_name: custom
 from_email:

--- a/Tests/Security/UserProviderTest.php
+++ b/Tests/Security/UserProviderTest.php
@@ -113,4 +113,16 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->userProvider->refreshUser($providedUser);
     }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     */
+    public function testRefreshPasswordChangedThrowsAuthenticationException()
+    {
+        $this->userProvider->setForceLoginOnPasswordChange(true);
+        $user = $this->getMockBuilder('FOS\UserBundle\Model\User')
+                    ->setMethods(array('getPassword'))
+                    ->getMock();
+        $this->userProvider->refreshUser($user);
+    }
 }


### PR DESCRIPTION
If a user is logged in to multiple sessions and they change their password in one session, then in some cases, sites would prefer to force the user to re-login to any other session that might exist for security reasons.  

I'm not sure sure if this PR is the best option in fitting into the Symfony/FOSUser security framework, so if there's a better way to do it, please let me know.