### PR TITLE
Update overriding_forms.md

### DIFF
--- a/Resources/doc/overriding_forms.md
+++ b/Resources/doc/overriding_forms.md
@@ -38,11 +38,23 @@ class User extends BaseUser
      * @ORM\Column(type="string", length=255)
      *
      * @Assert\NotBlank(message="Please enter your name.", groups={"Registration", "Profile"})
-     * @Assert\MinLength(limit="3", message="The name is too short.", groups={"Registration", "Profile"})
-     * @Assert\MaxLength(limit="255", message="The name is too long.", groups={"Registration", "Profile"})
+     * @Assert\Length(min="3", groups={"Registration", "Profile"})
+     * @Assert\Length(max="255", groups={"Registration", "Profile"})
      */
     protected $name;
+    
+    // Make sure you create a getter and setter methods for each new field
+     public function getName()
+    {
+        return $this->name;
+    }
 
+   public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
     // ...
 }
 ```

--- a/Resources/doc/overriding_forms.md
+++ b/Resources/doc/overriding_forms.md
@@ -44,15 +44,14 @@ class User extends BaseUser
     protected $name;
     
     // Make sure you create a getter and setter methods for each new field
-     public function getName()
+    public function getName()
     {
         return $this->name;
     }
 
-   public function setName($name)
+    public function setName($name)
     {
         $this->name = $name;
-
         return $this;
     }
     // ...


### PR DESCRIPTION
Old instructions no longer valid for the latest symfony 2.6.4.
Removed the min length as its depreciated. 
Also added the getter and setter methods