### PR TITLE
Remove trailing colon from form labels

### DIFF
--- a/Resources/translations/FOSUserBundle.ar.yml
+++ b/Resources/translations/FOSUserBundle.ar.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "إسم المستخدم:"
-        password: "كلمة المرور:"
+        username: إسم المستخدم
+        password: كلمة المرور
         remember_me: حفظ البيانات
         submit: تسجيل دخول
 
@@ -61,7 +61,7 @@ resetting:
     check_email: لقد تم إرسال رسالة إلكترونية إلى %email%  يحتوي على رابط يجب إتباعه لإعادة تعيين كلمة المرور الخاصة بك.
     request:
         invalid_username: إسم المستخدم او  البريد الالكتروني "%username%" غير موجود
-        username: "إسم المستخدم او البريد الالكتروني:"
+        username: إسم المستخدم او البريد الالكتروني
         submit: إعادة ضبط كلمة المرور
     reset:
         submit: تغيير كلمة المرور
@@ -86,11 +86,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "إسم المجموعة :"
-    username: "إسم المستخدم :"
-    email: "البريد الإلكتروني :"
-    current_password: "كلمة المرور الحالية :"
-    password: "كلمة المرور :"
-    password_confirmation: "تأكيد :"
-    new_password: "كلمة المرور الجديدة :"
-    new_password_confirmation: "تأكيد كلمة المرور :"
+    group_name: إسم المجموعة 
+    username: إسم المستخدم 
+    email: البريد الإلكتروني 
+    current_password: كلمة المرور الحالية 
+    password: كلمة المرور 
+    password_confirmation: تأكيد 
+    new_password: كلمة المرور الجديدة 
+    new_password_confirmation: تأكيد كلمة المرور 

--- a/Resources/translations/FOSUserBundle.bg.yml
+++ b/Resources/translations/FOSUserBundle.bg.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Потребителско име:"
-        password: "Парола:"
+        username: Потребителско име
+        password: Парола
         remember_me: Запомни ме
         submit: Вход
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Изпратихме писмо с линк за активация на посочения E-mail адрес: %email%. Ако не откривате писмото проверете и в папка СПАМ.
     request:
         invalid_username: Потребителското име или E-mail адрес "%username%" не съществува.
-        username: "Потребителско име / E-mail:"
+        username: Потребителско име / E-mail
         submit: Промени паролата
     reset:
         submit: Промени паролата
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Име на група:"
-    username: "Потребителско име:"
-    email: "E-mail:"
-    current_password: "Текуща парола:"
-    password: "Парола:"
-    password_confirmation: "Парола (отново):"
-    new_password: "Нова парола:"
-    new_password_confirmation: "Нова парола (отново):"
+    group_name: Име на група
+    username: Потребителско име
+    email: E-mail
+    current_password: Текуща парола
+    password: Парола
+    password_confirmation: Парола (отново)
+    new_password: Нова парола
+    new_password_confirmation: Нова парола (отново)

--- a/Resources/translations/FOSUserBundle.ca.yml
+++ b/Resources/translations/FOSUserBundle.ca.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Nom d'usuari:"
-        password: "Contrasenya:"
+        username: Nom d'usuari
+        password: Contrasenya
         remember_me: Recorda'm
         submit: Entra
 
@@ -59,7 +59,7 @@ resetting:
     check_email: S'ha enviat un correu electrònic a %email%. Conté un enllaç que heu de clicar per restablir la contrasenya.
     request:
         invalid_username: El nom d'usuari o correu electrònic "%username%" no existeix.
-        username: "Nom d'usuari o correu electrònic:"
+        username: Nom d'usuari o correu electrònic
         submit: Restableix la contrasenya
     reset:
         submit: Canvia la contrasenya
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Nom del grup:"
-    username: "Nom d'usuari:"
-    email: "Correu electrònic:"
-    current_password: "Contrasenya actual:"
-    password: "Contrasenya:"
-    password_confirmation: "Verificació:"
-    new_password: "Nova contrasenya:"
-    new_password_confirmation: "Verificació:"
+    group_name: Nom del grup
+    username: Nom d'usuari
+    email: Correu electrònic
+    current_password: Contrasenya actual
+    password: Contrasenya
+    password_confirmation: Verificació
+    new_password: Nova contrasenya
+    new_password_confirmation: Verificació

--- a/Resources/translations/FOSUserBundle.cs.yml
+++ b/Resources/translations/FOSUserBundle.cs.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Uživatelské jméno:"
-        password: "Heslo:"
+        username: Uživatelské jméno
+        password: Heslo
         remember_me: Zapamatovat si
         submit: Přihlásit
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Na adresu %email% byl zaslán e-mail s návodem na nastavení nového hesla. E-mail obsahuje odkaz, na který je nutné kliknout, bez tohoto úkonu není možné nové heslo nastavit.
     request:
         invalid_username: Uživatelské jméno nebo e-mail "%username%" neexistují.
-        username: "Uživatelské jméno nebo e-mail:"
+        username: Uživatelské jméno nebo e-mail
         submit: Nastavit nové heslo
     reset:
         submit: Nastavit nové heslo
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Název skupiny:"
-    username: "Uživatelské jméno:"
-    email: "E-mail:"
-    current_password: "Současné heslo:"
-    password: "Heslo:"
-    password_confirmation: "Potvrzení hesla:"
-    new_password: "Nové heslo:"
-    new_password_confirmation: "Potvrzení hesla:"
+    group_name: Název skupiny
+    username: Uživatelské jméno
+    email: E-mail
+    current_password: Současné heslo
+    password: Heslo
+    password_confirmation: Potvrzení hesla
+    new_password: Nové heslo
+    new_password_confirmation: Potvrzení hesla

--- a/Resources/translations/FOSUserBundle.da.yml
+++ b/Resources/translations/FOSUserBundle.da.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Brugernavn:"
-        password: "Kodeord:"
+        username: Brugernavn
+        password: Kodeord
         remember_me: Husk mig
         submit: Log ind
 
@@ -59,7 +59,7 @@ resetting:
     check_email: En email er blevet sendt til %email%. Den indeholder et link til at nulstille dit kodeord.
     request:
         invalid_username: Brugeren "%username" findes ikke
-        username: "Brugernavn:"
+        username: Brugernavn
         submit: Nulstil kodeord
     reset:
         submit: Skift kodeord
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Gruppe navn:"
-    username: "Brugernavn:"
-    email: "Email:"
-    current_password: "Nuværende kodeord:"
-    password: "Kodeord:"
-    password_confirmation: "Gentag kodeord:"
-    new_password: "Nyt kodeord:"
-    new_password_confirmation: "Gentag kodeord:"
+    group_name: Gruppe navn
+    username: Brugernavn
+    email: Email
+    current_password: Nuværende kodeord
+    password: Kodeord
+    password_confirmation: Gentag kodeord
+    new_password: Nyt kodeord
+    new_password_confirmation: Gentag kodeord

--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Benutzername:"
-        password: "Passwort:"
+        username: Benutzername
+        password: Passwort
         remember_me: An mich erinnern
         submit: Anmelden
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Eine E-Mail wurde an %email% gesendet. Sie enthält einen Link, den Sie anklicken müssen, um Ihr Passwort zurückzusetzen.
     request:
         invalid_username: Der Benutzername oder die E-Mail-Adresse "%username%" existiert nicht.
-        username: "Benutzername oder E-Mail-Adresse:"
+        username: Benutzername oder E-Mail-Adresse
         submit: Passwort zurücksetzen
     reset:
         submit: Passwort ändern
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Gruppenname:"
-    username: "Benutzername:"
-    email: "E-Mail-Adresse:"
-    current_password: "Derzeitiges Passwort:"
-    password: "Passwort:"
-    password_confirmation: "Passwort bestätigen:"
-    new_password: "Neues Passwort:"
-    new_password_confirmation: "Neues Passwort bestätigen:"
+    group_name: Gruppenname
+    username: Benutzername
+    email: E-Mail-Adresse
+    current_password: Derzeitiges Passwort
+    password: Passwort
+    password_confirmation: Passwort bestätigen
+    new_password: Neues Passwort
+    new_password_confirmation: Neues Passwort bestätigen

--- a/Resources/translations/FOSUserBundle.el.yml
+++ b/Resources/translations/FOSUserBundle.el.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Όνομα Χρήστη:"
-        password: "Κωδικός Πρόσβασης:"
+        username: Όνομα Χρήστη
+        password: Κωδικός Πρόσβασης
         remember_me: Να με θυμάσαι
         submit: Είσοδος
 
@@ -58,7 +58,7 @@ resetting:
     check_email: Ένα email στάλθηκε στο %email%. Περιέχει ένα σύνδεσμο για να επαναφέρετε τον κωδικό πρόσβασής σας.
     request:
         invalid_username: Το όνομα χρήστη ή η διεύθυνση ηλεκτρονικού ταχυδρομείου "% username%" δεν υπάρχει.
-        username: "Όνομα χρήστη ή διεύθυνση e-mail:"
+        username: Όνομα χρήστη ή διεύθυνση e-mail
         submit: Επαναφορά του κωδικού πρόσβασης
     reset:
         submit: Αλλαγή κωδικού πρόσβασης
@@ -82,11 +82,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Όνομα ομάδας:"
-    username: "Όνομα Χρήστη:"
-    email: "Email:"
-    current_password: "Τρέχον κωδικός πρόσβασης:"
-    password: "Κωδικός πρόσβασης:"
-    password_confirmation: "Επαλήθευση:"
-    new_password: "Νέος Κωδικός πρόσβασης:"
-    new_password_confirmation: "Επαλήθευση:"
+    group_name: Όνομα ομάδας
+    username: Όνομα Χρήστη
+    email: Email
+    current_password: Τρέχον κωδικός πρόσβασης
+    password: Κωδικός πρόσβασης
+    password_confirmation: Επαλήθευση
+    new_password: Νέος Κωδικός πρόσβασης
+    new_password_confirmation: Επαλήθευση

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Username:"
-        password: "Password:"
+        username: Username
+        password: Password
         remember_me: Remember me
         submit: Login
 
@@ -59,7 +59,7 @@ resetting:
     check_email: An email has been sent to %email%. It contains a link you must click to reset your password.
     request:
         invalid_username: The username or email address "%username%" does not exist.
-        username: "Username or email address:"
+        username: Username or email address
         submit: Reset password
     reset:
         submit: Change password
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Group name:"
-    username: "Username:"
-    email: "Email:"
-    current_password: "Current password:"
-    password: "Password:"
-    password_confirmation: "Repeat password:"
-    new_password: "New password:"
-    new_password_confirmation: "Repeat new password:"
+    group_name: Group name
+    username: Username
+    email: Email
+    current_password: Current password
+    password: Password
+    password_confirmation: Repeat password
+    new_password: New password
+    new_password_confirmation: Repeat new password

--- a/Resources/translations/FOSUserBundle.es.yml
+++ b/Resources/translations/FOSUserBundle.es.yml
@@ -14,10 +14,10 @@ group:
 # Security
 security:
     login:
-        username: "Nombre de usuario:"
-        username_email: "Nombre de usuario o email:"
-        email: "Email:"
-        password: "Contraseña:"
+        username: Nombre de usuario
+        username_email: Nombre de usuario o email
+        email: Email
+        password: Contraseña
         remember_me: Recordar
         submit: Entrar
 
@@ -61,7 +61,7 @@ resetting:
     check_email: Un email ha sido enviado a %email%. Contiene un enlace de activación que debes presionar para restablecer tu contraseña.
     request:
         invalid_username: El usuario o dirección de correo "%username%" no existe.
-        username: "Nombre de usuario:"
+        username: Nombre de usuario
         submit: Restablecer contraseña
     reset:
         submit: Cambiar contraseña
@@ -86,11 +86,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Nombre de grupo:"
-    username: "Nombre de usuario:"
-    email: "Email:"
-    current_password: "Contraseña actual:"
-    password: "Contraseña:"
-    password_confirmation: "Repita la contraseña:"
-    new_password: "Nueva contraseña:"
-    new_password_confirmation: "Repita la contraseña:"
+    group_name: Nombre de grupo
+    username: Nombre de usuario
+    email: Email
+    current_password: Contraseña actual
+    password: Contraseña
+    password_confirmation: Repita la contraseña
+    new_password: Nueva contraseña
+    new_password_confirmation: Repita la contraseña

--- a/Resources/translations/FOSUserBundle.et.yml
+++ b/Resources/translations/FOSUserBundle.et.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Kasutajanimi:"
-        password: "Salasõna:"
+        username: Kasutajanimi
+        password: Salasõna
         remember_me: Jäta mind meelde
         submit: Sisene
 
@@ -59,7 +59,7 @@ resetting:
     check_email: E-mail on saadetud aadressile %email%. Selles sisaldub viide, mis tuleb salasõna muutmiseks avada.
     request:
         #invalid_username: The username or email address "%username%" does not exist.
-        username: "Kasutajanimi:"
+        username: Kasutajanimi
         submit: Saada salasõna
     reset:
         submit: Muuda salasõna
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Grupi nimi:"
-    username: "Kasutajanimi:"
-    email: "E-mail:"
-    current_password: "Vana salasõna:"
-    password: "Salasõna:"
-    password_confirmation: "Salasõna uuesti:"
-    new_password: "Uus salasõna:"
-    new_password_confirmation: "Salasõna uuesti:"
+    group_name: Grupi nimi
+    username: Kasutajanimi
+    email: E-mail
+    current_password: Vana salasõna
+    password: Salasõna
+    password_confirmation: Salasõna uuesti
+    new_password: Uus salasõna
+    new_password_confirmation: Salasõna uuesti

--- a/Resources/translations/FOSUserBundle.eu.yml
+++ b/Resources/translations/FOSUserBundle.eu.yml
@@ -14,10 +14,10 @@ group:
 # Security
 security:
     login:
-        username: "Erabiltzaile izena:"
-        username_email: "Erabiltzaile izena edo e-posta:"
-        email: "E-posta:"
-        password: "Pasahitza:"
+        username: Erabiltzaile izena
+        username_email: Erabiltzaile izena edo e-posta
+        email: E-posta
+        password: Pasahitza
         remember_me: Oroitu
         submit: Sartu
 
@@ -61,7 +61,7 @@ resetting:
     check_email: Email bat bidali zaio %email% helbideari. Pasahitza berreskuratzeko esteka zehazten da bertan.
     request:
         invalid_username: %username% erabiltzailea edo E-posta ez da existitzen.
-        username: "Erabiltzaile izena:"
+        username: Erabiltzaile izena
         submit: Pasahitza berreskuratu
     reset:
         submit: Pasahitza aldatu
@@ -86,11 +86,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Taldearen izena:"
-    username: "Erabiltzaile izena:"
-    email: "E-posta:"
-    current_password: "Oraingo pasahitza:"
-    password: "Pasahitza:"
-    password_confirmation: "Errepikatu pasahitza:"
-    new_password: "Pasahitz berria:"
-    new_password_confirmation: "Errepikatu pasahitza:"
+    group_name: Taldearen izena
+    username: Erabiltzaile izena
+    email: E-posta
+    current_password: Oraingo pasahitza
+    password: Pasahitza
+    password_confirmation: Errepikatu pasahitza
+    new_password: Pasahitz berria
+    new_password_confirmation: Errepikatu pasahitza

--- a/Resources/translations/FOSUserBundle.fa.yml
+++ b/Resources/translations/FOSUserBundle.fa.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "نام کاربری:"
-        password: "کلمه عبور:"
+        username: نام کاربری
+        password: کلمه عبور
         remember_me: مرا به یاد سپار
         submit: ورود
 
@@ -59,7 +59,7 @@ resetting:
     check_email: ایمیلی به %email% فرستاده شده است. این ایمیل دارای پیوندی است که برای بازنشانی کلمه عبور باید روی آن کلیک کنید.
     request:
         invalid_username: نام کاربری یا ایمیل "%username%" موجود نیست.
-        username: "نام کاربری یا ایمیل:"
+        username: نام کاربری یا ایمیل
         submit: بازنشانی کلمه عبور
     reset:
         submit: تغییر کلمه عبور
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "نام گروه:"
-    username: "نام کاربری:"
-    email: "ایمیل:"
-    current_password: "کلمه عبور کنونی:"
-    password: "کلمه عبور:"
-    password_confirmation: "تایید کلمه عبور:"
-    new_password: "کلمه عبور جدید:"
-    new_password_confirmation: "تایید کلمه عبور جدید:"
+    group_name: نام گروه
+    username: نام کاربری
+    email: ایمیل
+    current_password: کلمه عبور کنونی
+    password: کلمه عبور
+    password_confirmation: تایید کلمه عبور
+    new_password: کلمه عبور جدید
+    new_password_confirmation: تایید کلمه عبور جدید

--- a/Resources/translations/FOSUserBundle.fi.yml
+++ b/Resources/translations/FOSUserBundle.fi.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Käyttäjätunnus:"
-        password: "Salasana:"
+        username: Käyttäjätunnus
+        password: Salasana
         remember_me: Muista minut
         submit: Kirjaudu
 
@@ -58,7 +58,7 @@ resetting:
     check_email: Sähköposti on lähetetty osoitteeseen %email%. Se sisältää linkin, jota klikkaamalla salasana alustetaan.
     request:
         invalid_username: Käyttäjätunnusta tai sähköpostiosoitetta "%username%" ei löydy järjestelmästä.
-        username: "Käyttäjätunnus tai sähköpostiosoite:"
+        username: Käyttäjätunnus tai sähköpostiosoite
         submit: Alusta salasana
     reset:
         submit: Vaihda salasana
@@ -82,11 +82,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Ryhmän nimi:"
-    username: "Käyttäjätunnus:"
-    email: "Sähköpostiosoite:"
-    current_password: "Nykyinen salasana:"
-    password: "Salasana:"
-    password_confirmation: "Salasana uudestaan:"
-    new_password: "Uusi salasana:"
-    new_password_confirmation: "Salasana uudestaan:"
+    group_name: Ryhmän nimi
+    username: Käyttäjätunnus
+    email: Sähköpostiosoite
+    current_password: Nykyinen salasana
+    password: Salasana
+    password_confirmation: Salasana uudestaan
+    new_password: Uusi salasana
+    new_password_confirmation: Salasana uudestaan

--- a/Resources/translations/FOSUserBundle.fr.yml
+++ b/Resources/translations/FOSUserBundle.fr.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Nom d'utilisateur :"
-        password: "Mot de passe :"
+        username: Nom d'utilisateur 
+        password: Mot de passe 
         remember_me: Se souvenir de moi
         submit: Connexion
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Un e-mail a été envoyé à l'adresse %email%. Il contient un lien sur lequel il vous faudra cliquer afin de réinitialiser votre mot de passe.
     request:
         invalid_username: Le nom d'utilisateur ou l'adresse e-mail "%username%" n'existe pas.
-        username: "Nom d'utilisateur ou adresse e-mail :"
+        username: Nom d'utilisateur ou adresse e-mail 
         submit: Réinitialiser le mot de passe
     reset:
         submit: Modifier le mot de passe
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Nom du groupe :"
-    username: "Nom d'utilisateur :"
-    email: "Adresse e-mail :"
-    current_password: "Mot de passe actuel :"
-    password: "Mot de passe :"
-    password_confirmation: "Vérification :"
-    new_password: "Nouveau mot de passe :"
-    new_password_confirmation: "Vérification :"
+    group_name: Nom du groupe 
+    username: Nom d'utilisateur 
+    email: Adresse e-mail 
+    current_password: Mot de passe actuel 
+    password: Mot de passe 
+    password_confirmation: Vérification 
+    new_password: Nouveau mot de passe 
+    new_password_confirmation: Vérification 

--- a/Resources/translations/FOSUserBundle.he.yml
+++ b/Resources/translations/FOSUserBundle.he.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "שם משתמש:"
-        password: "סיסמה:"
+        username: שם משתמש
+        password: סיסמה
         remember_me: זכור אותי
         submit: התחבר
 
@@ -59,7 +59,7 @@ resetting:
     check_email: הודעת דוא"ל נשלחה ל-%email%. ההודעה מכילה קישור לאיפוס סיסמה שלך.
     request:
         invalid_username: שם משתמש או דוא"ל "%username%" לא קיים.
-        username: "שם משתמש או דואר אלקטרוני:"
+        username: שם משתמש או דואר אלקטרוני
         submit: איפוס סיסמה
     reset:
         submit: שינוי סיסמה
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "שם קבוצה:"
-    username: "שם משתמש:"
-    email: "דוא\"ל:"
-    current_password: "Current password:"
-    password: "סיסמה:"
-    password_confirmation: "Verification:"
-    new_password: "סיסמה חדשה:"
-    new_password_confirmation: "Verification:"
+    group_name: שם קבוצה
+    username: שם משתמש
+    email: דוא\"ל
+    current_password: Current password
+    password: סיסמה
+    password_confirmation: Verification
+    new_password: סיסמה חדשה
+    new_password_confirmation: Verification

--- a/Resources/translations/FOSUserBundle.hr.yml
+++ b/Resources/translations/FOSUserBundle.hr.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Korisničko ime:"
-        password: "Lozinka:"
+        username: Korisničko ime
+        password: Lozinka
         remember_me: Zapamti me
         submit: Prijava
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Na %email%  smo vam poslali poruku s poveznicom za promjenu lozinke. Lozinku resetirajte klikom na tu poveznicu.
     request:
         invalid_username: Korisničko ime "%username%" ne postoji.
-        username: "Korisničko ime:"
+        username: Korisničko ime
         submit: Izmijeni lozinku
     reset:
         submit: Spremi lozinku
@@ -85,10 +85,10 @@ layout:
 # Form field labels
 form:
     group_name: "Ime grupe"
-    username: "Korisničko ime:"
-    email: "Email:"
-    current_password: "Trenutna lozinka:"
+    username: Korisničko ime
+    email: Email
+    current_password: Trenutna lozinka
     password: "Lozinka"
-    password_confirmation: "Potvrda lozinke:"
-    new_password: "Nova lozinka:"
-    new_password_confirmation: "Potvrda lozinke:"
+    password_confirmation: Potvrda lozinke
+    new_password: Nova lozinka
+    new_password_confirmation: Potvrda lozinke

--- a/Resources/translations/FOSUserBundle.hu.yml
+++ b/Resources/translations/FOSUserBundle.hu.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Felhasználónév:"
-        password: "Jelszó:"
+        username: Felhasználónév
+        password: Jelszó
         remember_me: Megjegyzés
         submit: Belépés
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Egy e-mail lett küldve a(z) %email% címre. Egy linket tartalmaz, amire rá kell kattintani a jeszó lecseréléséhez.
     request:
         invalid_username: A(z) %username% felhasználónév vagy e-mail cím nem létezik.
-        username: "Felhasználónév vagy e-mail cím:"
+        username: Felhasználónév vagy e-mail cím
         submit: Jelszó lecserélése
     reset:
         submit: Jelszó megváltoztatása
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Csoport név:"
-    username: "Felhasználónév:"
-    email: "E-mail:"
-    current_password: "Jelenlegi jelszó:"
-    password: "Jelszó:"
-    password_confirmation: "Megerősítés:"
-    new_password: "Új jelszó:"
-    new_password_confirmation: "Megerősítés:"
+    group_name: Csoport név
+    username: Felhasználónév
+    email: E-mail
+    current_password: Jelenlegi jelszó
+    password: Jelszó
+    password_confirmation: Megerősítés
+    new_password: Új jelszó
+    new_password_confirmation: Megerősítés

--- a/Resources/translations/FOSUserBundle.id.yml
+++ b/Resources/translations/FOSUserBundle.id.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Nama Pengguna:"
-        password: "Password:"
+        username: Nama Pengguna
+        password: Password
         remember_me: Selalu Ingat Saya
         submit: Login
 
@@ -61,7 +61,7 @@ resetting:
     check_email: Email telah dikirim ke %email%. Anda harus mengklik link di dalam email tersebut agar dapat mereset password anda.
     request:
         invalid_username: Nama pengguna atau email "%username%" tidak terdaftar.
-        username: "Nama Pengguna Atau Alamat Email anda:"
+        username: Nama Pengguna Atau Alamat Email anda
         submit: Reset password
     reset:
         submit: Ubah password
@@ -87,11 +87,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Nama Grup:"
-    username: "Nama Pengguna:"
-    email: "Email:"
-    current_password: "Password saat ini:"
-    password: "Password:"
-    password_confirmation: "Verifikasi Password:"
-    new_password: "Password Baru:"
-    new_password_confirmation: "Masukkan Ulang Password Baru Anda:"
+    group_name: Nama Grup
+    username: Nama Pengguna
+    email: Email
+    current_password: Password saat ini
+    password: Password
+    password_confirmation: Verifikasi Password
+    new_password: Password Baru
+    new_password_confirmation: Masukkan Ulang Password Baru Anda

--- a/Resources/translations/FOSUserBundle.it.yml
+++ b/Resources/translations/FOSUserBundle.it.yml
@@ -15,8 +15,8 @@ group:
 # Security
 security:
     login:
-        username: "Username:"
-        password: "Password:"
+        username: Username
+        password: Password
         remember_me: Ricordami
         submit: Login
 
@@ -60,7 +60,7 @@ resetting:
     check_email: Una email è stata inviata a %email%. Contiene il link d'attivazione che devi utilizzare per il reset della password.
     request:
         invalid_username: Username o indirizzo email "%username%" non esistente.
-        username: "Username o indirizzo email:"
+        username: Username o indirizzo email
         submit: Password reset
     reset:
         submit: Cambia password
@@ -85,11 +85,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Nome gruppo:"
-    username: "Username:"
-    email: "Email:"
-    current_password: "Password corrente:"
-    password: "Password:"
-    password_confirmation: "Ripeti password:"
-    new_password: "Nuova password:"
-    new_password_confirmation: "Ripeti password:"
+    group_name: Nome gruppo
+    username: Username
+    email: Email
+    current_password: Password corrente
+    password: Password
+    password_confirmation: Ripeti password
+    new_password: Nuova password
+    new_password_confirmation: Ripeti password

--- a/Resources/translations/FOSUserBundle.ja.yml
+++ b/Resources/translations/FOSUserBundle.ja.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "ユーザー名:"
-        password: "パスワード:"
+        username: ユーザー名
+        password: パスワード
         remember_me: ログイン状態を記憶する
         submit: ログイン
 
@@ -59,7 +59,7 @@ resetting:
     check_email: %email% 宛にメールを送信しました。メールに記載された確認 URL にアクセスして、アカウントを有効化してください。
     request:
         invalid_username: '"%username%" というユーザー名またはメールアドレスは存在しません。'
-        username: "ユーザー名かメールアドレス:"
+        username: ユーザー名かメールアドレス
         submit: パスワードのリセット
     reset:
         submit: パスワードの変更
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "グループ名:"
-    username: "ユーザー名:"
-    email: "メールアドレス:"
-    current_password: "現在のパスワード:"
-    password: "パスワード:"
-    password_confirmation: "確認:"
-    new_password: "新しいパスワード:"
-    new_password_confirmation: "確認:"
+    group_name: グループ名
+    username: ユーザー名
+    email: メールアドレス
+    current_password: 現在のパスワード
+    password: パスワード
+    password_confirmation: 確認
+    new_password: 新しいパスワード
+    new_password_confirmation: 確認

--- a/Resources/translations/FOSUserBundle.lb.yml
+++ b/Resources/translations/FOSUserBundle.lb.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Benotzernumm:"
-        password: "Passwuert:"
+        username: Benotzernumm
+        password: Passwuert
         remember_me: U mech erënneren
         submit: Umellen
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Eng E-Mail gouf un %email% geschéckt. Se enthält e Link, deen s Du uklicke muss, fir Däi Passwort zeréckzesetzen.
     request:
         invalid_username: De Benotzer "%username%" existéiert net.
-        username: "Benotzernumm:"
+        username: Benotzernumm
         submit: Passwuert zerécksetzen
     reset:
         submit: Passwuert ännern
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Gruppennumm:"
-    username: "Benotzernumm:"
-    email: "E-Mail-Adress:"
-    current_password: "Aktuellt Passwuert:"
-    password: "Passwuert:"
-    password_confirmation: "Bestätegung:"
-    new_password: "Neit Passwuert:"
-    new_password_confirmation: "Bestätegung:"
+    group_name: Gruppennumm
+    username: Benotzernumm
+    email: E-Mail-Adress
+    current_password: Aktuellt Passwuert
+    password: Passwuert
+    password_confirmation: Bestätegung
+    new_password: Neit Passwuert
+    new_password_confirmation: Bestätegung

--- a/Resources/translations/FOSUserBundle.lt.yml
+++ b/Resources/translations/FOSUserBundle.lt.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Naudotojo vardas:"
-        password: "Slaptažodis:"
+        username: Naudotojo vardas
+        password: Slaptažodis
         remember_me: Atsiminti
         submit: Prisijungti
 
@@ -59,7 +59,7 @@ resetting:
     check_email: El. pašto pranešimas išsiųstas adresu %email%. Jame rasite nuorodą, kurią paspaudę, galėsite pakeisti savo slaptažodį.
     request:
         invalid_username: Naudotojo vardas arba el. paštas "%username%" neegzistuoja.
-        username: "Naudotojo vardas arba el. paštas:"
+        username: Naudotojo vardas arba el. paštas
         submit: Tęsti
     reset:
         submit: Pakeisti slaptažodį
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Grupės vardas:"
-    username: "Naudotojo vardas:"
-    email: "El. paštas:"
-    current_password: "Dabartinis slaptažodis:"
-    password: "Slaptažodis:"
-    password_confirmation: "Pakartoti slaptažodį:"
-    new_password: "Naujas slaptažodis:"
-    new_password_confirmation: "Naujas slaptažodis (pakartoti):"
+    group_name: Grupės vardas
+    username: Naudotojo vardas
+    email: El. paštas
+    current_password: Dabartinis slaptažodis
+    password: Slaptažodis
+    password_confirmation: Pakartoti slaptažodį
+    new_password: Naujas slaptažodis
+    new_password_confirmation: Naujas slaptažodis (pakartoti)

--- a/Resources/translations/FOSUserBundle.lv.yml
+++ b/Resources/translations/FOSUserBundle.lv.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Lietotājvārds:"
-        password: "Parole:"
+        username: Lietotājvārds
+        password: Parole
         remember_me: Atcerēties mani
         submit: Ienākt
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Uz %email% tika nosūtīts e-pasts ar saiti, kurai jāseko, lai atiestatītu paroli.
     request:
         invalid_username: Lietotājs vai e-pasta adrese "%username%" neeksistē.
-        username: "Lietotājvārds vai e-pasta adrese:"
+        username: Lietotājvārds vai e-pasta adrese
         submit: Atiestatīt paroli
     reset:
         submit: Nomainīt paroli
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Grupas nosaukums:"
-    username: "Lietotājvārds:"
-    email: "E-pasts:"
-    current_password: "Esošā parole:"
-    password: "Parole:"
-    password_confirmation: "Atkārtoti:"
-    new_password: "Jaunā parole:"
-    new_password_confirmation: "Atkārtoti:"
+    group_name: Grupas nosaukums
+    username: Lietotājvārds
+    email: E-pasts
+    current_password: Esošā parole
+    password: Parole
+    password_confirmation: Atkārtoti
+    new_password: Jaunā parole
+    new_password_confirmation: Atkārtoti

--- a/Resources/translations/FOSUserBundle.nb.yml
+++ b/Resources/translations/FOSUserBundle.nb.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Brukernavn:"
-        password: "Passord:"
+        username: Brukernavn
+        password: Passord
         remember_me: Husk meg
         submit: Logg inn
 
@@ -59,7 +59,7 @@ resetting:
     check_email: En epost har blitt sendt til %email%. Den inneholder en lenke du må klikke på for å tilbakestille passordet.
     request:
         invalid_username: Brukernavnet eller epostadressen "%username%" eksisterer ikke.
-        username: "Brukernavn eller epostadresse:"
+        username: Brukernavn eller epostadresse
         submit: Tilbakestill passord
     reset:
         submit: Endre passord
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Gruppenavn:"
-    username: "Brukernavn:"
-    email: "Epost:"
-    current_password: "Nåværende passord:"
-    password: "Passord:"
-    password_confirmation: "Verifisering:"
-    new_password: "Nytt passord:"
-    new_password_confirmation: "Verifisering:"
+    group_name: Gruppenavn
+    username: Brukernavn
+    email: Epost
+    current_password: Nåværende passord
+    password: Passord
+    password_confirmation: Verifisering
+    new_password: Nytt passord
+    new_password_confirmation: Verifisering

--- a/Resources/translations/FOSUserBundle.nl.yml
+++ b/Resources/translations/FOSUserBundle.nl.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Gebruikersnaam:"
-        password: "Wachtwoord:"
+        username: Gebruikersnaam
+        password: Wachtwoord
         remember_me: Onthoud mijn gegevens
         submit: Inloggen
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Er is een e-mail verstuurd naar %email%, met een link om uw wachtwoord te resetten.
     request:
         invalid_username: De gebruiker "%username%" bestaat niet.
-        username: "Gebruikersnaam of e-mailadres:"
+        username: Gebruikersnaam of e-mailadres
         submit: Reset wachtwoord
     reset:
         submit: Wijzig wachtwoord
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Groep naam:"
-    username: "Gebruikersnaam:"
-    email: "E-mail:"
-    current_password: "Huidig wachtwoord:"
-    password: "Wachtwoord:"
-    password_confirmation: "Wachtwoord controle:"
-    new_password: "Nieuw wachtwoord:"
-    new_password_confirmation: "Wachtwoord controle:"
+    group_name: Groep naam
+    username: Gebruikersnaam
+    email: E-mail
+    current_password: Huidig wachtwoord
+    password: Wachtwoord
+    password_confirmation: Wachtwoord controle
+    new_password: Nieuw wachtwoord
+    new_password_confirmation: Wachtwoord controle

--- a/Resources/translations/FOSUserBundle.pl.yml
+++ b/Resources/translations/FOSUserBundle.pl.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Nazwa użytkownika:"
-        password: "Hasło:"
+        username: Nazwa użytkownika
+        password: Hasło
         remember_me: Nie wylogowuj mnie
         submit: Zaloguj
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Na adres %email% wysłano wiadomość e-mail. Zawiera ona link w którego należy kliknąć aby zresetować hasło.
     request:
         invalid_username: Nazwa użytkownika lub e-mail "%username%" nie istnieje.
-        username: "Nazwa użytkownika lub e-mail:"
+        username: Nazwa użytkownika lub e-mail
         submit: Resetuj hasło
     reset:
         submit: Zmień hasło
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Nazwa grupy:"
-    username: "Nazwa użytkownika:"
-    email: "E-mail:"
-    current_password: "Obecne hasło:"
-    password: "Hasło:"
-    password_confirmation: "Powtórz hasło:"
-    new_password: "Nowe hasło:"
-    new_password_confirmation: "Powtórz hasło:"
+    group_name: Nazwa grupy
+    username: Nazwa użytkownika
+    email: E-mail
+    current_password: Obecne hasło
+    password: Hasło
+    password_confirmation: Powtórz hasło
+    new_password: Nowe hasło
+    new_password_confirmation: Powtórz hasło

--- a/Resources/translations/FOSUserBundle.pt.yml
+++ b/Resources/translations/FOSUserBundle.pt.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Utilizador:"
-        password: "Password:"
+        username: Utilizador
+        password: Password
         remember_me: Lembrar-me
         submit: Entrar
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Foi enviado um email para %email% com a informação necessária para recuperar a sua password.
     request:
         invalid_username: O username ou email "%username%" não existe.
-        username: "Utilizador:"
+        username: Utilizador
         submit: Recuperar password
     reset:
         submit: Alterar password
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Nome do Grupo:"
-    username: "Utilizador:"
-    email: "Email:"
-    current_password: "Password atual:"
-    password: "Password:"
-    password_confirmation: "Verificar:"
-    new_password: "Nova password:"
-    new_password_confirmation: "Verificar:"
+    group_name: Nome do Grupo
+    username: Utilizador
+    email: Email
+    current_password: Password atual
+    password: Password
+    password_confirmation: Verificar
+    new_password: Nova password
+    new_password_confirmation: Verificar

--- a/Resources/translations/FOSUserBundle.pt_BR.yml
+++ b/Resources/translations/FOSUserBundle.pt_BR.yml
@@ -14,10 +14,10 @@ group:
 # Security
 security:
     login:
-        username: "Usuário:"
-        username_email: "Usuário ou e-mail:"
-        email: "E-mail:"
-        password: "Senha:"
+        username: Usuário
+        username_email: Usuário ou e-mail
+        email: E-mail
+        password: Senha
         remember_me: Permanecer conectado
         submit: Entrar
 
@@ -61,7 +61,7 @@ resetting:
     check_email: Foi enviado um email para %email%. Para recuperar a sua senha, clique no link da mensagem.
     request:
         invalid_username: O usuário ou endereço de email "%username%" não está cadastrado.
-        username: "Usuário ou email:"
+        username: Usuário ou email
         submit: Recuperar senha
     reset:
         submit: Alterar senha
@@ -86,11 +86,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Nome do Grupo:"
-    username: "Usuário:"
-    email: "Email:"
-    current_password: "Senha atual:"
-    password: "Senha:"
-    password_confirmation: "Repita a senha:"
-    new_password: "Nova senha:"
-    new_password_confirmation: "Repita a senha:"
+    group_name: Nome do Grupo
+    username: Usuário
+    email: Email
+    current_password: Senha atual
+    password: Senha
+    password_confirmation: Repita a senha
+    new_password: Nova senha
+    new_password_confirmation: Repita a senha

--- a/Resources/translations/FOSUserBundle.ro.yml
+++ b/Resources/translations/FOSUserBundle.ro.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Nume de utilizator:"
-        password: "Parola:"
+        username: Nume de utilizator
+        password: Parola
         remember_me: Ține-mă minte
         submit: Autentificare
 
@@ -59,7 +59,7 @@ resetting:
     check_email: A fost trimis un email către %email%. Conține un link pe care trebuie să îl accesezi pentru a-ți reseta parola.
     request:
         invalid_username: Numele de utilizator sau adresa de email "%username%" nu există.
-        username: "Numele de utilizator sau adresa de email:"
+        username: Numele de utilizator sau adresa de email
         submit: Resetează parola
     reset:
         submit: Schimbă parola
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Numele grupului:"
-    username: "Nume de utilizator:"
-    email: "Email:"
-    current_password: "Parola curentă:"
-    password: "Parolă:"
-    password_confirmation: "Verificare parolă:"
-    new_password: "Parola nouă:"
-    new_password_confirmation: "Verificare parolă:"
+    group_name: Numele grupului
+    username: Nume de utilizator
+    email: Email
+    current_password: Parola curentă
+    password: Parolă
+    password_confirmation: Verificare parolă
+    new_password: Parola nouă
+    new_password_confirmation: Verificare parolă

--- a/Resources/translations/FOSUserBundle.ru.yml
+++ b/Resources/translations/FOSUserBundle.ru.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Имя пользователя:"
-        password: "Пароль:"
+        username: Имя пользователя
+        password: Пароль
         remember_me: Запомнить меня
         submit: Войти
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Письмо на адрес %email% уже отправлено. Оно содержит ссылку, при переходе по которой ваш пароль будет сброшен.
     request:
         invalid_username: Пользователь "%username%" не существует.
-        username: "Имя пользователя:"
+        username: Имя пользователя
         submit: Сбросить пароль
     reset:
         submit: Изменить пароль
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Название группы:"
-    username: "Имя пользователя:"
-    email: "Электронная почта:"
-    current_password: "Текущий пароль:"
-    password: "Пароль:"
-    password_confirmation: "Подтвердите пароль:"
-    new_password: "Новый пароль:"
-    new_password_confirmation: "Подтвердите пароль:"
+    group_name: Название группы
+    username: Имя пользователя
+    email: Электронная почта
+    current_password: Текущий пароль
+    password: Пароль
+    password_confirmation: Подтвердите пароль
+    new_password: Новый пароль
+    new_password_confirmation: Подтвердите пароль

--- a/Resources/translations/FOSUserBundle.sk.yml
+++ b/Resources/translations/FOSUserBundle.sk.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Používateľské meno:"
-        password: "Heslo:"
+        username: Používateľské meno
+        password: Heslo
         remember_me: Zapamätať si
         submit: Prihlásenie
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Postup pre zmenu hesla bol zaslaný na adresu %email%. Správa obsahuje link, na ktorú treba kliknúť pre úspešné dokončenie zmeny hesla.
     request:
         invalid_username: Používateľské meno alebo emailová adresa "%username%" neexistuje. Skontrolujte si prosím Vami zadané údaje a skúste znovu.
-        username: "Používateľské meno alebo emailová adresa:"
+        username: Používateľské meno alebo emailová adresa
         submit: Obnova hesla
     reset:
         submit: Zmeniť heslo
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Názov skupiny:"
-    username: "Používateľské meno:"
-    email: "Email:"
-    current_password: "Súčasné heslo:"
-    password: "Heslo:"
-    password_confirmation: "Potvrdenie hesla:"
-    new_password: "Nové heslo:"
-    new_password_confirmation: "Potvrdenie hesla:"
+    group_name: Názov skupiny
+    username: Používateľské meno
+    email: Email
+    current_password: Súčasné heslo
+    password: Heslo
+    password_confirmation: Potvrdenie hesla
+    new_password: Nové heslo
+    new_password_confirmation: Potvrdenie hesla

--- a/Resources/translations/FOSUserBundle.sl.yml
+++ b/Resources/translations/FOSUserBundle.sl.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Uporabniško ime:"
-        password: "Geslo:"
+        username: Uporabniško ime
+        password: Geslo
         remember_me: Zapomni si me
         submit: Prijava
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Na %email% smo vam poslali sporočilo s kodo za spremembo gesla. Geslo boste spremenili po kliku na to povezavo.
     request:
         invalid_username: Uporabnik "%username%" ne obstaja.
-        username: "Uporabniško ime:"
+        username: Uporabniško ime
         submit: Spremeni geslo
     reset:
         submit: Spremeni geslo
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Ime skupine:"
-    username: "Uporabniško ime:"
-    email: "Email:"
-    current_password: "Trenutno geslo:"
-    password: "Geslo:"
-    password_confirmation: "Preverjanje gesla:"
-    new_password: "Novo geslo:"
-    new_password_confirmation: "Preverjanje gesla:"
+    group_name: Ime skupine
+    username: Uporabniško ime
+    email: Email
+    current_password: Trenutno geslo
+    password: Geslo
+    password_confirmation: Preverjanje gesla
+    new_password: Novo geslo
+    new_password_confirmation: Preverjanje gesla

--- a/Resources/translations/FOSUserBundle.sr_Latn.yml
+++ b/Resources/translations/FOSUserBundle.sr_Latn.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Korisničko ime:"
-        password: "Lozinka:"
+        username: Korisničko ime
+        password: Lozinka
         remember_me: Zapamti me
         submit: Prijavi se
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Poruka je poslata na adresu %email%. Ona sadrži link koji morate kliknuti da bi resetovali Vašu lozinku.
     request:
         invalid_username: Korisničko ime ili adresa e-pošte "%username%" ne postoji.
-        username: "Korisničko ime ili adresa e-pošte:"
+        username: Korisničko ime ili adresa e-pošte
         submit: Resetuj lozinku
     reset:
         submit: Izmeni lozinku
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Naziv grupe:"
-    username: "Korisničko ime:"
-    email: "Adresa e-pošte:"
-    current_password: "Trenutna lozinka:"
-    password: "Lozinka:"
-    password_confirmation: "Potvrda lozinke:"
-    new_password: "Nova lozinka:"
-    new_password_confirmation: "Potvrda lozinke:"
+    group_name: Naziv grupe
+    username: Korisničko ime
+    email: Adresa e-pošte
+    current_password: Trenutna lozinka
+    password: Lozinka
+    password_confirmation: Potvrda lozinke
+    new_password: Nova lozinka
+    new_password_confirmation: Potvrda lozinke

--- a/Resources/translations/FOSUserBundle.sv.yml
+++ b/Resources/translations/FOSUserBundle.sv.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Användarnamn:"
-        password: "Lösenord:"
+        username: Användarnamn
+        password: Lösenord
         remember_me: Kom ihåg mig
         submit: Logga in
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Ett meddelande har skickats till %email%. Det innehåller en länk som du måste klicka på för att återställa ditt lösenord.
     request:
         invalid_username: Användarnamnet eller epost-adressen "%username%" finns inte.
-        username: "Användarnamn eller epost-adress:"
+        username: Användarnamn eller epost-adress
         submit: Återställ lösenord
     reset:
         submit: Ändra lösenord
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Gruppnamn:"
-    username: "Användarnamn:"
-    email: "Epost:"
-    current_password: "Nuvarande lösenord:"
-    password: "Lösenord:"
-    password_confirmation: "Verifiering:"
-    new_password: "Nytt lösenord:"
-    new_password_confirmation: "Verifiering:"
+    group_name: Gruppnamn
+    username: Användarnamn
+    email: Epost
+    current_password: Nuvarande lösenord
+    password: Lösenord
+    password_confirmation: Verifiering
+    new_password: Nytt lösenord
+    new_password_confirmation: Verifiering

--- a/Resources/translations/FOSUserBundle.th.yml
+++ b/Resources/translations/FOSUserBundle.th.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "ชื่อผู้ใช้:"
-        password: "รหัสผ่าน:"
+        username: ชื่อผู้ใช้
+        password: รหัสผ่าน
         remember_me: จำการเข้าระบบ
         submit: เข้าระบบ
 
@@ -59,7 +59,7 @@ resetting:
     check_email: ระบบได้ส่งอีเมล์การขอเปลี่ยนรหัสผ่านไปที่ %email% คุณต้องคลิกลิงค์ที่ส่งไปเพื่อทำการเปลี่ยนระหัสผ่าน
     request:
         invalid_username: ชื่อผู้ใช้หรืออีเมล "%username%" ไม่มีอยู่ในระบบ
-        username: "ชื่อผู้ใช้หรืออีเมล์:"
+        username: ชื่อผู้ใช้หรืออีเมล์
         submit: เปลี่ยนรหัสผ่าน
     reset:
         submit: บันทึกการเปลี่ยนแปลงรหัส
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "ชื่อกลุ่ม:"
-    username: "ชื่อเข้าระบบ:"
-    email: "อีเมล์:"
-    current_password: "รหัสผ่านปัจจุบัน:"
-    password: "รหัสผ่าน:"
-    password_confirmation: "ยืนยันรหัสผ่าน:"
-    new_password: "รหัสผ่านใหม่:"
-    new_password_confirmation: "ยืนยันรหัสผ่านใหม่:"
+    group_name: ชื่อกลุ่ม
+    username: ชื่อเข้าระบบ
+    email: อีเมล์
+    current_password: รหัสผ่านปัจจุบัน
+    password: รหัสผ่าน
+    password_confirmation: ยืนยันรหัสผ่าน
+    new_password: รหัสผ่านใหม่
+    new_password_confirmation: ยืนยันรหัสผ่านใหม่

--- a/Resources/translations/FOSUserBundle.tr.yml
+++ b/Resources/translations/FOSUserBundle.tr.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Kullanıcı adı:"
-        password: "Parola:"
+        username: Kullanıcı adı
+        password: Parola
         remember_me: Beni hatırla
         submit: Giriş
 
@@ -60,7 +60,7 @@ resetting:
     check_email: %email% adresine parolanızı sıfırlama adresi bulunan bir e-posta gönderildi.
     request:
         invalid_username: %username% şeklinde bir kullanıcı adı ya da e-posta adresi bulunamadı.
-        username: "Kullanıcı adı ya da e-posta adresi:"
+        username: Kullanıcı adı ya da e-posta adresi
         submit: Parolayı Sıfırla
     reset:
         submit: Parolayı değiştir
@@ -86,11 +86,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Gurup Adı:"
-    username: "Kullanıcı adı:"
-    email: "E-posta adresi:"
-    current_password: "Geçerli Parola:"
-    password: "Parola:"
-    password_confirmation: "Onay:"
-    new_password: "Yeni Parola:"
-    new_password_confirmation: "Onay:"
+    group_name: Gurup Adı
+    username: Kullanıcı adı
+    email: E-posta adresi
+    current_password: Geçerli Parola
+    password: Parola
+    password_confirmation: Onay
+    new_password: Yeni Parola
+    new_password_confirmation: Onay

--- a/Resources/translations/FOSUserBundle.uk.yml
+++ b/Resources/translations/FOSUserBundle.uk.yml
@@ -14,8 +14,8 @@ group:
 # Security
 security:
     login:
-        username: "Ім'я користувача:"
-        password: "Пароль:"
+        username: Ім'я користувача
+        password: Пароль
         remember_me: "Запам'ятати мене"
         submit: Увійти
 
@@ -59,7 +59,7 @@ resetting:
     check_email: Листа на адресу %email% вже відправлено. Воно містить посилання, при переході за яким Ваш пароль буде скинуто.
     request:
         invalid_username: Користувач "%username%" не існує.
-        username: "Ім'я користувача:"
+        username: Ім'я користувача
         submit: Скинути пароль
     reset:
         submit: Змінити пароль
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: "Назва групи:"
-    username: "Ім'я користувача:"
-    email: "Електронна адреса:"
-    current_password: "Поточний пароль:"
-    password: "Пароль:"
-    password_confirmation: "Підтвердіть пароль:"
-    new_password: "Новий пароль:"
-    new_password_confirmation: "Підтвердіть пароль:"
+    group_name: Назва групи
+    username: Ім'я користувача
+    email: Електронна адреса
+    current_password: Поточний пароль
+    password: Пароль
+    password_confirmation: Підтвердіть пароль
+    new_password: Новий пароль
+    new_password_confirmation: Підтвердіть пароль


### PR DESCRIPTION
As requested in PR #941, we should remove the trailing colon from the translation strings for form labels.

The colon is a styling issue that can be added via the `{{form_label}}` block or a `label::after` CSS selector if you want.

I could not find any other Symfony bundle that includes the trailing colon like FOSUserBundle does.

The patch was created using this command:
```
for x in `ls FOSUserBundl*`; do sed '-e s/:\ "\(.*\):"/: \1/' < $x > x ; mv x $x ; done
```