### PR TITLE
Fixed registration form throwing error on Symfony 2.7.4 

### DIFF
--- a/Resources/views/Registration/register_content.html.twig
+++ b/Resources/views/Registration/register_content.html.twig
@@ -1,8 +1,8 @@
 {% trans_default_domain 'FOSUserBundle' %}
 
-<form action="{{ path('fos_user_registration_register') }}" {{ form_enctype(form) }} method="POST" class="fos_user_registration_register">
+{{ form_start(form, {'method': 'post', 'action': path('fos_user_registration_register'), 'attr': {'class': 'fos_user_registration_register'}}) }}
     {{ form_widget(form) }}
     <div>
         <input type="submit" value="{{ 'registration.submit'|trans }}" />
     </div>
-</form>
+{{ form_end(form) }}


### PR DESCRIPTION
Deprecated form variable (as of Symfony 2.3) `{{ form_enctype(form) }}` was causing the registration page to throw an error on Symfony 2.7.4.  Updated the registration template to fit current best practices.