### PR TITLE
Remove the mailing-list notification on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,3 @@ php:
 sudo: false
 
 install: composer install
-
-notifications:
-  email: friendsofsymfony-dev@googlegroups.com


### PR DESCRIPTION
These notifications require moderation each time, meaning that the merger generally does not get notified at the time the merge broke tests.
Thus, half of the mail notifications reaching the moderation queue are actually for builds in forks for people enabling Travis in their fork too.
I think notifying the people merging the PR (which is what Travis does by default) is more useful and creates less maintenance overhead.