### PR TITLE
Update event subscriber to not use deprecated methods

### DIFF
--- a/EventListener/AuthenticationListener.php
+++ b/EventListener/AuthenticationListener.php
@@ -15,6 +15,7 @@ use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\Event\FilterUserResponseEvent;
 use FOS\UserBundle\Security\LoginManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Exception\AccountStatusException;
 
@@ -38,16 +39,21 @@ class AuthenticationListener implements EventSubscriberInterface
         );
     }
 
-    public function authenticate(FilterUserResponseEvent $event)
+    public function authenticate(FilterUserResponseEvent $event, $eventName = null, EventDispatcherInterface $eventDispatcher = null)
     {
         if (!$event->getUser()->isEnabled()) {
             return;
         }
 
+        // BC for SF < 2.4
+        if (null === $eventDispatcher) {
+            $eventDispatcher = $event->getDispatcher();
+        }
+
         try {
             $this->loginManager->loginUser($this->firewallName, $event->getUser(), $event->getResponse());
 
-            $event->getDispatcher()->dispatch(FOSUserEvents::SECURITY_IMPLICIT_LOGIN, new UserEvent($event->getUser(), $event->getRequest()));
+            $eventDispatcher->dispatch(FOSUserEvents::SECURITY_IMPLICIT_LOGIN, new UserEvent($event->getUser(), $event->getRequest()));
         } catch (AccountStatusException $ex) {
             // We simply do not authenticate users which do not pass the user
             // checker (not enabled, expired, etc.).

--- a/EventListener/FlashListener.php
+++ b/EventListener/FlashListener.php
@@ -51,13 +51,18 @@ class FlashListener implements EventSubscriberInterface
         );
     }
 
-    public function addSuccessFlash(Event $event)
+    public function addSuccessFlash(Event $event, $eventName = null)
     {
-        if (!isset(self::$successMessages[$event->getName()])) {
+        // BC for SF < 2.4
+        if (null === $eventName) {
+            $eventName = $event->getName();
+        }
+
+        if (!isset(self::$successMessages[$eventName])) {
             throw new \InvalidArgumentException('This event does not correspond to a known flash message');
         }
 
-        $this->session->getFlashBag()->add('success', $this->trans(self::$successMessages[$event->getName()]));
+        $this->session->getFlashBag()->add('success', $this->trans(self::$successMessages[$eventName]));
     }
 
     private function trans($message, array $params = array())

--- a/Tests/EventListener/AuthenticationListenerTest.php
+++ b/Tests/EventListener/AuthenticationListenerTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace FOS\UserBundle\Tests\EventListener;
+
+use FOS\UserBundle\Event\FilterUserResponseEvent;
+use FOS\UserBundle\EventListener\AuthenticationListener;
+use FOS\UserBundle\FOSUserEvents;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
+{
+    const FIREWALL_NAME = 'foo';
+
+    /** @var EventDispatcherInterface */
+    private $eventDispatcher;
+
+    /** @var FilterUserResponseEvent */
+    private $event;
+
+    /** @var AuthenticationListener */
+    private $listener;
+
+    public function setUp()
+    {
+        $user = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $user
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $response = $this->getMock('Symfony\Component\HttpFoundation\Response');
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $this->event = new FilterUserResponseEvent($user, $request, $response);
+
+        $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcher');
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch');
+
+        $loginManager = $this->getMock('FOS\UserBundle\Security\LoginManagerInterface');
+
+        $this->listener = new AuthenticationListener($loginManager, self::FIREWALL_NAME);
+    }
+
+    public function testAuthenticateLegacy()
+    {
+        $this->event->setDispatcher($this->eventDispatcher);
+        $this->event->setName(FOSUserEvents::REGISTRATION_COMPLETED);
+
+        $this->listener->authenticate($this->event);
+    }
+
+    public function testAuthenticate()
+    {
+        $this->listener->authenticate($this->event, FOSUserEvents::REGISTRATION_COMPLETED, $this->eventDispatcher);
+    }
+}

--- a/Tests/EventListener/FlashListenerTest.php
+++ b/Tests/EventListener/FlashListenerTest.php
@@ -1,0 +1,44 @@
+<?php
+namespace FOS\UserBundle\Tests\EventListener;
+
+use FOS\UserBundle\EventListener\FlashListener;
+use FOS\UserBundle\FOSUserEvents;
+use Symfony\Component\EventDispatcher\Event;
+
+class FlashListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Event */
+    private $event;
+
+    /** @var FlashListener */
+    private $listener;
+
+    public function setUp()
+    {
+        $this->event = new Event();
+
+        $flashBag = $this->getMock('Symfony\Component\HttpFoundation\Session\Flash\FlashBag');
+
+        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session
+            ->expects($this->once())
+            ->method('getFlashBag')
+            ->willReturn($flashBag);
+
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+
+        $this->listener = new FlashListener($session, $translator);
+    }
+
+    public function testAddSuccessFlashLegacy()
+    {
+        $this->event->setName(FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
+
+        $this->listener->addSuccessFlash($this->event);
+    }
+
+    public function testAddSuccessFlash()
+    {
+        $this->listener->addSuccessFlash($this->event, FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
+    }
+}


### PR DESCRIPTION
This PR avoids usage of deprecated `Event` methods `getName()` and `getDispatcher()` in event subscribers, to not trigger deprecation warnings in SF 2.7.