### PR TITLE
Adjustments for Danish translation

### DIFF
--- a/Resources/translations/FOSUserBundle.da.yml
+++ b/Resources/translations/FOSUserBundle.da.yml
@@ -15,7 +15,7 @@ group:
 security:
     login:
         username: Brugernavn
-        password: Kodeord
+        password: Adgangskode
         remember_me: Husk mig
         submit: Log ind
 
@@ -23,7 +23,7 @@ security:
 profile:
     show:
         username: Brugernavn
-        email: Email
+        email: E-mail
     edit:
         submit: Opdater
     flash:
@@ -31,13 +31,13 @@ profile:
 
 # Password change
 change_password:
-    submit: Skift kodeord
+    submit: Skift adgangskode
     flash:
-        success: Kodeordet er blevet opdateret
+        success: Adgangskoden er blevet opdateret
 
 # Registration
 registration:
-    check_email: En email er blevet sendt til %email%. Den indeholder et aktiveringslink du skal bruge for at aktivere din konto.
+    check_email: En e-mail er blevet sendt til %email%. Den indeholder et aktiveringslink, du skal følge for at aktivere din konto.
     confirmed: Tillykke %username%, din konto er nu aktiveret
     #back: Back to the originating page.
     submit: Registrer
@@ -48,29 +48,29 @@ registration:
         message: |
             Hej %username%!
 
-            For at færdiggøre valideringen af din konto, besøg venligst %confirmationUrl%
+            For at færdiggøre aktiveringen af din konto, besøg venligst %confirmationUrl%
 
             Venlig hilsen,
             Holdet bag siden.
 
 # Password resetting
 resetting:
-    password_already_requested: Denne brugers kodeord er allerede blevet nulstillet inden for de sidste 24 timer.
-    check_email: En email er blevet sendt til %email%. Den indeholder et link til at nulstille dit kodeord.
+    password_already_requested: Denne brugers adgangskode er allerede blevet nulstillet inden for de sidste 24 timer.
+    check_email: En e-mail er blevet sendt til %email%. Den indeholder et link, du skal følge for at nulstille din adgangskode.
     request:
-        invalid_username: Brugeren "%username" findes ikke
-        username: Brugernavn
-        submit: Nulstil kodeord
+        invalid_username: Brugernavnet eller e-mailadressen "%username" findes ikke.
+        username: Brugernavn eller e-mailadresse
+        submit: Nulstil adgangskode
     reset:
-        submit: Skift kodeord
+        submit: Skift adgangskode
     flash:
-        success: Kodeordet er blevet nulstillet
+        success: Adgangskoden er blevet nulstillet
     email:
         subject: Velkommen %username%!
         message: |
             Hej %username%!
 
-            For at nulstille dit kodeord, besøg venligst %confirmationUrl%
+            For at nulstille din adgangskode, besøg venligst %confirmationUrl%
 
             Venlig hilsen,
             Holdet bag siden.
@@ -84,11 +84,11 @@ layout:
 
 # Form field labels
 form:
-    group_name: Gruppe navn
+    group_name: Gruppenavn
     username: Brugernavn
-    email: Email
-    current_password: Nuværende kodeord
-    password: Kodeord
-    password_confirmation: Gentag kodeord
-    new_password: Nyt kodeord
-    new_password_confirmation: Gentag kodeord
+    email: E-mail
+    current_password: Nuværende adgangskode
+    password: Adgangskode
+    password_confirmation: Gentag adgangskode
+    new_password: Ny adgangskode
+    new_password_confirmation: Gentag adgangskode

--- a/Resources/translations/validators.da.yml
+++ b/Resources/translations/validators.da.yml
@@ -1,24 +1,24 @@
 fos_user:
     username:
-        already_used: Brugernavnet er optaget
+        already_used: Brugernavnet er allerede i brug
         blank: Indtast venligst et brugernavn
-        short: Brugernavnet er for kort
-        long: Brugernavnet er for langt
+        short: [-Inf,Inf]Brugernavnet er for kort"
+        long: [-Inf,Inf]Brugernavnet er for langt"
     email:
-        already_used: E-mail adressen er allerede brugt
-        blank: Indtast venligst en e-mail adresse
-        short: E-mail adressen er for kort
-        long: E-mail adressen er for lang
-        invalid: E-mail adressen er ikke gyldig
+        already_used: E-mailadressen er allerede i brug
+        blank: Indtast venligst en e-mailadresse
+        short: [-Inf,Inf]E-mailadressen er for kort"
+        long: [-Inf,Inf]E-mailadressen er for lang"
+        invalid: E-mailadressen er ikke gyldig
     password:
-        blank: Indtast venligst et kodeord
-        short: Kodeordet er for kort
+        blank: Indtast venligst en adgangskode
+        short: [-Inf,Inf]Adgangskoden er for kort"
     new_password:
-        blank: Indtast venligst et nyt kodeord
-        short: Det nye kodeord er for kort
+        blank: Indtast venligst en ny adgangskode
+        short: [-Inf,Inf]Den nye adgangskode er for kort"
     current_password:
-        invalid: Det indtastede kodeord er forkert
+        invalid: Den indtastede adgangskode er forkert
     group:
         blank: Indtast venligst et navn
-        short: Navnet er for kort
-        long: Navnet er for langt
+        short: [-Inf,Inf]Navnet er for kort"
+        long: [-Inf,Inf]Navnet er for langt"


### PR DESCRIPTION
- Use more widely used "adgangskode" instead of "kodeord". Wikipedia, Facebook, and Twitter all use "adgangskode".
- The official spelling of "[e-mail](http://dsn.dk/?retskriv=email&ae=0)" is with a hyphon.
- Add some missing commas.
- A few adjustments to make the Danish translations match the English more closely.

This PR is identical to PR #2032 but for the 1.3.x branch.