### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/Tests           export-ignore
+/.gitattributes  export-ignore
+/.gitignore      export-ignore
+/.travis.yml     export-ignore
+/README.markdown export-ignore
+/Upgrade.md      export-ignore


### PR DESCRIPTION
Adding a `.gitattributes` file will prevent the files and folders specified here to not be included when pulling in the package via composer (and other such tools).