### PR TITLE
Updated translation for 'Bad credentials.' message

### DIFF
--- a/Resources/translations/FOSUserBundle.bg.yml
+++ b/Resources/translations/FOSUserBundle.bg.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Невалидно потребителско име или парола
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Невалидно потребителско име или парола.
+
 security:
     login:
         username: Потребителско име

--- a/Resources/translations/FOSUserBundle.cs.yml
+++ b/Resources/translations/FOSUserBundle.cs.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Neplatné přihlašovací údaje
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Neplatné přihlašovací údaje.
+
 security:
     login:
         username: Uživatelské jméno

--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Benutzername oder Passwort ungültig
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Benutzername oder Passwort ungültig.
+
 security:
     login:
         username: Benutzername

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Invalid username or password
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Invalid username or password.
+
 security:
     login:
         username: Username

--- a/Resources/translations/FOSUserBundle.es.yml
+++ b/Resources/translations/FOSUserBundle.es.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Nombre de usuario o Contraseña inválido
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Nombre de usuario o Contraseña inválido.
+
 security:
     login:
         username: Nombre de usuario

--- a/Resources/translations/FOSUserBundle.fa.yml
+++ b/Resources/translations/FOSUserBundle.fa.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": نام کاربری یا کلمه عبور غیر مجاز
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": نام کاربری یا کلمه عبور غیر مجاز.
+
 security:
     login:
         username: نام کاربری

--- a/Resources/translations/FOSUserBundle.fi.yml
+++ b/Resources/translations/FOSUserBundle.fi.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Epäkelpo käyttäjätunnus tai salasana
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Epäkelpo käyttäjätunnus tai salasana.
+
 security:
     login:
         username: Käyttäjätunnus

--- a/Resources/translations/FOSUserBundle.fr.yml
+++ b/Resources/translations/FOSUserBundle.fr.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Nom d'utilisateur ou mot de passe incorrect
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Nom d'utilisateur ou mot de passe incorrect.
+
 security:
     login:
         username: Nom d'utilisateur

--- a/Resources/translations/FOSUserBundle.hr.yml
+++ b/Resources/translations/FOSUserBundle.hr.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Krivo korisničko ime ili lozinka
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Krivo korisničko ime ili lozinka.
+
 security:
     login:
         username: Korisničko ime

--- a/Resources/translations/FOSUserBundle.hu.yml
+++ b/Resources/translations/FOSUserBundle.hu.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": "Helytelen felhasználónév vagy jelszó"
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": "Helytelen felhasználónév vagy jelszó."
+
 security:
     login:
         username: Felhasználónév

--- a/Resources/translations/FOSUserBundle.ja.yml
+++ b/Resources/translations/FOSUserBundle.ja.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": ユーザ名またはパスワードが間違っています
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": ユーザ名またはパスワードが間違っています。
+
 security:
     login:
         username: ユーザー名

--- a/Resources/translations/FOSUserBundle.lt.yml
+++ b/Resources/translations/FOSUserBundle.lt.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Neteisingas naudotojas arba slaptažodis
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Neteisingas naudotojas arba slaptažodis.
+
 security:
     login:
         username: Naudotojas

--- a/Resources/translations/FOSUserBundle.lv.yml
+++ b/Resources/translations/FOSUserBundle.lv.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Nederīgs lietotājvārds vai parole
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Nederīgs lietotājvārds vai parole.
+
 security:
     login:
         username: Lietotājvārds

--- a/Resources/translations/FOSUserBundle.nl.yml
+++ b/Resources/translations/FOSUserBundle.nl.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Gebruikersnaam of wachtwoord ongeldig
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Gebruikersnaam of wachtwoord ongeldig.
+
 security:
     login:
         username: Gebruikersnaam

--- a/Resources/translations/FOSUserBundle.pl.yml
+++ b/Resources/translations/FOSUserBundle.pl.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Nieprawidłowa nazwa użytkownika lub hasło
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Nieprawidłowa nazwa użytkownika lub hasło.
+
 security:
     login:
         username: Nazwa użytkownika

--- a/Resources/translations/FOSUserBundle.pt_BR.yml
+++ b/Resources/translations/FOSUserBundle.pt_BR.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Usuário ou senha inválida
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Usuário ou senha inválida.
+
 security:
     login:
         username: Usuário

--- a/Resources/translations/FOSUserBundle.ru.yml
+++ b/Resources/translations/FOSUserBundle.ru.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Неправильное имя пользователя или пароль
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Неправильное имя пользователя или пароль.
+
 security:
     login:
         username: Имя пользователя

--- a/Resources/translations/FOSUserBundle.sl.yml
+++ b/Resources/translations/FOSUserBundle.sl.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Napačno uporabniško ime ali geslo
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Napačno uporabniško ime ali geslo.
+
 security:
     login:
         username: Uporabniško ime

--- a/Resources/translations/FOSUserBundle.sr_Latn.yml
+++ b/Resources/translations/FOSUserBundle.sr_Latn.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Nevalidno korisničko ime ili lozinka
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Nevalidno korisničko ime ili lozinka.
+
 security:
     login:
         username: Korisničko ime

--- a/Resources/translations/FOSUserBundle.tr.yml
+++ b/Resources/translations/FOSUserBundle.tr.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": Geçersiz kullanıcı adı ya da parola
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": Geçersiz kullanıcı adı ya da parola.
+
 security:
     login:
         username: Kullanıcı adı

--- a/Resources/translations/FOSUserBundle.uk.yml
+++ b/Resources/translations/FOSUserBundle.uk.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": "Невірне ім'я користувача або пароль"
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": "Невірне ім'я користувача або пароль."
+
 security:
     login:
         username: Ім'я користувача

--- a/Resources/translations/FOSUserBundle.zh_CN.yml
+++ b/Resources/translations/FOSUserBundle.zh_CN.yml
@@ -14,6 +14,9 @@ group:
 # Security
 "Bad credentials": 用户名或密码不正确
 
+# Since Symfony 2.6 the error message has changed
+"Bad credentials.": 用户名或密码不正确。
+
 security:
     login:
         username: 用户名

--- a/Resources/translations/FOSUserBundle.zh_CN.yml
+++ b/Resources/translations/FOSUserBundle.zh_CN.yml
@@ -16,8 +16,8 @@ group:
 
 security:
     login:
-        username: 用户名：
-        password: 密码：
+        username: 用户名
+        password: 密码
         remember_me: 自动登录
         submit: 登录
 
@@ -61,7 +61,7 @@ resetting:
     check_email: 系统向%email%发送了一封包含密码重置链接的邮件，请查收。
     request:
         invalid_username: 用户名“%username%”不存在
-        username: 用户名或邮箱：
+        username: 用户名或邮箱
         submit: 重置密码
     reset:
         submit: 修改密码
@@ -86,11 +86,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: 小组名称：
-    username: 用户名：
-    email: 电子邮箱：
-    current_password: 当前密码：
-    password: 密码：
-    password_confirmation: 确认密码：
-    new_password: 新密码：
-    new_password_confirmation: 确认新密码：
+    group_name: 小组名称
+    username: 用户名
+    email: 电子邮箱
+    current_password: 当前密码
+    password: 密码
+    password_confirmation: 确认密码
+    new_password: 新密码
+    new_password_confirmation: 确认新密码


### PR DESCRIPTION
Source string has been changed https://github.com/symfony/security-core/commit/f4e65fb1d5cca6057c3111784df733d0f04517f4