### PR TITLE
[BC Break] Remove more fields from the User class

### DIFF
--- a/Model/UserInterface.php
+++ b/Model/UserInterface.php
@@ -127,15 +127,6 @@ interface UserInterface extends AdvancedUserInterface, \Serializable
     public function setEnabled($boolean);
 
     /**
-     * Sets the locking status of the user.
-     *
-     * @param bool $boolean
-     *
-     * @return self
-     */
-    public function setLocked($boolean);
-
-    /**
      * Sets the super admin status.
      *
      * @param bool $boolean

--- a/Resources/config/doctrine-mapping/User.couchdb.xml
+++ b/Resources/config/doctrine-mapping/User.couchdb.xml
@@ -11,8 +11,6 @@
         <field name="salt" fieldName="salt" type="string" />
         <field name="password" fieldName="password" type="string" />
         <field name="lastLogin" fieldName="lastLogin" type="datetime" />
-        <field name="locked" fieldName="locked" type="mixed" />
-        <field name="expiresAt" fieldName="expiresAt" type="datetime" />
         <field name="confirmationToken" fieldName="confirmationToken" type="string" />
         <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="datetime" />
         <field name="roles" fieldName="roles" type="mixed" />

--- a/Resources/config/doctrine-mapping/User.mongodb.xml
+++ b/Resources/config/doctrine-mapping/User.mongodb.xml
@@ -22,17 +22,12 @@
 
         <field name="lastLogin" fieldName="lastLogin" type="date" />
 
-        <field name="locked" fieldName="locked" type="boolean" />
-
-        <field name="expiresAt" fieldName="expiresAt" type="date" />
-
         <field name="confirmationToken" fieldName="confirmationToken" type="string" />
 
         <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="date" />
 
         <field name="roles" fieldName="roles" type="collection" />
 
-        <field name="credentialsExpireAt" fieldName="credentialsExpireAt" type="date" />
         <indexes>
             <index>
                 <key name="usernameCanonical" order="asc" />

--- a/Resources/config/doctrine-mapping/User.orm.xml
+++ b/Resources/config/doctrine-mapping/User.orm.xml
@@ -22,17 +22,11 @@
 
         <field name="lastLogin" column="last_login" type="datetime" nullable="true" />
 
-        <field name="locked" column="locked" type="boolean" />
-
-        <field name="expiresAt" column="expires_at" type="datetime" nullable="true" />
-
         <field name="confirmationToken" column="confirmation_token" type="string" length="180" unique="true" nullable="true" />
 
         <field name="passwordRequestedAt" column="password_requested_at" type="datetime" nullable="true" />
 
         <field name="roles" column="roles" type="array" />
-
-        <field name="credentialsExpireAt" column="credentials_expire_at" type="datetime" nullable="true" />
 
     </mapped-superclass>
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -8,13 +8,24 @@ break. For the full list of changes, please look at the Changelog file.
 
 Methods and properties removed from `FOS\UserBundle\Model\User`
 
-- `$expired`
-- `$credentialsExpired`
-- `setExpired()` (use `setExpiresAt(\DateTime::now()` instead)
-- `setCredentialsExpired()` (use `setCredentialsExpireAt(\DateTime::now()` instead)
+- `$locked`
+- `$expired` and `$expiredAt`
+- `$credentialsExpired` and `$credentialsExpired`
+- `setLocked()` and `isLocked()`
+- `setExpired()` and `setExpiresAt()`
+- `setCredentialsExpired()` and `setCredentialsExpireAt()`
 
-You need to drop the fields `expired` and `credentials_expired` from your database
-schema, because they aren't mapped anymore.
+These properties were used to implement advanced features of the AdvancedUserInterface
+from the Symfony component, but neither Symfony nor this bundle are providing
+ways to use these features fully (expired credentials would just prevent
+logging in for instance).
+Projects needing to use these advanced feature should add the fields they
+need in their User class and override the corresponding method to provide
+an implementation fitting their requirement. Projects wanting to keep the
+previous behavior of the bundle can copy the condition used in 1.3.7.
+
+You need to drop the removed fields from your database schema, because they
+aren't mapped anymore.
 
 ### LoginManager
 


### PR DESCRIPTION
These fields are used by advanced features of the security system, which are not ready out of the box in the bundle anyway. The provided fields was the cause of complaints from 2 sides:
- people complaining about useless fields in the DB when they don't use the feature
- people complaining about the implementation not fitting their business needs.
The bundle does not provide the storage for these properties anymore.
Projects needing to use these features should add the fields and the implementation they need in their child User class instead.