### PR TITLE
Make entity manager lazy

### DIFF
--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="fos_user.user_manager.default" class="FOS\UserBundle\Doctrine\UserManager" public="false" lazy=true>
+        <service id="fos_user.user_manager.default" class="FOS\UserBundle\Doctrine\UserManager" public="false" lazy="true">
             <argument type="service" id="fos_user.util.password_updater" />
             <argument type="service" id="fos_user.util.canonical_fields_updater" />
             <argument type="service" id="fos_user.object_manager" />

--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="fos_user.user_manager.default" class="FOS\UserBundle\Doctrine\UserManager" public="false">
+        <service id="fos_user.user_manager.default" class="FOS\UserBundle\Doctrine\UserManager" public="false" lazy=true>
             <argument type="service" id="fos_user.util.password_updater" />
             <argument type="service" id="fos_user.util.canonical_fields_updater" />
             <argument type="service" id="fos_user.object_manager" />


### PR DESCRIPTION
Instantiating the `UserManager` requires a DB connection, hence once the bundle installed, a simple cache warmup will now require a database connection even though it is not necessary.
