### PR TITLE
Removed index dropDups

### DIFF
--- a/Resources/config/doctrine-mapping/Group.mongodb.xml
+++ b/Resources/config/doctrine-mapping/Group.mongodb.xml
@@ -15,7 +15,6 @@
                 <key name="name" order="asc" />
                 <option name="safe" value="true" />
                 <option name="unique" value="true" />
-                <option name="dropDups" value="true" />
             </index>
         </indexes>
 

--- a/Resources/config/doctrine-mapping/User.mongodb.xml
+++ b/Resources/config/doctrine-mapping/User.mongodb.xml
@@ -42,13 +42,11 @@
                 <key name="usernameCanonical" order="asc" />
                 <option name="safe" value="true" />
                 <option name="unique" value="true" />
-                <option name="dropDups" value="true" />
             </index>
             <index>
                 <key name="emailCanonical" order="asc" />
                 <option name="safe" value="true" />
                 <option name="unique" value="true" />
-                <option name="dropDups" value="true" />
             </index>
         </indexes>
 


### PR DESCRIPTION
Removed index option 'dropDups' as discussed in https://github.com/FriendsOfSymfony/FOSUserBundle/pull/1809

> Historically, it could result in unexpected data loss when creating the indexes, and the option has actually be removed entirely in MongoDB 3.0.