### PR TITLE
The user ID is not always an integer number

### DIFF
--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -65,7 +65,7 @@ class UserProvider implements UserProviderInterface
         }
 
         if (null === $reloadedUser = $this->userManager->findUserBy(array('id' => $user->getId()))) {
-            throw new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $user->getId()));
+            throw new UsernameNotFoundException(sprintf('User with ID "%s" could not be reloaded.', $user->getId()));
         }
 
         return $reloadedUser;


### PR DESCRIPTION
Inside the `refreshUser` method, the message for the `UsernameNotFoundException` assumes that the user ID is a number but this is not true (for example, I'm using `Rhumsaa\Uuid\Uuid`).