### PR TITLE
Regenerate the hash on password update

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,7 @@ Changelog
 * [BC break] The signature of the `UserManager` constructor has changed.
 * [BC break] The translation key `resetting.request.invalid_username` has been removed.
 * [BC break] The propel dependency was dropped.
+* [BC break] The `salt` field of the `User` class is now nullable.
 
 ### 2.0.0-alpha3 (2015-09-15)
 

--- a/Model/User.php
+++ b/Model/User.php
@@ -105,7 +105,6 @@ abstract class User implements UserInterface, GroupableInterface
      */
     public function __construct()
     {
-        $this->salt = base_convert(sha1(uniqid(mt_rand(), true)), 16, 36);
         $this->enabled = false;
         $this->roles = array();
     }
@@ -356,6 +355,14 @@ abstract class User implements UserInterface, GroupableInterface
         $this->usernameCanonical = $usernameCanonical;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSalt($salt)
+    {
+        $this->salt = $salt;
     }
 
     public function setEmail($email)

--- a/Model/UserInterface.php
+++ b/Model/UserInterface.php
@@ -56,6 +56,11 @@ interface UserInterface extends AdvancedUserInterface, \Serializable
     public function setUsernameCanonical($usernameCanonical);
 
     /**
+     * @param string|null $salt
+     */
+    public function setSalt($salt);
+
+    /**
      * Gets email.
      *
      * @return string

--- a/Resources/config/doctrine-mapping/User.orm.xml
+++ b/Resources/config/doctrine-mapping/User.orm.xml
@@ -16,7 +16,7 @@
 
         <field name="enabled" column="enabled" type="boolean" />
 
-        <field name="salt" column="salt" type="string" />
+        <field name="salt" column="salt" type="string" nullable="true" />
 
         <field name="password" column="password" type="string" />
 

--- a/Util/PasswordUpdater.php
+++ b/Util/PasswordUpdater.php
@@ -12,6 +12,7 @@
 namespace FOS\UserBundle\Util;
 
 use FOS\UserBundle\Model\UserInterface;
+use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
@@ -37,6 +38,14 @@ class PasswordUpdater implements PasswordUpdaterInterface
         }
 
         $encoder = $this->encoderFactory->getEncoder($user);
+
+        if ($encoder instanceof BCryptPasswordEncoder) {
+            $user->setSalt(null);
+        } else {
+            $salt = rtrim(str_replace('+', '.', base64_encode(random_bytes(32))), '=');
+            $user->setSalt($salt);
+        }
+
         $hashedPassword = $encoder->encodePassword($plainPassword, $user->getSalt());
         $user->setPassword($hashedPassword);
         $user->eraseCredentials();


### PR DESCRIPTION
When using Bcrypt, this keeps the hash as null, as PHP deprecated passing a hash.

Small BC break: the UserInterface now includes a setter for the salt (does not impact people extending the base class, as the base class implements the setter)

Closes #1066
Closes #946