### PR TITLE
Removing extends layout.html.twig in example

### DIFF
--- a/Resources/doc/overriding_templates.rst
+++ b/Resources/doc/overriding_templates.rst
@@ -65,8 +65,6 @@ to override the one provided by the bundle.
 
 .. code-block:: html+jinja
 
-    {% extends 'layout.html.twig' %}
-
     {% block title %}Demo Application{% endblock %}
 
     {% block content %}


### PR DESCRIPTION
The "extends line " fires up an error :

Unable to find template "layout.html.twig" in FOSUserBundle::layout.html.twig at line 1. 

with Symfony 2.8.x LTS and FOSuser 2.x as of 9 March 2016 install.

This is my first try to improve Symfony Documentation, please be gentle ;-)