### PR TITLE
Fixed doc issues

### DIFF
--- a/Resources/doc/form_type.rst
+++ b/Resources/doc/form_type.rst
@@ -3,9 +3,7 @@ The username Form Type
 
 FOSUserBundle provides a convenient username form type, named ``fos_user_username``.
 It appears as a text input, accepts usernames and convert them to a User
-instance.
-
-.. code-block::
+instance::
 
     class MessageFormType extends AbstractType
     {

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -469,21 +469,24 @@ of the bundle.
 
 The following documents are available:
 
-- :doc:`/overriding_templates`
-- :doc:`/overriding_controllers`
-- :doc:`/overriding_forms`
-- :doc:`/user_manager`
-- :doc:`/command_line_tools`
-- :doc:`/logging_by_username_or_email`
-- :doc:`/form_type`
-- :doc:`/emails`
-- :doc:`/groups`
-- :doc:`/doctrine`
-- :doc:`/overriding_validation`
-- :doc:`/canonicalizer`
-- :doc:`/custom_storage_layer`
-- :doc:`/configuration_reference`
-- :doc:`/adding_invitation_registration`
+.. toctree::
+    :maxdepth: 1
+
+    overriding_templates
+    overriding_controllers
+    overriding_forms
+    user_manager
+    command_line_tools
+    logging_by_username_or_email
+    form_type
+    emails
+    groups
+    doctrine
+    overriding_validation
+    canonicalizer
+    custom_storage_layer
+    configuration_reference
+    adding_invitation_registration
 
 .. _security component documentation: https://symfony.com/doc/current/book/security.html
 .. _Symfony documentation: https://symfony.com/doc/current/book/translation.html


### PR DESCRIPTION
This PR tries to fix the errors reported by our doc build tool:

```
form_type.rst:8: ERROR: Error in "code-block" directive:
1 argument(s) required, 0 supplied.
.. code-block::
    class MessageFormType extends AbstractType
    {
        public function buildForm(FormBuilderInterface $builder, array $options)
        {
            $builder->add('recipient', 'fos_user_username');
        }
    }
adding_invitation_registration.rst:: WARNING: document isn't included in any toctree
canonicalizer.rst:: WARNING: document isn't included in any toctree
command_line_tools.rst:: WARNING: document isn't included in any toctree
configuration_reference.rst:: WARNING: document isn't included in any toctree
custom_storage_layer.rst:: WARNING: document isn't included in any toctree
doctrine.rst:: WARNING: document isn't included in any toctree
emails.rst:: WARNING: document isn't included in any toctree
form_type.rst:: WARNING: document isn't included in any toctree
groups.rst:: WARNING: document isn't included in any toctree
logging_by_username_or_email.rst:: WARNING: document isn't included in any toctree
overriding_controllers.rst:: WARNING: document isn't included in any toctree
overriding_forms.rst:: WARNING: document isn't included in any toctree
overriding_templates.rst:: WARNING: document isn't included in any toctree
overriding_validation.rst:: WARNING: document isn't included in any toctree
user_manager.rst:: WARNING: document isn't included in any toctree
```