### PR TITLE
Fix deprecated SecurityContext usage on loginManager

### DIFF
--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -55,6 +55,18 @@ class FOSUserExtension extends Extension
             $loader->load(sprintf('%s.xml', $basename));
         }
 
+        // Set the SecurityContext for Symfony <2.6
+        // Should go back to simple xml configuration after <2.6 support
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $tokenStorageReference = new Reference('security.token_storage');
+        } else {
+            $tokenStorageReference = new Reference('security.context');
+        }
+        $container
+            ->getDefinition('fos_user.security.login_manager')
+            ->replaceArgument(0, $tokenStorageReference)
+        ;
+
         if ($config['use_flash_notifications']) {
             $loader->load('flash_notifications.xml');
         }

--- a/FOSUserBundle.php
+++ b/FOSUserBundle.php
@@ -11,13 +11,13 @@
 
 namespace FOS\UserBundle;
 
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use FOS\UserBundle\DependencyInjection\Compiler\ValidationPass;
-use FOS\UserBundle\DependencyInjection\Compiler\RegisterMappingsPass;
+use Doctrine\Bundle\CouchDBBundle\DependencyInjection\Compiler\DoctrineCouchDBMappingsPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
-use Doctrine\Bundle\CouchDBBundle\DependencyInjection\Compiler\DoctrineCouchDBMappingsPass;
+use FOS\UserBundle\DependencyInjection\Compiler\RegisterMappingsPass;
+use FOS\UserBundle\DependencyInjection\Compiler\ValidationPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Matthieu Bontemps <matthieu@knplabs.com>

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -16,7 +16,7 @@
         </service>
 
         <service id="fos_user.security.login_manager" class="%fos_user.security.login_manager.class%">
-            <argument type="service" id="security.context" />
+            <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
             <argument type="service" id="security.user_checker" />
             <argument type="service" id="security.authentication.session_strategy" />
             <argument type="service" id="service_container" />


### PR DESCRIPTION
Fix deprecated `SecurityContext` usage on loginManager.

Symfony 2.3+ BC kept.

@xabbuh: I search a long time on PR, nobody already did this normally. :-)