### PR TITLE
Update index.md

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -335,7 +335,7 @@ security:
         - { path: ^/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin/, role: ROLE_ADMIN }
+        - { path: ^/admin, role: ROLE_ADMIN }
 ```
 
 Under the `providers` section, you are making the bundle's packaged user provider


### PR DESCRIPTION
Removed / from admin/

So that optimised for user-friendly plug-and-playability, otherwise going to /admin will be accessible by non-admin (which may not be initially obvious to people new to symfony).
