### PR TITLE
Let composer automatically detect a version to require

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -50,7 +50,7 @@ Require the bundle with composer:
 
 .. code-block:: bash
 
-    $ composer require friendsofsymfony/user-bundle "~1.3"
+    $ composer require friendsofsymfony/user-bundle
 
 Composer will install the bundle to your project's ``vendor/friendsofsymfony/user-bundle`` directory.
 


### PR DESCRIPTION
Otherwise, you end up with odd situations like in the symfony docs it recommends `~2.0@dev` which is bad practice unless required. Furthermore, it's an extra place to remember to update the branch number when doing branching.

http://symfony.com/doc/current/bundles/FOSUserBundle/index.html#step-1-download-fosuserbundle-using-composer

This will conflict when you merge 1.3.x into 2.0.x as the branch is specified there explicitly.