### PR TITLE
Deprecated `expired` and `credentialsExpired`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-### 2.0.0 (2015-XX-XX)
+### 2.0.0-alpha2 (2015-XX-XX)
 
 * [BC break] The deprecated entity classes have been removed.
 * The minimum requirement for Symfony has been bumped to 2.3 (older versions are already EOLed).
@@ -11,6 +11,8 @@ Changelog
 * [BC break] The templating engine configuration has been removed, as well as the related code.
 * [BC break] Changed the XML namespace to `http://friendsofsymfony.github.io/schema/dic/user`
 * [BC break] Added `UserInterface::getId`.
+* [BC break] Removed unused properties `expired` and `credentialsExpired` including corresponding methods. This may break code,
+  makes use of this methods, extending classes, and/or existing installations because of missing mappings for required db fields.
 
 ### 2.0.0-alpha1 (2014-09-26)
 

--- a/Model/User.php
+++ b/Model/User.php
@@ -98,11 +98,6 @@ abstract class User implements UserInterface, GroupableInterface
     protected $locked;
 
     /**
-     * @var boolean
-     */
-    protected $expired;
-
-    /**
      * @var \DateTime
      */
     protected $expiresAt;
@@ -111,11 +106,6 @@ abstract class User implements UserInterface, GroupableInterface
      * @var array
      */
     protected $roles;
-
-    /**
-     * @var boolean
-     */
-    protected $credentialsExpired;
 
     /**
      * @var \DateTime
@@ -127,9 +117,7 @@ abstract class User implements UserInterface, GroupableInterface
         $this->salt = base_convert(sha1(uniqid(mt_rand(), true)), 16, 36);
         $this->enabled = false;
         $this->locked = false;
-        $this->expired = false;
         $this->roles = array();
-        $this->credentialsExpired = false;
     }
 
     public function addRole($role)
@@ -161,9 +149,7 @@ abstract class User implements UserInterface, GroupableInterface
             $this->salt,
             $this->usernameCanonical,
             $this->username,
-            $this->expired,
             $this->locked,
-            $this->credentialsExpired,
             $this->enabled,
             $this->id,
             $this->expiresAt,
@@ -190,9 +176,7 @@ abstract class User implements UserInterface, GroupableInterface
             $this->salt,
             $this->usernameCanonical,
             $this->username,
-            $this->expired,
             $this->locked,
-            $this->credentialsExpired,
             $this->enabled,
             $this->id,
             $this->expiresAt,
@@ -311,10 +295,6 @@ abstract class User implements UserInterface, GroupableInterface
 
     public function isAccountNonExpired()
     {
-        if (true === $this->expired) {
-            return false;
-        }
-
         if (null !== $this->expiresAt && $this->expiresAt->getTimestamp() < time()) {
             return false;
         }
@@ -329,10 +309,6 @@ abstract class User implements UserInterface, GroupableInterface
 
     public function isCredentialsNonExpired()
     {
-        if (true === $this->credentialsExpired) {
-            return false;
-        }
-
         if (null !== $this->credentialsExpireAt && $this->credentialsExpireAt->getTimestamp() < time()) {
             return false;
         }
@@ -340,19 +316,9 @@ abstract class User implements UserInterface, GroupableInterface
         return true;
     }
 
-    public function isCredentialsExpired()
-    {
-        return !$this->isCredentialsNonExpired();
-    }
-
     public function isEnabled()
     {
         return $this->enabled;
-    }
-
-    public function isExpired()
-    {
-        return !$this->isAccountNonExpired();
     }
 
     public function isLocked()
@@ -401,18 +367,6 @@ abstract class User implements UserInterface, GroupableInterface
         return $this;
     }
 
-    /**
-     * @param boolean $boolean
-     *
-     * @return User
-     */
-    public function setCredentialsExpired($boolean)
-    {
-        $this->credentialsExpired = $boolean;
-
-        return $this;
-    }
-
     public function setEmail($email)
     {
         $this->email = $email;
@@ -430,20 +384,6 @@ abstract class User implements UserInterface, GroupableInterface
     public function setEnabled($boolean)
     {
         $this->enabled = (Boolean) $boolean;
-
-        return $this;
-    }
-
-    /**
-     * Sets this user to expired.
-     *
-     * @param Boolean $boolean
-     *
-     * @return User
-     */
-    public function setExpired($boolean)
-    {
-        $this->expired = (Boolean) $boolean;
 
         return $this;
     }

--- a/Propel/User.php
+++ b/Propel/User.php
@@ -44,9 +44,7 @@ class User extends BaseUser implements UserInterface, GroupableInterface
                 $this->username,
                 $this->salt,
                 $this->password,
-                $this->expired,
                 $this->locked,
-                $this->credentials_expired,
                 $this->enabled,
                 $this->_new,
             )
@@ -69,9 +67,7 @@ class User extends BaseUser implements UserInterface, GroupableInterface
             $this->username,
             $this->salt,
             $this->password,
-            $this->expired,
             $this->locked,
-            $this->credentials_expired,
             $this->enabled,
             $this->_new
         ) = $data;
@@ -167,10 +163,6 @@ class User extends BaseUser implements UserInterface, GroupableInterface
      */
     public function isAccountNonExpired()
     {
-        if (true === $this->getExpired()) {
-            return false;
-        }
-
         if (null !== $this->getExpiresAt() && $this->getExpiresAt()->getTimestamp() < time()) {
             return false;
         }
@@ -191,10 +183,6 @@ class User extends BaseUser implements UserInterface, GroupableInterface
      */
     public function isCredentialsNonExpired()
     {
-        if (true === $this->getCredentialsExpired()) {
-            return false;
-        }
-
         if (null !== $this->getCredentialsExpireAt() && $this->getCredentialsExpireAt()->getTimestamp() < time()) {
             return false;
         }

--- a/Resources/config/doctrine-mapping/User.couchdb.xml
+++ b/Resources/config/doctrine-mapping/User.couchdb.xml
@@ -12,7 +12,6 @@
         <field name="password" fieldName="password" type="string" />
         <field name="lastLogin" fieldName="lastLogin" type="datetime" />
         <field name="locked" fieldName="locked" type="mixed" />
-        <field name="expired" fieldName="expired" type="mixed" />
         <field name="expiresAt" fieldName="expiresAt" type="datetime" />
         <field name="confirmationToken" fieldName="confirmationToken" type="string" />
         <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="datetime" />

--- a/Resources/config/doctrine-mapping/User.mongodb.xml
+++ b/Resources/config/doctrine-mapping/User.mongodb.xml
@@ -24,8 +24,6 @@
 
         <field name="locked" fieldName="locked" type="boolean" />
 
-        <field name="expired" fieldName="expired" type="boolean" />
-
         <field name="expiresAt" fieldName="expiresAt" type="date" />
 
         <field name="confirmationToken" fieldName="confirmationToken" type="string" />
@@ -33,8 +31,6 @@
         <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="date" />
 
         <field name="roles" fieldName="roles" type="collection" />
-
-        <field name="credentialsExpired" fieldName="credentialsExpired" type="boolean" />
 
         <field name="credentialsExpireAt" fieldName="credentialsExpireAt" type="date" />
         <indexes>

--- a/Resources/config/doctrine-mapping/User.orm.xml
+++ b/Resources/config/doctrine-mapping/User.orm.xml
@@ -24,8 +24,6 @@
 
         <field name="locked" column="locked" type="boolean" />
 
-        <field name="expired" column="expired" type="boolean" />
-
         <field name="expiresAt" column="expires_at" type="datetime" nullable="true" />
 
         <field name="confirmationToken" column="confirmation_token" type="string" nullable="true" />
@@ -33,8 +31,6 @@
         <field name="passwordRequestedAt" column="password_requested_at" type="datetime" nullable="true" />
 
         <field name="roles" column="roles" type="array" />
-
-        <field name="credentialsExpired" column="credentials_expired" type="boolean" />
 
         <field name="credentialsExpireAt" column="credentials_expire_at" type="datetime" nullable="true" />
 

--- a/Resources/config/propel/schema.xml
+++ b/Resources/config/propel/schema.xml
@@ -20,11 +20,9 @@
         <column name="password" type="varchar" size="255" required="true" />
         <column name="last_login" type="timestamp" required="false" />
         <column name="locked" type="boolean" defaultValue="false" />
-        <column name="expired" type="boolean" defaultValue="false" />
         <column name="expires_at" type="timestamp" required="false" />
         <column name="confirmation_token" type="varchar" size="255" required="false" />
         <column name="password_requested_at" type="timestamp" required="false" />
-        <column name="credentials_expired" type="boolean" defaultValue="false" />
         <column name="credentials_expire_at" type="timestamp" required="false" />
         <column name="roles" type="array" />
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -4,6 +4,18 @@ Upgrade instruction
 This document describes the changes needed when upgrading because of a BC
 break. For the full list of changes, please look at the Changelog file.
 
+## 2.0-alpha1 to 2.0.0-alpha2
+
+Methods and properties removed from `FOS\UserBundle\Model\User`
+
+- `$expired`
+- `$credentialsExpired`
+- `setExpired()` (use `setExpireAt(\DateTime::now()` instead)
+- `setCredentialsExpired()` (use `setCredentialsExpireAt(\DateTime::now()` instead)
+
+You need to drop the fields `expired` and `credentials_expired` from your database
+schema, because they aren't mapped anymore.
+
 ## 1.3 to 2.0-alpha1
 
 ### User Provider


### PR DESCRIPTION
Replaces https://github.com/FriendsOfSymfony/FOSUserBundle/pull/1751