### PR TITLE
Drop support for symfony 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.6
       env: SYMFONY_VERSION=2.7.*
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*

--- a/composer.json
+++ b/composer.json
@@ -21,22 +21,22 @@
     ],
     "require": {
         "php": "^5.3.9 || ^7.0",
-        "symfony/form": "^2.3 || ^3.0",
-        "symfony/framework-bundle": "^2.3 || ^3.0",
-        "symfony/security-bundle": "^2.3 || ^3.0",
-        "symfony/twig-bundle": "^2.3 || ^3.0"
+        "symfony/form": "^2.7 || ^3.0",
+        "symfony/framework-bundle": "^2.7 || ^3.0",
+        "symfony/security-bundle": "^2.7 || ^3.0",
+        "symfony/twig-bundle": "^2.7 || ^3.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.3",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0",
-        "symfony/console": "^2.3 || ^3.0",
+        "symfony/console": "^2.7 || ^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
-        "symfony/validator": "^2.3 || ^3.0",
-        "symfony/yaml": "^2.3 || ^3.0",
+        "symfony/validator": "^2.7 || ^3.0",
+        "symfony/yaml": "^2.7 || ^3.0",
         "willdurand/propel-typehintable-behavior": "^1.0"
     },
     "conflict": {
-        "symfony/doctrine-bridge": "<2.3"
+        "symfony/doctrine-bridge": "<2.7"
     },
     "suggest": {
         "willdurand/propel-typehintable-behavior": "Needed when using the propel implementation"


### PR DESCRIPTION
According to the [symfony roadmap](https://symfony.com/roadmap?version=2.3#checker), the lowest LTE release is only supported til may 2017.

IMHO we should drop the symfony 2.3 support with the next major release, which has no ETA at the moment.