### PR TITLE
Unique index for confirmation_token field ( Propel + Doctrine )

### DIFF
--- a/Resources/config/doctrine-mapping/User.mongodb.xml
+++ b/Resources/config/doctrine-mapping/User.mongodb.xml
@@ -48,6 +48,12 @@
                 <option name="safe" value="true" />
                 <option name="unique" value="true" />
             </index>
+            <index>
+                <key name="confirmationToken" order="asc" />
+                <option name="safe" value="true" />
+                <option name="sparse" value="true" />
+                <option name="unique" value="true" />
+            </index>
         </indexes>
 
     </mapped-superclass>

--- a/Resources/config/doctrine-mapping/User.orm.xml
+++ b/Resources/config/doctrine-mapping/User.orm.xml
@@ -28,7 +28,7 @@
 
         <field name="expiresAt" column="expires_at" type="datetime" nullable="true" />
 
-        <field name="confirmationToken" column="confirmation_token" type="string" nullable="true" />
+        <field name="confirmationToken" column="confirmation_token" type="string" unique="true" nullable="true" />
 
         <field name="passwordRequestedAt" column="password_requested_at" type="datetime" nullable="true" />
 

--- a/Resources/config/propel/schema.xml
+++ b/Resources/config/propel/schema.xml
@@ -23,6 +23,10 @@
         <column name="expired" type="boolean" defaultValue="false" />
         <column name="expires_at" type="timestamp" required="false" />
         <column name="confirmation_token" type="varchar" size="255" required="false" />
+        <unique>
+            <unique-column name="confirmation_token" />
+        </unique>
+        
         <column name="password_requested_at" type="timestamp" required="false" />
         <column name="credentials_expired" type="boolean" defaultValue="false" />
         <column name="credentials_expire_at" type="timestamp" required="false" />


### PR DESCRIPTION
Adding unique index to confirmation_token field in Doctrine (orm and mongodb) + Propel.
Fix: #674
i.e. I can't find any couchdb documentation about unique indexes, I think it hasn't.