### PR TITLE
Deprecated `expired` and `credentialsExpired`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,9 @@ Changelog
   variable rather than an error message.
 * [BC break] The templating engine configuration has been removed, as well as the related code.
 * [BC break] Changed the XML namespace to `http://friendsofsymfony.github.io/schema/dic/user`
+* [BC break] Removed unused properties `expired` and `credentialsExpired` including corresponding methods. This may break code,
+  makes use of this methods, extending classes, and/or existing installations because of missing mappings for required db fields
+  [#1751]
 
 ### 2.0.0-alpha1 (2014-09-26)
 

--- a/Model/User.php
+++ b/Model/User.php
@@ -98,11 +98,6 @@ abstract class User implements UserInterface, GroupableInterface
     protected $locked;
 
     /**
-     * @var boolean
-     */
-    protected $expired;
-
-    /**
      * @var \DateTime
      */
     protected $expiresAt;
@@ -111,11 +106,6 @@ abstract class User implements UserInterface, GroupableInterface
      * @var array
      */
     protected $roles;
-
-    /**
-     * @var boolean
-     */
-    protected $credentialsExpired;
 
     /**
      * @var \DateTime
@@ -127,9 +117,7 @@ abstract class User implements UserInterface, GroupableInterface
         $this->salt = base_convert(sha1(uniqid(mt_rand(), true)), 16, 36);
         $this->enabled = false;
         $this->locked = false;
-        $this->expired = false;
         $this->roles = array();
-        $this->credentialsExpired = false;
     }
 
     public function addRole($role)
@@ -160,9 +148,9 @@ abstract class User implements UserInterface, GroupableInterface
             $this->salt,
             $this->usernameCanonical,
             $this->username,
-            $this->expired,
+            false,
             $this->locked,
-            $this->credentialsExpired,
+            false,
             $this->enabled,
             $this->id,
         ));
@@ -185,9 +173,9 @@ abstract class User implements UserInterface, GroupableInterface
             $this->salt,
             $this->usernameCanonical,
             $this->username,
-            $this->expired,
+            ,
             $this->locked,
-            $this->credentialsExpired,
+            ,
             $this->enabled,
             $this->id
         ) = $data;
@@ -304,10 +292,6 @@ abstract class User implements UserInterface, GroupableInterface
 
     public function isAccountNonExpired()
     {
-        if (true === $this->expired) {
-            return false;
-        }
-
         if (null !== $this->expiresAt && $this->expiresAt->getTimestamp() < time()) {
             return false;
         }
@@ -322,10 +306,6 @@ abstract class User implements UserInterface, GroupableInterface
 
     public function isCredentialsNonExpired()
     {
-        if (true === $this->credentialsExpired) {
-            return false;
-        }
-
         if (null !== $this->credentialsExpireAt && $this->credentialsExpireAt->getTimestamp() < time()) {
             return false;
         }
@@ -394,18 +374,6 @@ abstract class User implements UserInterface, GroupableInterface
         return $this;
     }
 
-    /**
-     * @param boolean $boolean
-     *
-     * @return User
-     */
-    public function setCredentialsExpired($boolean)
-    {
-        $this->credentialsExpired = $boolean;
-
-        return $this;
-    }
-
     public function setEmail($email)
     {
         $this->email = $email;
@@ -423,20 +391,6 @@ abstract class User implements UserInterface, GroupableInterface
     public function setEnabled($boolean)
     {
         $this->enabled = (Boolean) $boolean;
-
-        return $this;
-    }
-
-    /**
-     * Sets this user to expired.
-     *
-     * @param Boolean $boolean
-     *
-     * @return User
-     */
-    public function setExpired($boolean)
-    {
-        $this->expired = (Boolean) $boolean;
 
         return $this;
     }

--- a/Resources/config/doctrine/model/User.couchdb.xml
+++ b/Resources/config/doctrine/model/User.couchdb.xml
@@ -12,7 +12,6 @@
         <field name="password" fieldName="password" type="string" />
         <field name="lastLogin" fieldName="lastLogin" type="datetime" />
         <field name="locked" fieldName="locked" type="mixed" />
-        <field name="expired" fieldName="expired" type="mixed" />
         <field name="expiresAt" fieldName="expiresAt" type="datetime" />
         <field name="confirmationToken" fieldName="confirmationToken" type="string" />
         <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="datetime" />

--- a/Resources/config/doctrine/model/User.mongodb.xml
+++ b/Resources/config/doctrine/model/User.mongodb.xml
@@ -24,8 +24,6 @@
 
         <field name="locked" fieldName="locked" type="boolean" />
 
-        <field name="expired" fieldName="expired" type="boolean" />
-
         <field name="expiresAt" fieldName="expiresAt" type="date" />
 
         <field name="confirmationToken" fieldName="confirmationToken" type="string" />
@@ -33,8 +31,6 @@
         <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="date" />
 
         <field name="roles" fieldName="roles" type="collection" />
-        
-        <field name="credentialsExpired" column="credentialsExpired" type="boolean" />
 
         <field name="credentialsExpireAt" column="credentialsExpireAt" type="date" />
         <indexes>

--- a/Resources/config/doctrine/model/User.orm.xml
+++ b/Resources/config/doctrine/model/User.orm.xml
@@ -24,8 +24,6 @@
 
         <field name="locked" column="locked" type="boolean" />
 
-        <field name="expired" column="expired" type="boolean" />
-
         <field name="expiresAt" column="expires_at" type="datetime" nullable="true" />
 
         <field name="confirmationToken" column="confirmation_token" type="string" nullable="true" />
@@ -33,8 +31,6 @@
         <field name="passwordRequestedAt" column="password_requested_at" type="datetime" nullable="true" />
 
         <field name="roles" column="roles" type="array" />
-
-        <field name="credentialsExpired" column="credentials_expired" type="boolean" />
 
         <field name="credentialsExpireAt" column="credentials_expire_at" type="datetime" nullable="true" />
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -4,6 +4,18 @@ Upgrade instruction
 This document describes the changes needed when upgrading because of a BC
 break. For the full list of changes, please look at the Changelog file.
 
+## 2.0-alpha to 2.0.0
+
+Methods and properties removed from `\FOS\UserBundle\Model\User` [#1751]
+
+- `$expired`
+- `$credentialsExpired`
+- `setExpired()` (use `setExpireAt(\DateTime::now()` instead)
+- `setCredentialsExpired()` (use `setCredentialsExpireAt(\DateTime::now()` instead)
+
+You need to drop the fields `expired` and `credentials_expired` from your database
+schema, because they aren't mapped anymore.
+
 ## 1.3 to 2.0-alpha1
 
 ### User Provider


### PR DESCRIPTION
Covers 

- `User::$expired`
- `User::$credentialsExpired`
- `User::setExpired()`
- `User::setCredentialsExpired()`

This methods already redirect to the timestamp-based properties (see below)

- `User::isExpired()`
- `User::isCredentialsExpired()`

This functionality is never used an they are somehow superfluous, because they are already covered by the corresponding `$expiredAt` and `$credentialsExpiredAt`

- `setExpired(true)` equivalent to `setExpiresAt(\DateTime::now())`
- `setExpired(false)` equivalent to `setExpiresAt(null)`


This said: Is there's a reason they are still kept?