### PR TITLE
Harmonize email detection with Symfony's EmailValidator

### DIFF
--- a/Model/UserManager.php
+++ b/Model/UserManager.php
@@ -101,7 +101,7 @@ abstract class UserManager implements UserManagerInterface, UserProviderInterfac
      */
     public function findUserByUsernameOrEmail($usernameOrEmail)
     {
-        if (filter_var($usernameOrEmail, FILTER_VALIDATE_EMAIL)) {
+        if (preg_match('/^.+\@\S+\.\S+$/', $usernameOrEmail)) {
             return $this->findUserByEmail($usernameOrEmail);
         }
 


### PR DESCRIPTION
Harmonize email detection with \Symfony\Component\Validator\Constraints\EmailValidator

As you can see in
https://github.com/symfony/validator/blob/master/Constraints/EmailValidator.php#L72
Symfony's EmailValidator differs from PHP core: https://github.com/php/php-src/blob/master/ext/filter/logical_filters.c#L601

Thus a user registered with one email (may be not valid in terms of RFC) can't login with this email later.

Maybe it will be better to use the EmailValidator class instead of just copy-n-pasting a regexp, but I didn't find a way to use this validator with parameters been set for my application (e.g. in `validation.yml`).