### PR TITLE
Allows to reset User::expiresAt to NULL

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -392,7 +392,7 @@ abstract class User implements UserInterface, GroupableInterface
      *
      * @return User
      */
-    public function setCredentialsExpireAt(\DateTime $date)
+    public function setCredentialsExpireAt(\DateTime $date = null)
     {
         $this->credentialsExpireAt = $date;
 
@@ -451,7 +451,7 @@ abstract class User implements UserInterface, GroupableInterface
      *
      * @return User
      */
-    public function setExpiresAt(\DateTime $date)
+    public function setExpiresAt(\DateTime $date = null)
     {
         $this->expiresAt = $date;
 

--- a/Tests/Model/UserTest.php
+++ b/Tests/Model/UserTest.php
@@ -78,6 +78,15 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($user->hasRole($newrole));
     }
 
+    public function testExpiresAtIsNullable()
+    {
+        $user = $this->getUser();
+        $user->setExpiresAt(new \DateTime());
+        $user->setCredentialsExpireAt(new \DateTime());
+        $user->setExpiresAt(null);
+        $user->setCredentialsExpireAt(null);
+    }
+
     /**
      * @return User
      */


### PR DESCRIPTION
Using a Symfony Form to edit the user, I can't save the form with a `null` date.