### PR TITLE
Fix incorrect note statement

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -146,7 +146,8 @@ class User extends BaseUser
 
 **Note:**
 
-> `User` is a reserved keyword in SQL so you cannot use it as table name.
+> `User` is a reserved keyword in the SQL standard.  
+> If you need to use reserved words, surround them with backticks: ``@ORM\Table(name="`user`")``
 
 ##### yaml
 


### PR DESCRIPTION
The note states that reserved keywords cannot be used.
This is not true, since
1) not all keywords are implemented by all vendors. For example, "user" is not a keyword in MySQL
2) keywords can be used when they are escaped with backticks