### PR TITLE
Add getters to UserManager

### DIFF
--- a/Model/UserManager.php
+++ b/Model/UserManager.php
@@ -93,4 +93,20 @@ abstract class UserManager implements UserManagerInterface
     {
         $this->passwordUpdater->hashPassword($user);
     }
+
+    /**
+     * @return PasswordUpdaterInterface
+     */
+    protected function getPasswordUpdater()
+    {
+        return $this->passwordUpdater;
+    }
+
+    /**
+     * @return CanonicalFieldsUpdater
+     */
+    protected function getCanonicalFieldsUpdater()
+    {
+        return $this->canonicalFieldsUpdater;
+    }
 }


### PR DESCRIPTION
Apparently people extend `UserManager` and need to be able to access the password and canonical field updaters.