### PR TITLE
fix exception message for unavailable model manager name

### DIFF
--- a/DependencyInjection/Compiler/RegisterMappingsPass.php
+++ b/DependencyInjection/Compiler/RegisterMappingsPass.php
@@ -14,7 +14,6 @@ namespace FOS\UserBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 
 /**
  * Forward compatibility class in case FOSUserBundle is used with older
@@ -72,7 +71,7 @@ class RegisterMappingsPass implements CompilerPassInterface
             }
         }
 
-        throw new ParameterNotFoundException('None of the managerParameters resulted in a valid name');
+        throw new \InvalidArgumentException('None of the managerParameters resulted in a valid name.');
     }
 
     public static function createOrmMappingDriver(array $mappings)


### PR DESCRIPTION
So instead of `You have requested a non-existent parameter "None of the managerParameters resulted in a valid name".` the exception message will now be just `None of the managerParameters resulted in a valid name.`.

Let me know if `InvalidArgumentException` doesn't fit here.