### PR TITLE
Travis improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,47 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
   - hhvm
-  
+  - nightly
+
 matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.5.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.6.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION="3.0.x-dev as 2.8"
   allow_failures:
-    - php: 7.0
+    - php: hhvm
+    - php: nightly
+    - env: SYMFONY_VERSION=2.7.*@dev
+    - env: SYMFONY_VERSION=2.8.*@dev
+    - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 
 sudo: false
 
-install: composer install
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - composer selfupdate
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+
+install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+
+script:
+  - phpunit --coverage-text
 
 notifications:
   email: friendsofsymfony-dev@googlegroups.com


### PR DESCRIPTION
This PR is a Travis improvement suggestion.

With this new config, we have:

 * Tests from php 5.3 to 5.6 + hhvm / nightly (7.0)
 * Tests form SF 2.3 to 2.6 and 2.7/2.8/3.0 allowed failure (in order to prevent deprecated issues)
 * Cache system to make tests quicker

Don't hesitate to tell me your thinking about this suggestion! :+1: 

Thanks