### PR TITLE
Remove option unique of the name index in group class

### DIFF
--- a/Resources/config/doctrine-mapping/Group.mongodb.xml
+++ b/Resources/config/doctrine-mapping/Group.mongodb.xml
@@ -14,7 +14,6 @@
             <index>
                 <key name="name" order="asc" />
                 <option name="safe" value="true" />
-                <option name="unique" value="true" />
             </index>
         </indexes>
 


### PR DESCRIPTION
In the mapping of Group for mongodb, there is a index for the name field but this index is indicated as unique.

So when we create two groups with the same name that generates an error 500 ``MongoDuplicateKeyException``.

`localhost:27017: insertDocument :: caused by :: 
11000 E11000 duplicate key error index`

because there isn't a constraint Unique on this field so i have removed the option.