### PR TITLE
Added REGISTRATION_FAILURE event

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -70,9 +70,18 @@ class RegistrationController extends Controller
             return $response;
         }
 
-        return $this->render('FOSUserBundle:Registration:register.html.twig', array(
-            'form' => $form->createView(),
-        ));
+        if($form->isSubmitted()) {
+            $event = new FormEvent($form, $request);
+            $dispatcher->dispatch(FOSUserEvents::REGISTRATION_FAILURE, $event);
+        }
+
+        if (null === $event || null === $response = $event->getResponse()) {
+            $response = $this->render('FOSUserBundle:Registration:register.html.twig', array(
+                'form' => $form->createView(),
+            ));
+        }
+
+        return $response;
     }
 
     /**

--- a/FOSUserEvents.php
+++ b/FOSUserEvents.php
@@ -137,6 +137,14 @@ final class FOSUserEvents
     const REGISTRATION_SUCCESS = 'fos_user.registration.success';
 
     /**
+     * The REGISTRATION_FAILURE event occurs when the registration form is not valid
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\FormEvent instance.
+     */
+    const REGISTRATION_FAILURE = 'fos_user.registration.failure';
+
+    /**
      * The REGISTRATION_COMPLETED event occurs after saving the user in the registration process.
      *
      * This event allows you to access the response which will be sent.


### PR DESCRIPTION
This allows to easily answer with a JsonResponse, ie:

```php

class JsonResponseListener implements EventSubscriberInterface
{
    private $errorSerializer;

    public function __construct(FormErrorsSerializer $errorsSerializer)
    {
        $this->errorSerializer = $errorsSerializer;
    }

    public static function getSubscribedEvents()
    {
        return array(
            FOSUserEvents::REGISTRATION_SUCCESS => 'onRegistrationSuccess',
            FOSUserEvents::REGISTRATION_FAILURE => 'onRegistrationFailure',
        );
    }

    public function onRegistrationSuccess(FormEvent $event)
    {
        $event->setResponse(new JsonResponse(array(
            "success" => true
        )));
    }

    public function onRegistrationFailure(FormEvent $event)
    {
        $event->setResponse(new JsonResponse(array(
            "success" => false,
            "reason" => $this->errorSerializer->serializeFormErrors($event->getForm(), true, true)
        )));
    }
}

``` 