### PR TITLE
Make DB config more flexible

### DIFF
--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -4,8 +4,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="fos_user.user_manager.class">FOS\UserBundle\Doctrine\UserManager</parameter>
+    </parameters>
+
     <services>
-        <service id="fos_user.user_manager.default" class="FOS\UserBundle\Doctrine\UserManager" public="false">
+        <service id="fos_user.user_manager.default" class="%fos_user.user_manager.class%" public="false">
             <argument type="service" id="security.encoder_factory" />
             <argument type="service" id="fos_user.util.username_canonicalizer" />
             <argument type="service" id="fos_user.util.email_canonicalizer" />

--- a/Resources/config/propel.xml
+++ b/Resources/config/propel.xml
@@ -4,8 +4,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="fos_user.user_manager.class">FOS\UserBundle\Propel\UserManager</parameter>
+    </parameters>
+
     <services>
-        <service id="fos_user.user_manager.default" class="FOS\UserBundle\Propel\UserManager" public="false">
+        <service id="fos_user.user_manager.default" class="%fos_user.user_manager.class%" public="false">
             <argument type="service" id="security.encoder_factory" />
             <argument type="service" id="fos_user.util.username_canonicalizer" />
             <argument type="service" id="fos_user.util.email_canonicalizer" />


### PR DESCRIPTION
Simplify `UserManager` overriding.

Without patch I have to write in my `config.yml` this lines:
```
services:
    fos_user.user_manager.default:
        class: Some\Custom\UserManager
        public: false
        arguments:
            - @security.encoder_factory
            - @fos_user.util.username_canonicalizer
            - @fos_user.util.email_canonicalizer
            - @fos_user.entity_manager
            - %fos_user.model.user.class%
```

With this patch, I have only to write this:
```
parameters:
    fos_user.user_manager.class: Some\Custom\UserManager
```