### PR TITLE
use a stable release of symfony 2.7 in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.6.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.7.*@dev
+      env: SYMFONY_VERSION=2.7.*
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*@dev
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
   allow_failures:
     - php: hhvm
     - php: nightly
-    - env: SYMFONY_VERSION=2.7.*@dev
     - env: SYMFONY_VERSION=2.8.*@dev
     - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 


### PR DESCRIPTION
since symfony 2.7 has a stable release now, travis should test the bundle with the stable symfony 2.7