### PR TITLE
Add tests for form types

### DIFF
--- a/Tests/Form/Type/ChangePasswordFormTypeTest.php
+++ b/Tests/Form/Type/ChangePasswordFormTypeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FOS\UserBundle\Tests\Form\Type;
+
+use FOS\UserBundle\Form\Type\ChangePasswordFormType;
+use FOS\UserBundle\Tests\TestUser;
+
+class ChangePasswordFormTypeTest extends ValidatorExtensionTypeTestCase
+{
+    public function testSubmit()
+    {
+        $user = new TestUser();
+        $user->setPassword('foo');
+
+        $form = $this->factory->create(new ChangePasswordFormType('FOS\UserBundle\Tests\TestUser'), $user);
+        $formData = array(
+            'current_password'      => 'foo',
+            'plainPassword'         => array(
+                'first'     => 'bar',
+                'second'    => 'bar',
+            ),
+        );
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($user, $form->getData());
+        $this->assertEquals('bar', $user->getPlainPassword());
+    }
+}

--- a/Tests/Form/Type/GroupFormTypeTest.php
+++ b/Tests/Form/Type/GroupFormTypeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace FOS\UserBundle\Tests\Form\Type;
+
+use FOS\UserBundle\Form\Type\GroupFormType;
+use FOS\UserBundle\Tests\TestGroup;
+
+class GroupFormTypeTest extends TypeTestCase
+{
+    public function testSubmit()
+    {
+        $group = new TestGroup('foo');
+
+        $form = $this->factory->create(new GroupFormType('FOS\UserBundle\Tests\TestGroup'), $group);
+        $formData = array(
+            'name'      => 'bar',
+        );
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($group, $form->getData());
+        $this->assertEquals('bar', $group->getName());
+    }
+}

--- a/Tests/Form/Type/ProfileFormTypeTest.php
+++ b/Tests/Form/Type/ProfileFormTypeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FOS\UserBundle\Tests\Form\Type;
+
+use FOS\UserBundle\Form\Type\ProfileFormType;
+use FOS\UserBundle\Tests\TestUser;
+
+class ProfileFormTypeTest extends ValidatorExtensionTypeTestCase
+{
+    public function testSubmit()
+    {
+        $user = new TestUser();
+
+        $form = $this->factory->create(new ProfileFormType('FOS\UserBundle\Tests\TestUser'), $user);
+        $formData = array(
+            'username'      => 'bar',
+            'email'         => 'john@doe.com',
+        );
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($user, $form->getData());
+        $this->assertEquals('bar', $user->getUsername());
+        $this->assertEquals('john@doe.com', $user->getEmail());
+    }
+}

--- a/Tests/Form/Type/RegistrationFormTypeTest.php
+++ b/Tests/Form/Type/RegistrationFormTypeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FOS\UserBundle\Tests\Form\Type;
+
+use FOS\UserBundle\Form\Type\RegistrationFormType;
+use FOS\UserBundle\Tests\TestUser;
+
+class RegistrationFormTypeTest extends ValidatorExtensionTypeTestCase
+{
+    public function testSubmit()
+    {
+        $user = new TestUser();
+
+        $form = $this->factory->create(new RegistrationFormType('FOS\UserBundle\Tests\TestUser'), $user);
+        $formData = array(
+            'username'      => 'bar',
+            'email'         => 'john@doe.com',
+            'plainPassword' => array(
+                'first'         => 'test',
+                'second'        => 'test',
+            )
+        );
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($user, $form->getData());
+        $this->assertEquals('bar', $user->getUsername());
+        $this->assertEquals('john@doe.com', $user->getEmail());
+        $this->assertEquals('test', $user->getPlainPassword());
+    }
+}

--- a/Tests/Form/Type/ResettingFormTypeTest.php
+++ b/Tests/Form/Type/ResettingFormTypeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace FOS\UserBundle\Tests\Form\Type;
+
+use FOS\UserBundle\Form\Type\ResettingFormType;
+use FOS\UserBundle\Tests\TestUser;
+
+class ResettingFormTypeTest extends ValidatorExtensionTypeTestCase
+{
+    public function testSubmit()
+    {
+        $user = new TestUser();
+
+        $form = $this->factory->create(new ResettingFormType('FOS\UserBundle\Tests\TestUser'), $user);
+        $formData = array(
+            'plainPassword' => array(
+                'first'         => 'test',
+                'second'        => 'test',
+            )
+        );
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($user, $form->getData());
+        $this->assertEquals('test', $user->getPlainPassword());
+    }
+}

--- a/Tests/Form/Type/TypeTestCase.php
+++ b/Tests/Form/Type/TypeTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace FOS\UserBundle\Tests\Form\Type;
+
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\Forms;
+use Symfony\Component\Form\Test\TypeTestCase as BaseTypeTestCase;
+
+/**
+ * Class TypeTestCase
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ *
+ * Could be removed for using directly base class since PR: https://github.com/symfony/symfony/pull/14506
+ */
+abstract class TypeTestCase extends BaseTypeTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->factory = Forms::createFormFactoryBuilder()
+            ->addExtensions($this->getExtensions())
+            ->addTypeExtensions($this->getTypeExtensions())
+            ->getFormFactory();
+
+        $this->builder = new FormBuilder(null, null, $this->dispatcher, $this->factory);
+    }
+
+    protected function getTypeExtensions()
+    {
+        return array();
+    }
+}

--- a/Tests/Form/Type/ValidatorExtensionTypeTestCase.php
+++ b/Tests/Form/Type/ValidatorExtensionTypeTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FOS\UserBundle\Tests\Form\Type;
+
+use Symfony\Component\Form\Extension\Validator\Type\FormTypeValidatorExtension;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * Class ValidatorExtensionTypeTestCase
+ * FormTypeValidatorExtension added as default. Useful for form types with `constraints` option
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class ValidatorExtensionTypeTestCase extends TypeTestCase
+{
+    protected function getTypeExtensions()
+    {
+        $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator->method('validate')->will($this->returnValue(new ConstraintViolationList()));
+
+        return array(
+            new FormTypeValidatorExtension($validator),
+        );
+    }
+}

--- a/Tests/TestGroup.php
+++ b/Tests/TestGroup.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FOS\UserBundle\Tests;
+
+use FOS\UserBundle\Model\Group;
+
+class TestGroup extends Group
+{
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+}


### PR DESCRIPTION
~~This PR fixes deprecated notices since SF 2.7.~~

~~Symfony 2.3+ BC kept.~~

EDIT: Already did on #1821.

Also added test cases for your form types.