### PR TITLE
Add user provider service to use FOSOAuthServerBundle

### DIFF
--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -4,12 +4,17 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
+  <parameters>
+        <parameter key="fos_user.security.user_provider.class">FOS\UserBundle\Security\UserProvider</parameter>
         <parameter key="fos_user.security.interactive_login_listener.class">FOS\UserBundle\EventListener\LastLoginListener</parameter>
         <parameter key="fos_user.security.login_manager.class">FOS\UserBundle\Security\LoginManager</parameter>
     </parameters>
 
     <services>
+        <service id="fos_user.security.user_provider" class="%fos_user.security.user_provider.class%">
+            <argument type="service" id="fos_user.user_manager" />
+        </service>
+
         <service id="fos_user.security.interactive_login_listener" class="%fos_user.security.interactive_login_listener.class%">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="fos_user.user_manager" />


### PR DESCRIPTION
from the commit https://github.com/FriendsOfSymfony/FOSUserBundle/commit/c7ebae5374de0f497c0bca6c779dc57517979e26
the UserManager don't implements `UserProviderInterface`

I create a UserProvider Service to use the FOSOAuthServerBundle easily