### PR TITLE
Fixed syntax error in the doc

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -58,20 +58,20 @@ Step 2: Enable the bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Enable the bundle in the kernel:
+ 
+.. code-block:: php
+   
+    <?php
+    // app/AppKernel.php
 
-``` php
-<?php
-// app/AppKernel.php
-
-public function registerBundles()
-{
-    $bundles = array(
-        // ...
-        new FOS\UserBundle\FOSUserBundle(),
-        // ...
-    );
-}
-```
+    public function registerBundles() 
+    {
+        $bundles = array(
+            // ...
+            new FOS\UserBundle\FOSUserBundle(),
+            // ...
+        );
+    }
 
 Step 3: Create your User class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -57,9 +57,7 @@ Composer will install the bundle to your project's ``vendor/friendsofsymfony/use
 Step 2: Enable the bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enable the bundle in the kernel:
- 
-.. code-block:: php
+Enable the bundle in the kernel::
    
     <?php
     // app/AppKernel.php


### PR DESCRIPTION
Fixed syntax error which was blocking preview generation. 
Error was due to migration form md to rst.