### PR TITLE
Fix incorrect doc statement about SQL keyword usage

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -173,7 +173,7 @@ start:
 
 .. caution::
 
-    ``user`` is a reserved keyword in SQL so you cannot use it as table name.
+    ``user`` is a reserved keyword in the SQL standard. If you need to use reserved words, surround them with backticks, *e.g.* ``@ORM\Table(name="`user`")``
 
 b) MongoDB User class
 .....................


### PR DESCRIPTION
The note states that reserved keywords cannot be used.
This is not true, since
1) not all keywords are implemented by all vendors. For example, "user" is not a keyword in MySQL
2) keywords can be used when they are escaped with backticks