### PR TITLE
Introduce new RolesFormType

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -55,6 +55,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('use_listener')->defaultTrue()->end()
                 ->booleanNode('use_flash_notifications')->defaultTrue()->end()
                 ->booleanNode('use_username_form_type')->defaultTrue()->end()
+                ->booleanNode('use_roles_form_type')->defaultTrue()->end()
                 ->arrayNode('from_email')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -105,6 +105,10 @@ class FOSUserExtension extends Extension
             $loader->load('username_form_type.xml');
         }
 
+        if ($config['use_roles_form_type']) {
+            $loader->load('roles_form_type.xml');
+        }
+
         $this->remapParametersNamespaces($config, $container, array(
             ''          => array(
                 'db_driver' => 'fos_user.storage',

--- a/Form/Type/GroupFormType.php
+++ b/Form/Type/GroupFormType.php
@@ -11,6 +11,7 @@
 
 namespace FOS\UserBundle\Form\Type;
 
+use FOS\UserBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -30,7 +31,16 @@ class GroupFormType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', null, array('label' => 'form.group_name', 'translation_domain' => 'FOSUserBundle'));
+        $builder
+            ->add('name', null, array(
+                'label' => 'form.group_name',
+                'translation_domain' => 'FOSUserBundle',
+            ))
+            ->add('roles', LegacyFormHelper::getType('FOS\UserBundle\Form\Type\RolesFormType'), array(
+                'label' => 'form.group_roles',
+                'translation_domain' => 'FOSUserBundle',
+            ))
+        ;
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/Form/Type/RolesFormType.php
+++ b/Form/Type/RolesFormType.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace FOS\UserBundle\Form\Type;
+
+use FOS\UserBundle\Util\LegacyFormHelper;
+use FOS\UserBundle\Util\RolesHelper;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form type to select multiple roles from the Symfony security system.
+ *
+ * @author Jonny Schmid <jonny@fourlabs.co.uk>
+ */
+class RolesFormType extends AbstractType
+{
+    /**
+     * @var RolesHelper
+     */
+    protected $rolesHelper;
+
+    /**
+     * Constructor.
+     *
+     * @param RolesHelper $rolesHelper
+     */
+    public function __construct(RolesHelper $rolesHelper)
+    {
+        $this->rolesHelper = $rolesHelper;
+    }
+
+    /**
+     * @see Symfony\Component\Form\AbstractType::configureOptions()
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'multiple' => true,
+            'choices' => $this->rolesHelper->getRoles(),
+            'choice_label' => function($role) {
+                return $role;
+            },
+            'choice_translation_domain' => false,
+        ]);
+    }
+
+    /**
+     * @see Symfony\Component\Form\AbstractType::getParent()
+     */
+    public function getParent()
+    {
+        return LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\ChoiceType');
+    }
+
+    // BC for SF < 3.0
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'fos_user_roles';
+    }
+}

--- a/Resources/config/roles_form_type.xml
+++ b/Resources/config/roles_form_type.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="fos_user.roles_form_type" class="FOS\UserBundle\Form\Type\RolesFormType">
+            <tag name="form.type" alias="fos_user_roles" />
+            <argument type="service" id="fos_user.util.roles_helper" />
+        </service>
+
+    </services>
+
+</container>

--- a/Resources/config/util.xml
+++ b/Resources/config/util.xml
@@ -16,6 +16,10 @@
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
+        <service id="fos_user.util.roles_helper" class="FOS\UserBundle\Util\RolesHelper" public="false">
+            <argument>%security.role_hierarchy.roles%</argument>
+        </service>
+
     </services>
 
 </container>

--- a/Resources/doc/configuration_reference.rst
+++ b/Resources/doc/configuration_reference.rst
@@ -12,6 +12,7 @@ All available configuration options are listed below with their default values.
         use_listener:           true
         use_flash_notifications: true
         use_username_form_type: true
+        use_roles_form_type: true
         model_manager_name:     null  # change it to the name of your entity/document manager if you don't want to use the default one.
         from_email:
             address:        webmaster@example.com

--- a/Resources/doc/form_type.rst
+++ b/Resources/doc/form_type.rst
@@ -26,3 +26,38 @@ instance::
         # app/config/config.yml
         fos_user:
             use_username_form_type: false
+
+The roles Form Type
+======================
+
+FOSUserBundle also provides a roles form type, named ``fos_user_roles``. It
+appears as a select input with all roles from Symfony's security system as
+options::
+
+    class UserGroupFormType extends AbstractType
+    {
+        public function buildForm(FormBuilderInterface $builder, array $options)
+        {
+            $builder->add('roles', 'FOS\UserBundle\Form\Type\RolesFormType');
+
+            // if you are using Symfony < 2.8 you should use the old name instead
+            // $builder->add('roles', 'fos_user_roles');
+        }
+    }
+
+.. note::
+
+    To find out more about roles, read the respective section in the
+    `Security <http://symfony.com/doc/current/book/security.html#roles>`_
+    chapter of the Symfony cookbook.
+
+.. note::
+
+    If you don't use this form type in your app, you can disable it to remove
+    the service from the container:
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        fos_user:
+            use_roles_form_type: false

--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -3,6 +3,7 @@ group:
         submit: 'Gruppe aktualisieren'
     show:
         name: Gruppenname
+        roles: Gruppenrollen
     new:
         submit: 'Gruppe erstellen'
     flash:
@@ -58,6 +59,7 @@ layout:
     logged_in_as: 'Angemeldet als %username%'
 form:
     group_name: Gruppenname
+    group_roles: 'Gruppelrollen'
     username: Benutzername
     email: E-Mail-Adresse
     current_password: 'Derzeitiges Passwort'

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -3,6 +3,7 @@ group:
         submit: 'Update group'
     show:
         name: 'Group name'
+        roles: 'Group roles'
     new:
         submit: 'Create group'
     flash:
@@ -78,6 +79,7 @@ layout:
 
 form:
     group_name: 'Group name'
+    group_roles: 'Group roles'
     username: Username
     email: Email
     current_password: 'Current password'

--- a/Resources/views/Group/show_content.html.twig
+++ b/Resources/views/Group/show_content.html.twig
@@ -2,4 +2,5 @@
 
 <div class="fos_user_group_show">
     <p>{{ 'group.show.name'|trans }}: {{ group.getName() }}</p>
+    <p>{{ 'group.show.roles'|trans }}: {{ group.getRoles()|join(', ') }}</p>
 </div>

--- a/Tests/Form/Type/GroupFormTypeTest.php
+++ b/Tests/Form/Type/GroupFormTypeTest.php
@@ -20,7 +20,7 @@ class GroupFormTypeTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function getTypeExtensions()
+    protected function getExtensions()
     {
         $extensions = parent::getTypeExtensions();
 
@@ -45,7 +45,7 @@ class GroupFormTypeTest extends TypeTestCase
         $this->assertTrue($form->isSynchronized());
         $this->assertEquals($group, $form->getData());
         $this->assertEquals('bar', $group->getName());
-        $this->assertEquals('roles', array());
+        $this->assertEquals(array(), $group->getRoles());
     }
 
     protected function getTypes()

--- a/Tests/Form/Type/GroupFormTypeTest.php
+++ b/Tests/Form/Type/GroupFormTypeTest.php
@@ -3,24 +3,49 @@
 namespace FOS\UserBundle\Tests\Form\Type;
 
 use FOS\UserBundle\Form\Type\GroupFormType;
+use FOS\UserBundle\Form\Type\RolesFormType;
 use FOS\UserBundle\Tests\TestGroup;
 use FOS\UserBundle\Util\LegacyFormHelper;
+use FOS\UserBundle\Util\RolesHelper;
+use Symfony\Component\Form\PreloadedExtension;
 
 class GroupFormTypeTest extends TypeTestCase
 {
+    private $rolesHelper;
+
+    protected function setUp()
+    {
+        $this->rolesHelper = new RolesHelper(array());
+
+        parent::setUp();
+    }
+
+    protected function getTypeExtensions()
+    {
+        $extensions = parent::getTypeExtensions();
+
+        $type = new RolesFormType($this->rolesHelper);
+
+        return array_merge($extensions, array(
+            new PreloadedExtension(array($type), array()),
+        ));
+    }
+
     public function testSubmit()
     {
         $group = new TestGroup('foo');
 
         $form = $this->factory->create(LegacyFormHelper::getType('FOS\UserBundle\Form\Type\GroupFormType'), $group);
         $formData = array(
-            'name'      => 'bar',
+            'name' => 'bar',
+            'roles' => array(),
         );
         $form->submit($formData);
 
         $this->assertTrue($form->isSynchronized());
         $this->assertEquals($group, $form->getData());
         $this->assertEquals('bar', $group->getName());
+        $this->assertEquals('roles', array());
     }
 
     protected function getTypes()

--- a/Util/RolesHelper.php
+++ b/Util/RolesHelper.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace FOS\UserBundle\Util;
+
+/**
+ * @internal
+ *
+ * @author Jonny Schmid <jonny@fourlabs.co.uk>
+ */
+final class RolesHelper
+{
+    /**
+     * @var array
+     */
+    private $roles;
+
+    /**
+     * Constructor.
+     *
+     * @param array $rolesHierarchy
+     */
+    public function __construct($rolesHierarchy)
+    {
+        $roles = array();
+
+        array_walk_recursive($rolesHierarchy, function($val) use (&$roles) {
+            $roles[] = $val;
+        });
+
+        $this->roles = array_unique($roles);
+    }
+
+    /**
+     * @return array Array of unique role names
+     */
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/FriendsOfSymfony/FOSUserBundle/issues/1597.

The [documentation points out](https://symfony.com/doc/master/bundles/FOSUserBundle/groups.html) that

> Symfony supports role inheritance so inheriting roles from groups is not always needed. If the role inheritance is enough for your use case, it is better to use it instead of groups as it is more efficient (loading the groups triggers the database).

So the form type doesn't support hierarchy.