### PR TITLE
Fixed semantical error in invitation example

### DIFF
--- a/Resources/doc/adding_invitation_registration.rst
+++ b/Resources/doc/adding_invitation_registration.rst
@@ -214,7 +214,7 @@ Create the custom data transformer::
             $dql = <<<DQL
     SELECT i
     FROM AppBundle:Invitation i
-    WHERE code = :code
+    WHERE i.code = :code
     AND NOT EXISTS(SELECT 1 FROM AppBundle:User u WHERE u.invitation = i)
     DQL;
 


### PR DESCRIPTION
This fixes the DQL used to look up invitation codes. Without using the table prefix, Doctrine will throw a semantical error.