### PR TITLE
Add a conflict with symfony/doctrine-bridge <2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
         "symfony/yaml": "~2.3|~3.0",
         "willdurand/propel-typehintable-behavior": "~1.0"
     },
+    "conflict": {
+        "symfony/doctrine-bridge": "<2.3"
+    },
     "suggest": {
         "willdurand/propel-typehintable-behavior": "Needed when using the propel implementation"
     },


### PR DESCRIPTION
FOSUserBundle requires the `RegisterMappingsPass` provided by the Doctrine Bridge >= 2.3. The Doctrine Bundle allows to use the Doctrine Bridge version 2.2 (it only has a soft dependency on `RegisterMappingsPass`).

See the following build using `composer --prefer-lower` for details: https://travis-ci.org/api-platform/core/jobs/134708264#L137

As Symfony 2.2 isn't supported anymore, an alternative fix is to update the Doctrine Bundle to require Symfony >=2.3.