### PR TITLE
Allow to use POST for logout

### DIFF
--- a/Resources/config/routing/security.xml
+++ b/Resources/config/routing/security.xml
@@ -12,7 +12,7 @@
         <default key="_controller">FOSUserBundle:Security:check</default>
     </route>
 
-    <route id="fos_user_security_logout" path="/logout" methods="GET">
+    <route id="fos_user_security_logout" path="/logout" methods="GET POST">
         <default key="_controller">FOSUserBundle:Security:logout</default>
     </route>
 

--- a/Tests/Routing/RoutingTest.php
+++ b/Tests/Routing/RoutingTest.php
@@ -64,7 +64,7 @@ class RoutingTest extends \PHPUnit_Framework_TestCase
 
             array('fos_user_security_login', '/login', array('GET', 'POST')),
             array('fos_user_security_check', '/login_check', array('POST')),
-            array('fos_user_security_logout', '/logout', array('GET')),
+            array('fos_user_security_logout', '/logout', array('GET', 'POST')),
         );
     }
 }


### PR DESCRIPTION
This is a follow-up for #1269.

IMO, logging out the user should be a POST request. I understand that this bundle does not want to enforce that and needs to still support GET for BC, but at least POST should be a valid method as well.