### PR TITLE
Revert "Redirect loggedin user on public pages"

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -41,10 +41,6 @@ class RegistrationController extends Controller
      */
     public function registerAction(Request $request)
     {
-        if ($this->getUser() instanceof UserInterface) {
-            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
-        }
-
         /** @var $formFactory FactoryInterface */
         $formFactory = $this->get('fos_user.registration.form.factory');
         /** @var $userManager UserManagerInterface */
@@ -102,10 +98,6 @@ class RegistrationController extends Controller
      */
     public function checkEmailAction()
     {
-        if ($this->getUser() instanceof UserInterface) {
-            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
-        }
-
         $email = $this->get('session')->get('fos_user_send_confirmation_email/email');
 
         if (empty($email)) {
@@ -134,10 +126,6 @@ class RegistrationController extends Controller
      */
     public function confirmAction(Request $request, $token)
     {
-        if ($this->getUser() instanceof UserInterface) {
-            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
-        }
-
         /** @var $userManager \FOS\UserBundle\Model\UserManagerInterface */
         $userManager = $this->get('fos_user.user_manager');
 

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -38,10 +38,6 @@ class ResettingController extends Controller
      */
     public function requestAction()
     {
-        if ($this->getUser() instanceof UserInterface) {
-            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
-        }
-
         return $this->render('FOSUserBundle:Resetting:request.html.twig');
     }
 
@@ -54,10 +50,6 @@ class ResettingController extends Controller
      */
     public function sendEmailAction(Request $request)
     {
-        if ($this->getUser() instanceof UserInterface) {
-            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
-        }
-
         $username = $request->request->get('username');
 
         /** @var $user UserInterface */
@@ -122,10 +114,6 @@ class ResettingController extends Controller
      */
     public function checkEmailAction(Request $request)
     {
-        if ($this->getUser() instanceof UserInterface) {
-            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
-        }
-
         $username = $request->query->get('username');
 
         if (empty($username)) {
@@ -148,10 +136,6 @@ class ResettingController extends Controller
      */
     public function resetAction(Request $request, $token)
     {
-        if ($this->getUser() instanceof UserInterface) {
-            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
-        }
-
         /** @var $formFactory \FOS\UserBundle\Form\Factory\FactoryInterface */
         $formFactory = $this->get('fos_user.resetting.form.factory');
         /** @var $userManager \FOS\UserBundle\Model\UserManagerInterface */

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -11,7 +11,6 @@
 
 namespace FOS\UserBundle\Controller;
 
-use FOS\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,10 +26,6 @@ class SecurityController extends Controller
      */
     public function loginAction(Request $request)
     {
-        if ($this->getUser() instanceof UserInterface) {
-            return $this->redirectToRoute($this->getParameter('fos_user.user.default_route'));
-        }
-
         /** @var $session \Symfony\Component\HttpFoundation\Session\Session */
         $session = $request->getSession();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -53,7 +53,6 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('use_listener')->defaultTrue()->end()
                 ->booleanNode('use_flash_notifications')->defaultTrue()->end()
                 ->booleanNode('use_username_form_type')->defaultTrue()->end()
-                ->scalarNode('user_default_route')->defaultValue('fos_user_profile_show')->end()
                 ->arrayNode('from_email')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -93,8 +93,6 @@ class FOSUserExtension extends Extension
             $loader->load('username_form_type.xml');
         }
 
-        $container->setParameter('fos_user.user.default_route', $config['user_default_route']);
-
         $this->remapParametersNamespaces($config, $container, array(
             '' => array(
                 'db_driver' => 'fos_user.storage',

--- a/Resources/doc/configuration_reference.rst
+++ b/Resources/doc/configuration_reference.rst
@@ -12,7 +12,6 @@ All available configuration options are listed below with their default values.
         use_listener:           true
         use_flash_notifications: true
         use_username_form_type: true
-        user_default_route:     fos_user_profile_show
         model_manager_name:     null  # change it to the name of your entity/document manager if you don't want to use the default one.
         from_email:
             address:        webmaster@example.com

--- a/Tests/DependencyInjection/FOSUserExtensionTest.php
+++ b/Tests/DependencyInjection/FOSUserExtensionTest.php
@@ -175,13 +175,6 @@ class FOSUserExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertAlias('fos_user.group_manager.default', 'fos_user.group_manager');
     }
 
-    public function testUserDefaultRoute()
-    {
-        $this->createFullConfiguration();
-
-        $this->assertParameter('fos_user_profile_show', 'fos_user.user.default_route');
-    }
-
     public function testUserLoadFormClassWithDefaults()
     {
         $this->createEmptyConfiguration();
@@ -388,7 +381,6 @@ EOF;
 db_driver: orm
 firewall_name: fos_user
 use_listener: true
-user_default_route: fos_user_profile_show
 use_flash_notifications: false
 user_class: Acme\MyBundle\Entity\User
 model_manager_name: custom


### PR DESCRIPTION
I feel we should revert https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2236 due to the following reasons:

1) It created some annoying bugs (people cannot register other users anymore and using the login form as sub request is not possible anymore; see https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2247 and https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2245)
2) The method `Controller::getUser()` is deprecated anyway.
3) Duplicate code everywhere.
4) If you want to restrict a page, an event listener would be a better use case.