### PR TITLE
Exclude tests from autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,17 @@
         "willdurand/propel-typehintable-behavior": "Needed when using the propel implementation"
     },
     "autoload": {
-        "psr-4": { "FOS\\UserBundle\\": "" }
+        "psr-4": {
+            "FOS\\UserBundle\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "FOS\\UserBundle\\Tests\\": "Tests/"
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
We don't need this tests classes in production.
