### PR TITLE
Add spaceless tag to email templates

### DIFF
--- a/Resources/views/Registration/email.txt.twig
+++ b/Resources/views/Registration/email.txt.twig
@@ -1,8 +1,10 @@
 {% trans_default_domain 'FOSUserBundle' %}
 {% block subject %}
+{% spaceless %}
 {% autoescape false %}
 {{ 'registration.email.subject'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
 {% endautoescape %}
+{% endspaceless %}
 {% endblock %}
 {% block body_text %}
 {% autoescape false %}


### PR DESCRIPTION
Add spaceless tag to email templates, to prevent having a newline in the email subject.