### PR TITLE
Use locally installed PHPUnit instead of the global version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ cs_dry_run:
 	./vendor/bin/php-cs-fixer fix --verbose --dry-run
 
 test:
-	phpunit --coverage-text
+	./vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
phpunit is part of "require-dev" in the composer.json, but is not used in Travis