### PR TITLE
Pass missing parameter to "trans" function.

### DIFF
--- a/Resources/views/Resetting/email.txt.twig
+++ b/Resources/views/Resetting/email.txt.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'FOSUserBundle' %}
 {% block subject %}
 {% autoescape false %}
-{{ 'resetting.email.subject'|trans }}
+{{ 'resetting.email.subject'|trans({'%username%': user.username}) }}
 {% endautoescape %}
 {% endblock %}
 {% block body_text %}


### PR DESCRIPTION
`resetting.email.subject` translation requires `%username%` being passed.