### PR TITLE
this was just inverted.

### DIFF
--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -76,7 +76,7 @@ class UserProvider implements UserProviderInterface
     {
         $userClass = $this->userManager->getClass();
 
-        return $userClass === $class || is_subclass_of($class, $userClass);
+        return $userClass === $class || is_subclass_of($userClass, $class);
     }
 
     /**


### PR DESCRIPTION
user provider is supposed to support the class passed as parameter if its user manager class is the same or a subclass but the code is inverting the test. it only return true if if the manager is for a super class. see http://php.net/manual/es/function.is-subclass-of.php