### PR TITLE
Added email only authentication

### DIFF
--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -29,6 +29,10 @@
         <service id="fos_user.user_provider.username_email" class="FOS\UserBundle\Security\EmailUserProvider" public="false">
             <argument type="service" id="fos_user.user_manager" />
         </service>
+
+        <service id="fos_user.user_provider.email" class="FOS\UserBundle\Security\EmailProvider" public="false">
+            <argument type="service" id="fos_user.user_manager" />
+        </service>
     </services>
 
 </container>

--- a/Resources/doc/logging_by_username_or_email.rst
+++ b/Resources/doc/logging_by_username_or_email.rst
@@ -13,3 +13,13 @@ using only the username:
         providers:
             fos_userbundle:
                 id: fos_user.user_provider.username_email
+
+To restrict authentication to only use email address use the following implementation:
+
+.. code-block:: yaml
+
+    # app/config/security.yml
+    security:
+        providers:
+            fos_userbundle:
+                id: fos_user.user_provider.email

--- a/Security/EmailProvider.php
+++ b/Security/EmailProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Security;
+
+class EmailUserProvider extends UserProvider
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function findUser($email)
+    {
+        return $this->userManager->findUserByEmail($email);
+    }
+}

--- a/Security/EmailProvider.php
+++ b/Security/EmailProvider.php
@@ -11,7 +11,7 @@
 
 namespace FOS\UserBundle\Security;
 
-class EmailUserProvider extends UserProvider
+class EmailProvider extends UserProvider
 {
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Currently there is no possibility to login only by email address. This PR adds this functionality, as I have found it was missing from the bundle. It is partially related to some issues, mainly #555 and #1564.
Now to enable "email only authentication" just use "email" user provider:

```
# app/config/security.yml
security:
    providers:
        fos_userbundle:
            id: fos_user.user_provider.email
```
