### PR TITLE
Allow nullable salt in password encoder

### DIFF
--- a/Resources/config/doctrine-mapping/User.couchdb.xml
+++ b/Resources/config/doctrine-mapping/User.couchdb.xml
@@ -8,7 +8,7 @@
         <field name="email" fieldName="email" type="string" index="true" />
         <field name="emailCanonical" fieldName="emailCanonical" type="string" index="true" />
         <field name="enabled" fieldName="enabled" type="mixed" />
-        <field name="salt" fieldName="salt" type="string" />
+        <field name="salt" fieldName="salt" type="string" nullable="true" />
         <field name="password" fieldName="password" type="string" />
         <field name="lastLogin" fieldName="lastLogin" type="datetime" />
         <field name="locked" fieldName="locked" type="mixed" />

--- a/Resources/config/doctrine-mapping/User.orm.xml
+++ b/Resources/config/doctrine-mapping/User.orm.xml
@@ -16,7 +16,7 @@
 
         <field name="enabled" column="enabled" type="boolean" />
 
-        <field name="salt" column="salt" type="string" />
+        <field name="salt" column="salt" type="string" nullable="true" />
 
         <field name="password" column="password" type="string" />
 


### PR DESCRIPTION
This should fix https://github.com/FriendsOfSymfony/FOSUserBundle/issues/946

Allows nullable salt for password encoders like Bcrypt.