### PR TITLE
Fix doc block

### DIFF
--- a/Model/GroupManagerInterface.php
+++ b/Model/GroupManagerInterface.php
@@ -58,7 +58,7 @@ interface GroupManagerInterface
     public function findGroupByName($name);
 
     /**
-     * Returns a collection with all user instances.
+     * Returns a collection with all group instances.
      *
      * @return \Traversable
      */


### PR DESCRIPTION
Just a little error someone made in their doc block.

```php
/**
 * Returns a collection with all user instances.
 *
 * @return \Traversable
 */
public function findGroups();
```