### PR TITLE
Fix a typo in the doc

### DIFF
--- a/Resources/doc/emails.md
+++ b/Resources/doc/emails.md
@@ -133,7 +133,7 @@ fos_user:
 {% autoescape false %}
 Hello {{ user.username }} !
 
-You can reset your email by accessing {{ confirmationUrl }}
+You can reset your password by accessing {{ confirmationUrl }}
 
 Greetings,
 the Acme team


### PR DESCRIPTION
Changed sample email text from "You can reset your email..." to "You can reset your password..."