### PR TITLE
Update SecurityController.php

### DIFF
--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -60,6 +60,7 @@ class SecurityController extends Controller
         }
 
         return $this->renderLogin(array(
+            'request' => $request,
             'last_username' => $lastUsername,
             'error' => $error,
             'csrf_token' => $csrfToken,


### PR DESCRIPTION
As of Symfony 2.7 getting the Request from DI (`$this->get('request')`) is deprecated. The only way to acquire it is a typehinted parameter.
Because of this reason if you need the request in `renderLogin`, you will have to get it as an argument, you cannot use DI anymore.