### PR TITLE
Fix Canonicalizer with illegal chars

### DIFF
--- a/Tests/Util/CanonicalizerTest.php
+++ b/Tests/Util/CanonicalizerTest.php
@@ -28,7 +28,7 @@ class CanonicalizerTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('FOO', 'foo'),
-            array(chr(171), '?'),
+            array(chr(171), PHP_VERSION_ID < 50600 ? chr(171) : '?'),
         );
     }
 }

--- a/Tests/Util/CanonicalizerTest.php
+++ b/Tests/Util/CanonicalizerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Tests\Util;
+
+use FOS\UserBundle\Util\Canonicalizer;
+
+class CanonicalizerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider canonicalizeProvider
+     */
+    public function testCanonicalize($source, $expectedResult)
+    {
+        $canonicalizer = new Canonicalizer();
+        $this->assertEquals($expectedResult, $canonicalizer->canonicalize($source));
+    }
+
+    public function canonicalizeProvider()
+    {
+        return array(
+            array('FOO', 'foo'),
+            array(chr(171), '?'),
+        );
+    }
+}

--- a/Util/Canonicalizer.php
+++ b/Util/Canonicalizer.php
@@ -13,8 +13,16 @@ namespace FOS\UserBundle\Util;
 
 class Canonicalizer implements CanonicalizerInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function canonicalize($string)
     {
-        return mb_convert_case($string, MB_CASE_LOWER, mb_detect_encoding($string));
+        $encoding = mb_detect_encoding($string);
+        $result = $encoding
+            ? mb_convert_case($string, MB_CASE_LOWER, $encoding)
+            : mb_convert_case($string, MB_CASE_LOWER);
+
+        return $result;
     }
 }


### PR DESCRIPTION
When pass illegal chars into `canonicalize` method, `mb_detect_encoding` returns false and `mb_convert_case` throws warning: `mb_convert_case(): Unknown encoding ""`