### PR TITLE
Use caret version notation in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,20 +20,20 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9",
-        "symfony/form": "~2.3|~3.0",
-        "symfony/framework-bundle": "~2.3|~3.0",
-        "symfony/security-bundle": "~2.3|~3.0",
-        "symfony/twig-bundle": "~2.3|~3.0"
+        "php": "^5.3.9 || ^7.0",
+        "symfony/form": "^2.3 || ^3.0",
+        "symfony/framework-bundle": "^2.3 || ^3.0",
+        "symfony/security-bundle": "^2.3 || ^3.0",
+        "symfony/twig-bundle": "^2.3 || ^3.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "~1.3",
-        "swiftmailer/swiftmailer": "~4.3|~5",
-        "symfony/console": "~2.3|~3.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0",
-        "symfony/validator": "~2.3|~3.0",
-        "symfony/yaml": "~2.3|~3.0",
-        "willdurand/propel-typehintable-behavior": "~1.0"
+        "doctrine/doctrine-bundle": "^1.3",
+        "swiftmailer/swiftmailer": "^4.3 || ^5.0",
+        "symfony/console": "^2.3 || ^3.0",
+        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "symfony/validator": "^2.3 || ^3.0",
+        "symfony/yaml": "^2.3 || ^3.0",
+        "willdurand/propel-typehintable-behavior": "^1.0"
     },
     "conflict": {
         "symfony/doctrine-bridge": "<2.3"


### PR DESCRIPTION
- The [caret operator](https://getcomposer.org/doc/articles/versions.md#caret) allows any non-breaking version.
- There is no valid php 6 release, so we should allow php 5 or 7 only
- There is no pipe operator, only a [double pipe](https://getcomposer.org/doc/articles/versions.md#range) exists