### PR TITLE
make constructor calls consistent with GetResponseUserEvent

### DIFF
--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -52,7 +52,7 @@ class ResettingController extends Controller
         $dispatcher = $this->get('event_dispatcher');
 
         /* Dispatch init event */
-        $event = new GetResponseNullableUserEvent($request, $user);
+        $event = new GetResponseNullableUserEvent($user, $request);
         $dispatcher->dispatch(FOSUserEvents::RESETTING_SEND_EMAIL_INITIALIZE, $event);
 
         if (null !== $event->getResponse()) {

--- a/Event/GetResponseNullableUserEvent.php
+++ b/Event/GetResponseNullableUserEvent.php
@@ -19,19 +19,23 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class GetResponseNullableUserEvent extends GetResponseUserEvent
 {
-    /** @var Request */
+    /**
+     * @var Request
+     */
     private $request;
 
-    /** @var UserInterface */
+    /**
+     * @var UserInterface
+     */
     private $user;
 
     /**
      * GetResponseNullableUserEvent constructor.
      *
-     * @param Request $request
      * @param UserInterface|null $user
+     * @param Request            $request
      */
-    public function __construct(Request $request, UserInterface $user = null)
+    public function __construct(UserInterface $user = null, Request $request)
     {
         $this->user = $user;
         $this->request = $request;


### PR DESCRIPTION
Refs #1906 

https://github.com/FriendsOfSymfony/FOSUserBundle/commit/e12f8bfe51ebbc18d9ef8b18d427d4b4a54a8ee5#commitcomment-18946873