### PR TITLE
Update polish translation for password reset email subject

### DIFF
--- a/Resources/translations/FOSUserBundle.pl.yml
+++ b/Resources/translations/FOSUserBundle.pl.yml
@@ -66,7 +66,7 @@ resetting:
     flash:
         success: Hasło zostało zresetowane
     email:
-        subject: Witaj %username%!
+        subject: Resetowanie hasła
         message: |
             Cześć %username%!
 


### PR DESCRIPTION
Translation for polish subject of reset password email unified with other languagues translations (proper phrase and removed username param)