### PR TITLE
added support for custom "invalid current password" message

### DIFF
--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -37,11 +37,19 @@ class ChangePasswordFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $constraints = array(
+            'message' => 'fos_user.current_password.invalid',
+        );
+
+        if (!empty($options['validation_groups'])) {
+            $constraints['groups'] = array(reset($options['validation_groups']));
+        }
+
         $builder->add('current_password', LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\PasswordType'), array(
             'label' => 'form.current_password',
             'translation_domain' => 'FOSUserBundle',
             'mapped' => false,
-            'constraints' => new UserPassword($this->getUserPasswordConstraints($options)),
+            'constraints' => new UserPassword($constraints),
         ));
 
         $builder->add('plainPassword', LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\RepeatedType'), array(
@@ -81,18 +89,5 @@ class ChangePasswordFormType extends AbstractType
     public function getBlockPrefix()
     {
         return 'fos_user_change_password';
-    }
-
-    protected function getUserPasswordConstraints($options)
-    {
-        $constraints = array(
-            'message' => 'fos_user.current_password.invalid',
-        );
-
-        if (!empty($options['validation_groups'])) {
-            $constraints['groups'] = array(reset($options['validation_groups']));
-        }
-
-        return $constraints;
     }
 }

--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -41,17 +41,9 @@ class ChangePasswordFormType extends AbstractType
             'label' => 'form.current_password',
             'translation_domain' => 'FOSUserBundle',
             'mapped' => false,
-            'constraints' => new UserPassword(
-                !empty($options['validation_groups'])
-                ? array(
-                    'message' => 'fos_user.current_password.invalid',
-                    'groups' =>  array(reset($options['validation_groups']))
-                )
-                : array(
-                    'message' => 'fos_user.current_password.invalid',
-                )
-            ),
+            'constraints' => new UserPassword($this->getUserPasswordConstraints($options)),
         ));
+
         $builder->add('plainPassword', LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\RepeatedType'), array(
             'type' => LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\PasswordType'),
             'options' => array('translation_domain' => 'FOSUserBundle'),
@@ -89,5 +81,18 @@ class ChangePasswordFormType extends AbstractType
     public function getBlockPrefix()
     {
         return 'fos_user_change_password';
+    }
+
+    protected function getUserPasswordConstraints($options)
+    {
+        $constraints = array(
+            'message' => 'fos_user.current_password.invalid',
+        );
+
+        if (!empty($options['validation_groups'])) {
+            $constraints['groups'] = array(reset($options['validation_groups']));
+        }
+
+        return $constraints;
     }
 }

--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -37,19 +37,19 @@ class ChangePasswordFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $constraints = array(
+        $constraintsOptions = array(
             'message' => 'fos_user.current_password.invalid',
         );
 
         if (!empty($options['validation_groups'])) {
-            $constraints['groups'] = array(reset($options['validation_groups']));
+            $constraintsOptions['groups'] = array(reset($options['validation_groups']));
         }
 
         $builder->add('current_password', LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\PasswordType'), array(
             'label' => 'form.current_password',
             'translation_domain' => 'FOSUserBundle',
             'mapped' => false,
-            'constraints' => new UserPassword($constraints),
+            'constraints' => new UserPassword($constraintsOptions),
         ));
 
         $builder->add('plainPassword', LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\RepeatedType'), array(

--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -41,7 +41,10 @@ class ChangePasswordFormType extends AbstractType
             'label' => 'form.current_password',
             'translation_domain' => 'FOSUserBundle',
             'mapped' => false,
-            'constraints' => new UserPassword(!empty($options['validation_groups']) ? array('groups' => array(reset($options['validation_groups']))) : null),
+            'constraints' => new UserPassword(array(
+                'message' => 'fos_user.current_password.invalid',
+                'groups' =>  !empty($options['validation_groups']) ? array(reset($options['validation_groups'])) : null
+            )),
         ));
         $builder->add('plainPassword', LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\RepeatedType'), array(
             'type' => LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\PasswordType'),

--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -46,10 +46,11 @@ class ChangePasswordFormType extends AbstractType
                 ? array(
                     'message' => 'fos_user.current_password.invalid',
                     'groups' =>  array(reset($options['validation_groups']))
+                )
                 : array(
                     'message' => 'fos_user.current_password.invalid',
                 )
-            )),
+            ),
         ));
         $builder->add('plainPassword', LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\RepeatedType'), array(
             'type' => LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\PasswordType'),

--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -41,9 +41,14 @@ class ChangePasswordFormType extends AbstractType
             'label' => 'form.current_password',
             'translation_domain' => 'FOSUserBundle',
             'mapped' => false,
-            'constraints' => new UserPassword(array(
-                'message' => 'fos_user.current_password.invalid',
-                'groups' =>  !empty($options['validation_groups']) ? array(reset($options['validation_groups'])) : null
+            'constraints' => new UserPassword(
+                !empty($options['validation_groups'])
+                ? array(
+                    'message' => 'fos_user.current_password.invalid',
+                    'groups' =>  array(reset($options['validation_groups']))
+                : array(
+                    'message' => 'fos_user.current_password.invalid',
+                )
             )),
         ));
         $builder->add('plainPassword', LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\RepeatedType'), array(


### PR DESCRIPTION
In the ChangePasswordFormType, the current error message for the `current_password` widget is the default from symfony Validator's component. The message currently reads: "This value should be the user's current password.".

Now the only conceivable use of the current password widget (at least with the `userPassword` validator) is for the user to enter his own password. The wording of the default error message is therefore not very appropriate, in that it refers to the user in the 3rd person. "This value should be YOUR current password." would be more appropriate, for example.

Interestingly, FOSUserBundle already has an error message defined for this (`fos_user.current_password.invalid`).

The proposed change makes use of that existing message and sets it on the ChnagePasswordFormType (on the `userpassword` valudatir of the form's `current_password` widget).

For customization, devs can easily overwrite the translation catalogue.