### PR TITLE
Change CSRF provider configuration on doc

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -327,7 +327,7 @@ security:
             pattern: ^/
             form_login:
                 provider: fos_userbundle
-                csrf_provider: form.csrf_provider
+                csrf_provider: security.csrf.token_manager # Use form.csrf_provider instead for Symfony <2.4
             logout:       true
             anonymous:    true
 


### PR DESCRIPTION
Usage of `security.csrf.token_manager` instead of `form.csrf_provider` will solve the following deprecated notice:

> DEPRECATED - The Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderAdapter class is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.