### PR TITLE
Redirect loggedin user on public pages

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -41,6 +41,10 @@ class RegistrationController extends Controller
      */
     public function registerAction(Request $request)
     {
+        if ($this->getUser() instanceof UserInterface) {
+            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
+        }
+
         /** @var $formFactory FactoryInterface */
         $formFactory = $this->get('fos_user.registration.form.factory');
         /** @var $userManager UserManagerInterface */
@@ -98,6 +102,10 @@ class RegistrationController extends Controller
      */
     public function checkEmailAction()
     {
+        if ($this->getUser() instanceof UserInterface) {
+            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
+        }
+
         $email = $this->get('session')->get('fos_user_send_confirmation_email/email');
 
         if (empty($email)) {
@@ -126,6 +134,10 @@ class RegistrationController extends Controller
      */
     public function confirmAction(Request $request, $token)
     {
+        if ($this->getUser() instanceof UserInterface) {
+            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
+        }
+
         /** @var $userManager \FOS\UserBundle\Model\UserManagerInterface */
         $userManager = $this->get('fos_user.user_manager');
 

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -38,6 +38,10 @@ class ResettingController extends Controller
      */
     public function requestAction()
     {
+        if ($this->getUser() instanceof UserInterface) {
+            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
+        }
+
         return $this->render('FOSUserBundle:Resetting:request.html.twig');
     }
 
@@ -50,6 +54,10 @@ class ResettingController extends Controller
      */
     public function sendEmailAction(Request $request)
     {
+        if ($this->getUser() instanceof UserInterface) {
+            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
+        }
+
         $username = $request->request->get('username');
 
         /** @var $user UserInterface */
@@ -121,6 +129,10 @@ class ResettingController extends Controller
      */
     public function checkEmailAction(Request $request)
     {
+        if ($this->getUser() instanceof UserInterface) {
+            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
+        }
+
         $email = $request->query->get('email');
 
         if (empty($email)) {
@@ -143,6 +155,10 @@ class ResettingController extends Controller
      */
     public function resetAction(Request $request, $token)
     {
+        if ($this->getUser() instanceof UserInterface) {
+            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
+        }
+
         /** @var $formFactory \FOS\UserBundle\Form\Factory\FactoryInterface */
         $formFactory = $this->get('fos_user.resetting.form.factory');
         /** @var $userManager \FOS\UserBundle\Model\UserManagerInterface */

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -11,6 +11,7 @@
 
 namespace FOS\UserBundle\Controller;
 
+use FOS\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,6 +28,10 @@ class SecurityController extends Controller
      */
     public function loginAction(Request $request)
     {
+        if ($this->getUser() instanceof UserInterface) {
+            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
+        }
+
         /** @var $session \Symfony\Component\HttpFoundation\Session\Session */
         $session = $request->getSession();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -53,6 +53,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('use_listener')->defaultTrue()->end()
                 ->booleanNode('use_flash_notifications')->defaultTrue()->end()
                 ->booleanNode('use_username_form_type')->defaultTrue()->end()
+                ->scalarNode('user_default_route')->defaultValue('fos_user_profile_show')->end()
                 ->arrayNode('from_email')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -111,6 +111,8 @@ class FOSUserExtension extends Extension
             $loader->load('username_form_type.xml');
         }
 
+        $container->setParameter('fos_user.user.default_route', $config['user_default_route']);
+
         $this->remapParametersNamespaces($config, $container, array(
             ''          => array(
                 'db_driver' => 'fos_user.storage',

--- a/Resources/doc/configuration_reference.rst
+++ b/Resources/doc/configuration_reference.rst
@@ -12,6 +12,7 @@ All available configuration options are listed below with their default values.
         use_listener:           true
         use_flash_notifications: true
         use_username_form_type: true
+        user_default_route:     fos_user_profile_show
         model_manager_name:     null  # change it to the name of your entity/document manager if you don't want to use the default one.
         from_email:
             address:        webmaster@example.com

--- a/Tests/DependencyInjection/FOSUserExtensionTest.php
+++ b/Tests/DependencyInjection/FOSUserExtensionTest.php
@@ -176,6 +176,13 @@ class FOSUserExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertAlias('fos_user.group_manager.default', 'fos_user.group_manager');
     }
 
+    public function testUserDefaultRoute()
+    {
+        $this->createFullConfiguration();
+
+        $this->assertParameter('fos_user_profile_show', 'fos_user.user.default_route');
+    }
+
     public function testUserLoadFormClassWithDefaults()
     {
         $this->createEmptyConfiguration();
@@ -379,6 +386,7 @@ EOF;
 db_driver: orm
 firewall_name: fos_user
 use_listener: true
+user_default_route: fos_user_profile_show
 use_flash_notifications: false
 user_class: Acme\MyBundle\Entity\User
 model_manager_name: custom


### PR DESCRIPTION
This should fix https://github.com/FriendsOfSymfony/FOSUserBundle/issues/889

Checks if a user is loggedin and redirects him to a defined page for the registration, reset and login page.