### PR TITLE
Drop support for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
@@ -11,7 +8,7 @@ php:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
+    - php: 5.6
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.9 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "symfony/form": "^2.3 || ^3.0",
         "symfony/framework-bundle": "^2.3 || ^3.0",
         "symfony/security-bundle": "^2.3 || ^3.0",


### PR DESCRIPTION
According to the [supported PHP versions](https://secure.php.net/supported-versions.php), we should drop support for old, unsecure versions with the next major release.