### PR TITLE
Update groups.rst

### DIFF
--- a/Resources/doc/groups.rst
+++ b/Resources/doc/groups.rst
@@ -64,7 +64,7 @@ a) ORM Group class implementation
 
         namespace MyProject\MyBundle\Entity;
 
-        use FOS\UserBundle\Model\Group as BaseGroup;
+        use FOS\UserBundle\Entity\Group as BaseGroup;
         use Doctrine\ORM\Mapping as ORM;
 
         /**


### PR DESCRIPTION
The extension of the Group from the FOSBundle must be from the Entity, not from the Model. If you extend the model, the required fields "name" and "roles" will not be created in the database. Took me an hour to find this error, I hope it can be changed soon.