### PR TITLE
Added RESETTING_REQUEST_SUCCESS event

### DIFF
--- a/FOSUserEvents.php
+++ b/FOSUserEvents.php
@@ -161,6 +161,14 @@ final class FOSUserEvents
     const REGISTRATION_CONFIRMED = 'fos_user.registration.confirmed';
 
     /**
+     * The RESETTING_REQUEST_SUCCESS event occurs when the resetting request form is submitted successfully.
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a FOS\UserBundle\Event\GetResponseUserEvent instance.
+     */
+    const RESETTING_REQUEST_SUCCESS = 'fos_user.resetting.request.success';
+
+    /**
      * The RESETTING_RESET_INITIALIZE event occurs when the resetting process is initialized.
      *
      * This event allows you to set the response to bypass the processing.


### PR DESCRIPTION
Hi,

I've noticed that on every project I'm doing, I have to override the resetting controller to do this:

```
$this->addFlash('success', $trans->trans('app.resetting.success'));

return $this->redirectToRoute('fos_user_security_login');
```

Now it would be possible to use an event for this.