### PR TITLE
Typo in removed property for upgrade instructions

### DIFF
--- a/Upgrade.md
+++ b/Upgrade.md
@@ -10,7 +10,7 @@ Methods and properties removed from `FOS\UserBundle\Model\User`
 
 - `$locked`
 - `$expired` and `$expiredAt`
-- `$credentialsExpired` and `$credentialsExpired`
+- `$credentialsExpired` and `$credentialsExpiredAt`
 - `setLocked()` and `isLocked()`
 - `setExpired()` and `setExpiresAt()`
 - `setCredentialsExpired()` and `setCredentialsExpireAt()`


### PR DESCRIPTION
Typo in removed property
second credentialsExpired should be credentialsExpiredAt