### PR TITLE
Add a generic listener capable of supplying RedirectResponses for the FormEvent events

### DIFF
--- a/EventListener/RedirectListener.php
+++ b/EventListener/RedirectListener.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\EventListener;
+
+use FOS\UserBundle\Event\FormEvent;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Redirect to a custom URL in response to FormEvent dispatches.
+ */
+class RedirectListener
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var string
+     */
+    private $route;
+
+    /**
+     * @param RouterInterface $router
+     * @param string $route
+     */
+    public function __construct(RouterInterface $router, $route)
+    {
+        $this->router = $router;
+        $this->route = $route;
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    public function redirect(FormEvent $event)
+    {
+        $event->setResponse(new RedirectResponse($this->router->generate($this->route)));
+    }
+}

--- a/Tests/EventListener/RedirectListenerTest.php
+++ b/Tests/EventListener/RedirectListenerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace FOS\UserBundle\Tests\EventListener;
+
+use FOS\UserBundle\EventListener\RedirectListener;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\RouterInterface;
+
+class RedirectListenerTest extends \PHPUnit_Framework_TestCase
+{
+    const ROUTE_NAME = 'foo';
+    const ROUTE_URL = 'http://www.example.com';
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var RedirectListener
+     */
+    private $listener;
+
+    public function setUp()
+    {
+        $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $this->router
+            ->expects($this->once())
+            ->method('generate')
+            ->with(self::ROUTE_NAME)
+            ->willReturn(self::ROUTE_URL);
+
+        $this->listener = new RedirectListener($this->router, self::ROUTE_NAME);
+    }
+
+    public function testRedirect()
+    {
+        $event = $this->getMockBuilder('FOS\UserBundle\Event\FormEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event
+            ->expects($this->once())
+            ->method('setResponse')
+            ->with(new RedirectResponse(self::ROUTE_URL));
+
+        $this->listener->redirect($event);
+    }
+}


### PR DESCRIPTION
I've used this in a couple of projects now, and it seems to be the kind of thing that could go into the bundle itself. It basically provides a quick and generic way to return a RedirectResponse to the bundle's controllers.

If this is acceptable, I'll adapt the docs accordingly.