### PR TITLE
Added travis config for symfony 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
     - php: 5.6
       env: SYMFONY_VERSION=3.0.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.1.*
   allow_failures:
     - php: hhvm
 


### PR DESCRIPTION
We should test symfony 3.1, which was [release in may](https://symfony.com/blog/symfony-3-1-0-released).