### PR TITLE
Fix deprecated routing configuration

### DIFF
--- a/Resources/config/routing/change_password.xml
+++ b/Resources/config/routing/change_password.xml
@@ -4,9 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_change_password" pattern="/change-password">
+    <route id="fos_user_change_password" path="/change-password" methods="GET POST">
         <default key="_controller">FOSUserBundle:ChangePassword:changePassword</default>
-        <requirement key="_method">GET|POST</requirement>
     </route>
 
 </routes>

--- a/Resources/config/routing/group.xml
+++ b/Resources/config/routing/group.xml
@@ -4,27 +4,24 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_group_list" pattern="/list">
+    <route id="fos_user_group_list" path="/list" methods="GET">
         <default key="_controller">FOSUserBundle:Group:list</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_group_new" pattern="/new">
+    <route id="fos_user_group_new" path="/new" methods="GET POST">
         <default key="_controller">FOSUserBundle:Group:new</default>
     </route>
 
-    <route id="fos_user_group_show" pattern="/{groupName}">
+    <route id="fos_user_group_show" path="/{groupName}" methods="GET">
         <default key="_controller">FOSUserBundle:Group:show</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_group_edit" pattern="/{groupName}/edit">
+    <route id="fos_user_group_edit" path="/{groupName}/edit" methods="GET POST">
         <default key="_controller">FOSUserBundle:Group:edit</default>
     </route>
 
-    <route id="fos_user_group_delete" pattern="/{groupName}/delete">
+    <route id="fos_user_group_delete" path="/{groupName}/delete" methods="GET">
         <default key="_controller">FOSUserBundle:Group:delete</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
 </routes>

--- a/Resources/config/routing/profile.xml
+++ b/Resources/config/routing/profile.xml
@@ -4,12 +4,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_profile_show" pattern="/">
+    <route id="fos_user_profile_show" path="/" methods="GET">
         <default key="_controller">FOSUserBundle:Profile:show</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_profile_edit" pattern="/edit">
+    <route id="fos_user_profile_edit" path="/edit" methods="GET POST">
         <default key="_controller">FOSUserBundle:Profile:edit</default>
     </route>
 

--- a/Resources/config/routing/registration.xml
+++ b/Resources/config/routing/registration.xml
@@ -4,23 +4,20 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_registration_register" pattern="/">
+    <route id="fos_user_registration_register" path="/" methods="GET POST">
         <default key="_controller">FOSUserBundle:Registration:register</default>
     </route>
 
-    <route id="fos_user_registration_check_email" pattern="/check-email">
+    <route id="fos_user_registration_check_email" path="/check-email" methods="GET">
         <default key="_controller">FOSUserBundle:Registration:checkEmail</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_registration_confirm" pattern="/confirm/{token}">
+    <route id="fos_user_registration_confirm" path="/confirm/{token}" methods="GET">
         <default key="_controller">FOSUserBundle:Registration:confirm</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_registration_confirmed" pattern="/confirmed">
+    <route id="fos_user_registration_confirmed" path="/confirmed" methods="GET">
         <default key="_controller">FOSUserBundle:Registration:confirmed</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
 </routes>

--- a/Resources/config/routing/resetting.xml
+++ b/Resources/config/routing/resetting.xml
@@ -4,24 +4,20 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_resetting_request" pattern="/request">
+    <route id="fos_user_resetting_request" path="/request" methods="GET">
         <default key="_controller">FOSUserBundle:Resetting:request</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_resetting_send_email" pattern="/send-email">
+    <route id="fos_user_resetting_send_email" path="/send-email" methods="POST">
         <default key="_controller">FOSUserBundle:Resetting:sendEmail</default>
-        <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="fos_user_resetting_check_email" pattern="/check-email">
+    <route id="fos_user_resetting_check_email" path="/check-email" methods="GET">
         <default key="_controller">FOSUserBundle:Resetting:checkEmail</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_resetting_reset" pattern="/reset/{token}">
+    <route id="fos_user_resetting_reset" path="/reset/{token}" methods="GET POST">
         <default key="_controller">FOSUserBundle:Resetting:reset</default>
-        <requirement key="_method">GET|POST</requirement>
     </route>
 
 </routes>

--- a/Resources/config/routing/security.xml
+++ b/Resources/config/routing/security.xml
@@ -4,16 +4,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_security_login" pattern="/login">
+    <route id="fos_user_security_login" path="/login" methods="GET POST">
         <default key="_controller">FOSUserBundle:Security:login</default>
     </route>
 
-    <route id="fos_user_security_check" pattern="/login_check">
+    <route id="fos_user_security_check" path="/login_check" methods="POST">
         <default key="_controller">FOSUserBundle:Security:check</default>
-        <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="fos_user_security_logout" pattern="/logout">
+    <route id="fos_user_security_logout" path="/logout" methods="GET">
         <default key="_controller">FOSUserBundle:Security:logout</default>
     </route>
 

--- a/Tests/Routing/RoutingTest.php
+++ b/Tests/Routing/RoutingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace FOS\UserBundle\Tests\Routing;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Loader\XmlFileLoader;
+use Symfony\Component\Routing\RouteCollection;
+
+class RoutingTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider loadRoutingProvider
+     */
+    public function testLoadRouting($routeName, $path, array $methods)
+    {
+        $locator = new FileLocator();
+        $loader = new XmlFileLoader($locator);
+
+        $collection = new RouteCollection();
+        $collection->addCollection($loader->load(__DIR__.'/../../Resources/config/routing/change_password.xml'));
+        $subCollection = $loader->load(__DIR__.'/../../Resources/config/routing/group.xml');
+        $subCollection->addPrefix('/group');
+        $collection->addCollection($subCollection);
+        $subCollection = $loader->load(__DIR__.'/../../Resources/config/routing/profile.xml');
+        $subCollection->addPrefix('/profile');
+        $collection->addCollection($subCollection);
+        $subCollection = $loader->load(__DIR__.'/../../Resources/config/routing/registration.xml');
+        $subCollection->addPrefix('/register');
+        $collection->addCollection($subCollection);
+        $subCollection = $loader->load(__DIR__.'/../../Resources/config/routing/resetting.xml');
+        $subCollection->addPrefix('/resetting');
+        $collection->addCollection($subCollection);
+        $collection->addCollection($loader->load(__DIR__.'/../../Resources/config/routing/security.xml'));
+
+        $route = $collection->get($routeName);
+        $this->assertNotNull($route, sprintf('The route "%s" should exists', $routeName));
+        $this->assertEquals($path, $route->getPath());
+        $this->assertEquals($methods, $route->getMethods());
+    }
+
+    public function loadRoutingProvider()
+    {
+        return array(
+            array('fos_user_change_password', '/change-password', array('GET', 'POST')),
+
+            array('fos_user_group_list', '/group/list', array('GET')),
+            array('fos_user_group_new', '/group/new', array('GET', 'POST')),
+            array('fos_user_group_show', '/group/{groupName}', array('GET')),
+            array('fos_user_group_edit', '/group/{groupName}/edit', array('GET', 'POST')),
+            array('fos_user_group_delete', '/group/{groupName}/delete', array('GET')),
+
+            array('fos_user_profile_show', '/profile/', array('GET')),
+            array('fos_user_profile_edit', '/profile/edit', array('GET', 'POST')),
+
+            array('fos_user_registration_register', '/register/', array('GET', 'POST')),
+            array('fos_user_registration_check_email', '/register/check-email', array('GET')),
+            array('fos_user_registration_confirm', '/register/confirm/{token}', array('GET')),
+            array('fos_user_registration_confirmed', '/register/confirmed', array('GET')),
+
+            array('fos_user_resetting_request', '/resetting/request', array('GET')),
+            array('fos_user_resetting_send_email', '/resetting/send-email', array('POST')),
+            array('fos_user_resetting_check_email', '/resetting/check-email', array('GET')),
+            array('fos_user_resetting_reset', '/resetting/reset/{token}', array('GET', 'POST')),
+
+            array('fos_user_security_login', '/login', array('GET', 'POST')),
+            array('fos_user_security_check', '/login_check', array('POST')),
+            array('fos_user_security_logout', '/logout', array('GET')),
+        );
+    }
+}


### PR DESCRIPTION
This PR fix deprecated routing config throwing related errors:

> The "pattern" is deprecated since version 2.2 and will be removed in 3.0. Use the "path" option in the route definition instead.

> The "_method" requirement is deprecated since version 2.2 and will be removed in 3.0. Use the setMethods() method instead or the "methods" option in the route definition.

The added tests reveal the errors by loading routing configuration files.