### PR TITLE
Add user manipulator events

### DIFF
--- a/Event/UserEvent.php
+++ b/Event/UserEvent.php
@@ -20,7 +20,7 @@ class UserEvent extends Event
     private $request;
     private $user;
 
-    public function __construct(UserInterface $user, Request $request)
+    public function __construct(UserInterface $user, Request $request = null)
     {
         $this->user = $user;
         $this->request = $request;

--- a/FOSUserEvents.php
+++ b/FOSUserEvents.php
@@ -213,4 +213,58 @@ final class FOSUserEvents
      * @Event("FOS\UserBundle\Event\UserEvent")
      */
     const SECURITY_IMPLICIT_LOGIN = 'fos_user.security.implicit_login';
+
+    /**
+     * The USER_CREATED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the created user and to add some behaviour after the creation.
+     *
+     * @Event("FOS\UserBundle\Event\UserEvent")
+     */
+    const USER_CREATED = 'fos_user.user.created';
+
+    /**
+     * The USER_PASSWORD_CHANGED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the created user and to add some behaviour after the password change.
+     *
+     * @Event("FOS\UserBundle\Event\UserEvent")
+     */
+    const USER_PASSWORD_CHANGED = 'fos_user.user.password_changed';
+
+    /**
+     * The USER_ACTIVATED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the activated user and to add some behaviour after the activation.
+     *
+     * @Event("FOS\UserBundle\Event\UserEvent")
+     */
+    const USER_ACTIVATED = 'fos_user.user.activated';
+
+    /**
+     * The USER_DEACTIVATED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the deactivated user and to add some behaviour after the deactivation.
+     *
+     * @Event("FOS\UserBundle\Event\UserEvent")
+     */
+    const USER_DEACTIVATED = 'fos_user.user.activated';
+
+    /**
+     * The USER_PROMOTED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the promoted user and to add some behaviour after the promotion.
+     *
+     * @Event("FOS\UserBundle\Event\UserEvent")
+     */
+    const USER_PROMOTED = 'fos_user.user.promoted';
+
+    /**
+     * The USER_DEMOTED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the demoted user and to add some behaviour after the demotion.
+     *
+     * @Event("FOS\UserBundle\Event\UserEvent")
+     */
+    const USER_DEMOTED = 'fos_user.user.demoted';
 }

--- a/Resources/config/util.xml
+++ b/Resources/config/util.xml
@@ -10,6 +10,8 @@
 
         <service id="fos_user.util.user_manipulator" class="FOS\UserBundle\Util\UserManipulator">
             <argument type="service" id="fos_user.user_manager" />
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="service_container" />
         </service>
 
         <service id="fos_user.util.token_generator.default" class="FOS\UserBundle\Util\TokenGenerator" public="false">

--- a/Tests/Util/UserManipulatorTest.php
+++ b/Tests/Util/UserManipulatorTest.php
@@ -11,6 +11,7 @@
 
 namespace FOS\UserBundle\Tests\Util;
 
+use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Util\UserManipulator;
 use FOS\UserBundle\Tests\TestUser;
 
@@ -36,7 +37,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($user))
             ->with($this->isInstanceOf('FOS\UserBundle\Tests\TestUser'));
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_CREATED, true);
+
+        $containerMock = $this->getContainerMock(true);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->create($username, $password, $email, $active, $superadmin);
 
         $this->assertEquals($username, $user->getUsername());
@@ -65,7 +70,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($user))
             ->with($this->isInstanceOf('FOS\UserBundle\Tests\TestUser'));
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_ACTIVATED, true);
+
+        $containerMock = $this->getContainerMock(true);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->activate($username);
 
         $this->assertEquals($username, $user->getUsername());
@@ -88,7 +97,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
         $userManagerMock->expects($this->never())
             ->method('updateUser');
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_ACTIVATED, false);
+
+        $containerMock = $this->getContainerMock(false);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->activate($invalidusername);
     }
 
@@ -111,7 +124,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($user))
             ->with($this->isInstanceOf('FOS\UserBundle\Tests\TestUser'));
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_DEACTIVATED, true);
+
+        $containerMock = $this->getContainerMock(true);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->deactivate($username);
 
         $this->assertEquals($username, $user->getUsername());
@@ -134,7 +151,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
         $userManagerMock->expects($this->never())
             ->method('updateUser');
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_DEACTIVATED, false);
+
+        $containerMock = $this->getContainerMock(false);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->deactivate($invalidusername);
     }
 
@@ -157,7 +178,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($user))
             ->with($this->isInstanceOf('FOS\UserBundle\Tests\TestUser'));
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_PROMOTED, true);
+
+        $containerMock = $this->getContainerMock(true);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->promote($username);
 
         $this->assertEquals($username, $user->getUsername());
@@ -180,7 +205,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
         $userManagerMock->expects($this->never())
             ->method('updateUser');
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_PROMOTED, false);
+
+        $containerMock = $this->getContainerMock(false);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->promote($invalidusername);
     }
 
@@ -203,7 +232,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($user))
             ->with($this->isInstanceOf('FOS\UserBundle\Tests\TestUser'));
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_DEMOTED, true);
+
+        $containerMock = $this->getContainerMock(true);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->demote($username);
 
         $this->assertEquals($username, $user->getUsername());
@@ -226,7 +259,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
         $userManagerMock->expects($this->never())
             ->method('updateUser');
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_DEMOTED, false);
+
+        $containerMock = $this->getContainerMock(false);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->demote($invalidusername);
     }
 
@@ -252,7 +289,11 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($user))
             ->with($this->isInstanceOf('FOS\UserBundle\Tests\TestUser'));
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_PASSWORD_CHANGED, true);
+
+        $containerMock = $this->getContainerMock(true);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->changePassword($username, $password);
 
         $this->assertEquals($username, $user->getUsername());
@@ -277,7 +318,76 @@ class UserManipulatorTest extends \PHPUnit_Framework_TestCase
         $userManagerMock->expects($this->never())
             ->method('updateUser');
 
-        $manipulator = new UserManipulator($userManagerMock);
+        $eventDispatcherMock = $this->getEventDispatcherMock(FOSUserEvents::USER_PASSWORD_CHANGED, false);
+
+        $containerMock = $this->getContainerMock(false);
+
+        $manipulator = new UserManipulator($userManagerMock, $eventDispatcherMock, $containerMock);
         $manipulator->changePassword($invalidusername, $password);
+    }
+
+    /**
+     * @param string $event
+     * @param bool   $once
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getEventDispatcherMock($event, $once = true)
+    {
+        $eventDispatcherMock = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+
+        $eventDispatcherMock->expects($once ? $this->once() : $this->never())
+            ->method('dispatch')
+            ->with($event);
+
+        return $eventDispatcherMock;
+    }
+
+    /**
+     * @param bool $once
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getContainerMock($once = true)
+    {
+        $containerMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        if (!class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            $containerMock->expects($this->any())
+                ->method('has')
+                ->willReturn(false)
+                ->with('request_stack');
+
+            $containerMock->expects($this->any())
+                ->method('get')
+                ->willReturn(null)
+                ->with('request');
+
+            $containerMock->expects($this->any())
+                ->method('isScopeActive')
+                ->willReturn(true)
+                ->with('request');
+
+            $containerMock->expects($this->any())
+                ->method('isScopeActive');
+        } else {
+            $containerMock->expects($this->any())
+                ->method('has')
+                ->willReturn(true)
+                ->with('request_stack');
+
+            $requestStack = $this->getMock('Symfony\Component\HttpFoundation\RequestStack');
+
+            $requestStack->expects($once ? $this->once() : $this->never())
+                ->method('getCurrentRequest')
+                ->willReturn(null);
+
+            $containerMock->expects($this->any())
+                ->method('get')
+                ->willReturn($requestStack)
+                ->with('request_stack');
+        }
+
+        return $containerMock;
     }
 }

--- a/Util/UserManipulator.php
+++ b/Util/UserManipulator.php
@@ -59,24 +59,6 @@ class UserManipulator
     }
 
     /**
-     * This method provides compatibility with 2.x and 3.x Symfony versions
-     *
-     * @return null|Request
-     */
-    private function getRequest()
-    {
-        $request = null;
-        if ($this->container->has('request_stack')) {
-            $request = $this->container->get('request_stack')->getCurrentRequest();
-        } elseif (method_exists($this->container, 'isScopeActive') && $this->container->isScopeActive('request')) {
-            // BC for SF <2.4
-            $request = $this->container->get('request');
-        }
-
-        return $request;
-    }
-
-    /**
      * Creates a user and returns it.
      *
      * @param string  $username
@@ -237,5 +219,23 @@ class UserManipulator
         }
 
         return $user;
+    }
+
+    /**
+     * This method provides compatibility with 2.x and 3.x Symfony versions
+     *
+     * @return null|Request
+     */
+    private function getRequest()
+    {
+        $request = null;
+        if ($this->container->has('request_stack')) {
+            $request = $this->container->get('request_stack')->getCurrentRequest();
+        } elseif (method_exists($this->container, 'isScopeActive') && $this->container->isScopeActive('request')) {
+            // BC for SF <2.4
+            $request = $this->container->get('request');
+        }
+
+        return $request;
     }
 }

--- a/Util/UserManipulator.php
+++ b/Util/UserManipulator.php
@@ -107,8 +107,6 @@ class UserManipulator
      * Activates the given user.
      *
      * @param string $username
-     *
-     * @return \FOS\UserBundle\Model\UserInterface
      */
     public function activate($username)
     {
@@ -118,16 +116,12 @@ class UserManipulator
 
         $event = new UserEvent($user, $this->getRequest());
         $this->dispatcher->dispatch(FOSUserEvents::USER_ACTIVATED, $event);
-
-        return $user;
     }
 
     /**
      * Deactivates the given user.
      *
      * @param string $username
-     *
-     * @return \FOS\UserBundle\Model\UserInterface
      */
     public function deactivate($username)
     {
@@ -137,8 +131,6 @@ class UserManipulator
 
         $event = new UserEvent($user, $this->getRequest());
         $this->dispatcher->dispatch(FOSUserEvents::USER_DEACTIVATED, $event);
-
-        return $user;
     }
 
     /**
@@ -146,8 +138,6 @@ class UserManipulator
      *
      * @param string $username
      * @param string $password
-     *
-     * @return \FOS\UserBundle\Model\UserInterface
      */
     public function changePassword($username, $password)
     {
@@ -157,16 +147,12 @@ class UserManipulator
 
         $event = new UserEvent($user, $this->getRequest());
         $this->dispatcher->dispatch(FOSUserEvents::USER_PASSWORD_CHANGED, $event);
-
-        return $user;
     }
 
     /**
      * Promotes the given user.
      *
      * @param string $username
-     *
-     * @return \FOS\UserBundle\Model\UserInterface
      */
     public function promote($username)
     {
@@ -176,16 +162,12 @@ class UserManipulator
 
         $event = new UserEvent($user, $this->getRequest());
         $this->dispatcher->dispatch(FOSUserEvents::USER_PROMOTED, $event);
-
-        return $user;
     }
 
     /**
      * Demotes the given user.
      *
      * @param string $username
-     *
-     * @return \FOS\UserBundle\Model\UserInterface
      */
     public function demote($username)
     {
@@ -195,8 +177,6 @@ class UserManipulator
 
         $event = new UserEvent($user, $this->getRequest());
         $this->dispatcher->dispatch(FOSUserEvents::USER_DEMOTED, $event);
-
-        return $user;
     }
 
     /**


### PR DESCRIPTION
Existing events allows to integrate some significative points of user actions (register, login, etc.)

In my case I want to create an Profile entity associated to the user when it's registered. Listening for FOSUserEvents::REGISTRATION_SUCCESS event I can do this with a simple listener method.

Now I have to import some users from other platform, and I'm doing this calling fos:user:create command from a script. Also I want to send an email with account migration info.

No command launches any event, so I can not interact with this action. All the fos:user:x commands
use the UserManipulator class to do their actions. In the same way, if you use the "fos_user.util.user_manipulator" service directly to do some action over the users, you will have the same problem.

So, I propose to include some events fired by the UserManipulator to solve this issue:

    FosUserEvents::USER_CREATED
    FosUserEvents::USER_PASSWORD_CHANGED
    FosUserEvents::USER_ACTIVATED
    FosUserEvents::USER_DEACTIVATED
    FosUserEvents::USER_PROMOTED
    FosUserEvents::USER_DEMOTED
