### PR TITLE
Use user's full name in email to header if available

### DIFF
--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -14,6 +14,7 @@ namespace FOS\UserBundle\Mailer;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use FOS\UserBundle\Model\UserInterface;
+use FOS\UserBundle\Model\FullNameInterface;
 use FOS\UserBundle\Mailer\MailerInterface;
 
 /**
@@ -45,7 +46,8 @@ class Mailer implements MailerInterface
             'user' => $user,
             'confirmationUrl' =>  $url
         ));
-        $this->sendEmailMessage($rendered, $this->parameters['from_email']['confirmation'], $user->getEmail());
+        $name = $user instanceof FullNameInterface ? $user->getFullName() : null;
+        $this->sendEmailMessage($rendered, $this->parameters['from_email']['confirmation'], $user->getEmail(), $name);
     }
 
     /**
@@ -59,15 +61,17 @@ class Mailer implements MailerInterface
             'user' => $user,
             'confirmationUrl' => $url
         ));
-        $this->sendEmailMessage($rendered, $this->parameters['from_email']['resetting'], $user->getEmail());
+        $name = $user instanceof FullNameInterface ? $user->getFullName() : null;
+        $this->sendEmailMessage($rendered, $this->parameters['from_email']['resetting'], $user->getEmail(), $name);
     }
 
     /**
      * @param string $renderedTemplate
      * @param string $fromEmail
      * @param string $toEmail
+     * @param string $name
      */
-    protected function sendEmailMessage($renderedTemplate, $fromEmail, $toEmail)
+    protected function sendEmailMessage($renderedTemplate, $fromEmail, $toEmail, $name = null)
     {
         // Render the email, use the first line as the subject, and the rest as the body
         $renderedLines = explode("\n", trim($renderedTemplate));
@@ -77,7 +81,7 @@ class Mailer implements MailerInterface
         $message = \Swift_Message::newInstance()
             ->setSubject($subject)
             ->setFrom($fromEmail)
-            ->setTo($toEmail)
+            ->setTo($toEmail, $name)
             ->setBody($body);
 
         $this->mailer->send($message);

--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -12,6 +12,7 @@
 namespace FOS\UserBundle\Mailer;
 
 use FOS\UserBundle\Model\UserInterface;
+use FOS\UserBundle\Model\FullNameInterface;
 use FOS\UserBundle\Mailer\MailerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -43,7 +44,8 @@ class TwigSwiftMailer implements MailerInterface
             'confirmationUrl' => $url
         );
 
-        $this->sendMessage($template, $context, $this->parameters['from_email']['confirmation'], $user->getEmail());
+        $name = $user instanceof FullNameInterface ? $user->getFullName() : null;
+        $this->sendMessage($template, $context, $this->parameters['from_email']['confirmation'], $user->getEmail(), $name);
     }
 
     public function sendResettingEmailMessage(UserInterface $user)
@@ -56,7 +58,8 @@ class TwigSwiftMailer implements MailerInterface
             'confirmationUrl' => $url
         );
 
-        $this->sendMessage($template, $context, $this->parameters['from_email']['resetting'], $user->getEmail());
+        $name = $user instanceof FullNameInterface ? $user->getFullName() : null;
+        $this->sendMessage($template, $context, $this->parameters['from_email']['resetting'], $user->getEmail(), $name);
     }
 
     /**
@@ -64,8 +67,9 @@ class TwigSwiftMailer implements MailerInterface
      * @param array  $context
      * @param string $fromEmail
      * @param string $toEmail
+     * @param string $name
      */
-    protected function sendMessage($templateName, $context, $fromEmail, $toEmail)
+    protected function sendMessage($templateName, $context, $fromEmail, $toEmail, $name = null)
     {
         $context = $this->twig->mergeGlobals($context);
         $template = $this->twig->loadTemplate($templateName);
@@ -76,7 +80,7 @@ class TwigSwiftMailer implements MailerInterface
         $message = \Swift_Message::newInstance()
             ->setSubject($subject)
             ->setFrom($fromEmail)
-            ->setTo($toEmail);
+            ->setTo($toEmail, $name);
 
         if (!empty($htmlBody)) {
             $message->setBody($htmlBody, 'text/html')

--- a/Model/FullNameInterface.php
+++ b/Model/FullNameInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Model;
+
+/**
+ * @author Ben Glassman <ben@vtdesignworks.com>
+ */
+interface FullNameInterface
+{
+    /**
+     * Get the user's full name
+     *
+     * @return self
+     */
+    public function getFullName();
+}


### PR DESCRIPTION
Including a recipient's full name in the to header of an email reduces the chance that the message will be considered spam by their email provider and client. This PR introduces an interface which consumers of this bundle can implement on their user class with the single method of getFullName. The default mailers will set this as the name to use for the "to" header.