### PR TITLE
Set non-default User entity properties within fos:user:create command

### DIFF
--- a/Command/CreateUserCommand.php
+++ b/Command/CreateUserCommand.php
@@ -38,6 +38,7 @@ class CreateUserCommand extends ContainerAwareCommand
                 new InputArgument('password', InputArgument::REQUIRED, 'The password'),
                 new InputOption('super-admin', null, InputOption::VALUE_NONE, 'Set the user as super admin'),
                 new InputOption('inactive', null, InputOption::VALUE_NONE, 'Set the user as inactive'),
+                new InputOption('property', null, InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'Set user property value'),
             ))
             ->setHelp(<<<EOT
 The <info>fos:user:create</info> command creates a user:
@@ -72,9 +73,12 @@ EOT
         $password   = $input->getArgument('password');
         $inactive   = $input->getOption('inactive');
         $superadmin = $input->getOption('super-admin');
+        $properties = $input->getOption('property');
+
+        $userproperties = $this->extractUserProperties($properties);
 
         $manipulator = $this->getContainer()->get('fos_user.util.user_manipulator');
-        $manipulator->create($username, $password, $email, !$inactive, $superadmin);
+        $manipulator->create($username, $password, $email, !$inactive, $superadmin, $userproperties);
 
         $output->writeln(sprintf('Created user <comment>%s</comment>', $username));
     }
@@ -128,5 +132,58 @@ EOT
             );
             $input->setArgument('password', $password);
         }
+    }
+
+    /**
+     * Extracts the name, type and value from an array containing string with "name(type)=value" format. Type is string
+     * if no type supplied.
+     *
+     * @param $properties
+     *
+     * @return array
+     */
+    private function extractUserProperties($properties)
+    {
+        $userproperties = array();
+        foreach($properties as $property) {
+            $parts = explode('=', $property, 2);
+            if(!empty($parts)) {
+                // Get the property type
+                $type = 'string';
+                $matches = array();
+                preg_match('~\((.*?)\)~', $parts[0], $matches);
+                if (!empty($matches) && 2 === count($matches)) {
+                    $validTypes = array(
+                        'null',
+                        'bool',
+                        'boolean',
+                        'int',
+                        'integer',
+                        'float',
+                    );
+                    if (in_array($matches[1], $validTypes)) {
+                        $type = $matches[1];
+                    }
+                }
+
+                // Get the property name and translate it to a setter
+                $method = null;
+                $nameParts = explode('(', $parts[0], 2);
+                if (!empty($nameParts)) {
+                    $method = $nameParts[0];
+                } else {
+                    $method = $parts[0];
+                }
+                $method = 'set' . ucwords($method);
+
+                // Get the property value
+                $value = $parts[1];
+                settype($value, $type);
+
+                $userproperties[$method] = $value;
+            }
+        }
+
+        return $userproperties;
     }
 }

--- a/Util/UserManipulator.php
+++ b/Util/UserManipulator.php
@@ -42,10 +42,11 @@ class UserManipulator
      * @param string  $email
      * @param Boolean $active
      * @param Boolean $superadmin
+     * @param array   $userproperties
      *
      * @return \FOS\UserBundle\Model\UserInterface
      */
-    public function create($username, $password, $email, $active, $superadmin)
+    public function create($username, $password, $email, $active, $superadmin, $userproperties = null)
     {
         $user = $this->userManager->createUser();
         $user->setUsername($username);
@@ -53,6 +54,13 @@ class UserManipulator
         $user->setPlainPassword($password);
         $user->setEnabled((Boolean) $active);
         $user->setSuperAdmin((Boolean) $superadmin);
+        if(!is_null($userproperties) && is_array($userproperties) && count($userproperties) > 0) {
+            foreach($userproperties as $method => $value) {
+                if (method_exists($user, $method)) {
+                    $user->{$method}($value);
+                }
+            }
+        }
         $this->userManager->updateUser($user);
 
         return $user;


### PR DESCRIPTION
I have a User entity that extends `FOS\UserBundle\Model\User` that has some mandatory properties (lastname, license status, etc.) for the ORM. As expected when running the `fos:user:create` command always gives me a `SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'xxxxxx' cannot be null` error. I though a way to set non-default properties could be useful.

I've created this "proof of concept" pull request just to ask all of you if the this feature should be further discussed or just forget it as no good/no usefull. Please **don't judge the code quality** as I know it most probably has bad code and bad practices in it.

This is an example of how I'm using it right now:

```
php app/console fos:user:create enekochan enekochan@domain.com password --property="name=Eneko" --property="lastname1=Chan" --property="licenseStatus(int)=1"
```

The idea is to set as many as --property options needed on the command, each one having a string in the format "name(type)=value". The name would be used to access the setter method and type would be used to cast the value.
