### PR TITLE
Fix UserPassword constraint validation groups

### DIFF
--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -36,7 +36,7 @@ class ChangePasswordFormType extends AbstractType
             'label' => 'form.current_password',
             'translation_domain' => 'FOSUserBundle',
             'mapped' => false,
-            'constraints' => new UserPassword(),
+            'constraints' => new UserPassword(!empty($options['validation_groups']) ? array('groups' => array(reset($options['validation_groups']))) : null),
         ));
         $builder->add('plainPassword', LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\RepeatedType'), array(
             'type' => LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\PasswordType'),


### PR DESCRIPTION
I would like to validate the `ChangePasswordFormType` form with the `ChangePassword` validation group only, by using this configuration :

```
change_password:
    form:
        validation_groups: [ChangePassword]
```

When doing this, the `UserPassword` constraint of the `current_password` field is not executed, because it only has the `Default` validation group. This PR fixes this.