### PR TITLE
Add Event Dispatch on Authentication Failure

### DIFF
--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -11,6 +11,8 @@
 
 namespace FOS\UserBundle\Controller;
 
+use FOS\UserBundle\Event\LoginErrorEvent;
+use FOS\UserBundle\FOSUserEvents;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Security;
@@ -43,7 +45,15 @@ class SecurityController extends Controller
             $error = null;
         }
 
-        if (!$error instanceof AuthenticationException) {
+        if ($error instanceof AuthenticationException) {
+            $event = new LoginErrorEvent($error, $request);
+
+            $this->get('event_dispatcher')->dispatch(FOSUserEvents::SECURITY_FAILED_LOGIN, $event);
+
+            if (null !== $event->getResponse()) {
+                return $event->getResponse();
+            }
+        } else {
             $error = null; // The value does not come from the security component.
         }
 

--- a/Event/LoginErrorEvent.php
+++ b/Event/LoginErrorEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+class LoginErrorEvent extends Event
+{
+    private $exception;
+    private $request;
+    private $response;
+
+    public function __construct(AuthenticationException $exception, Request $request)
+    {
+        $this->exception = $exception;
+        $this->request = $request;
+    }
+
+    /**
+     * @return AuthenticationException
+     */
+    public function getException()
+    {
+        return $this->exception;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/FOSUserEvents.php
+++ b/FOSUserEvents.php
@@ -191,4 +191,12 @@ final class FOSUserEvents
      * The event listener method receives a FOS\UserBundle\Event\UserEvent instance.
      */
     const SECURITY_IMPLICIT_LOGIN = 'fos_user.security.implicit_login';
+
+    /**
+     * The SECURITY_FAILED_LOGIN event occurs whenever a login attempt fails.
+     *
+     * The event allows you to access the exception and set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\LoginErrorEvent instance.
+     */
+    const SECURITY_FAILED_LOGIN = 'fos_user.security.failed_login';
 }


### PR DESCRIPTION
Trigger an event in the SecurityController's loginAction whenever an
AuthenticationException is present. The Request and Error are passed to
the listener. The listener has the option to pass back a response which
overrides the default response returned by the Controller.