### PR TITLE
Add trailing dot for all flash messages except fa, ja and zh_CN

### DIFF
--- a/Resources/translations/FOSUserBundle.bg.yml
+++ b/Resources/translations/FOSUserBundle.bg.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Нова група
     flash:
-        updated: Групата беше обновена успешно
-        created: Групата беше създадена успешно
-        deleted: Групата беше изтрита успешно
+        updated: Групата беше обновена успешно.
+        created: Групата беше създадена успешно.
+        deleted: Групата беше изтрита успешно.
 
 # Security
 "Bad credentials": Невалидно потребителско име или парола
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Запази
     flash:
-        updated: Профила беше успешно обновен
+        updated: Профила беше успешно обновен.
 
 # Password change
 change_password:
     submit: Промени паролата
     flash:
-        success: Паролата беше успешно променена
+        success: Паролата беше успешно променена.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Обратно към предишната страница.
     submit: Регистрация
     flash:
-        user_created: Потребителят беше успешно създаден
+        user_created: Потребителят беше успешно създаден.
     email:
         subject: Добре дошли, %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Промени паролата
     flash:
-        success: Паролата беше успешно променена
+        success: Паролата беше успешно променена.
     email:
         subject: Забравена парола
         message: |

--- a/Resources/translations/FOSUserBundle.ca.yml
+++ b/Resources/translations/FOSUserBundle.ca.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Crea el grup
     flash:
-        updated: S'ha actualitzat el grup
-        created: S'ha creat el grup
-        deleted: S'ha eliminat el grup
+        updated: S'ha actualitzat el grup.
+        created: S'ha creat el grup.
+        deleted: S'ha eliminat el grup.
 
 # Security
 security:
@@ -27,13 +27,13 @@ profile:
     edit:
         submit: Actualitza
     flash:
-        updated: S'ha actualitzat el perfil
+        updated: S'ha actualitzat el perfil.
 
 # Password change
 change_password:
     submit: Canvia la contrasenya
     flash:
-        success: S'ha canviat la contrasenya
+        success: S'ha canviat la contrasenya.
 
 # Registration
 registration:
@@ -42,7 +42,7 @@ registration:
     back: Torna a la pàgina original.
     submit: Registra
     flash:
-        user_created: S'ha creat l'usuari correctament
+        user_created: S'ha creat l'usuari correctament.
     email:
         subject: Benvingut %username%!
         message: |
@@ -64,7 +64,7 @@ resetting:
     reset:
         submit: Canvia la contrasenya
     flash:
-        success: S'ha restablert la contrasenya correctament
+        success: S'ha restablert la contrasenya correctament.
     email:
         subject: Restablir la contrasenya
         message: |

--- a/Resources/translations/FOSUserBundle.cs.yml
+++ b/Resources/translations/FOSUserBundle.cs.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Vytvořit skupinu
     flash:
-        updated: Skupina byla úspěšně aktualizována
-        created: Skupina byla úspěšně vytvořena
-        deleted: Skupina byla úspěšně vymazána
+        updated: Skupina byla úspěšně aktualizována.
+        created: Skupina byla úspěšně vytvořena.
+        deleted: Skupina byla úspěšně vymazána.
 
 # Security
 "Bad credentials": Neplatné přihlašovací údaje
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Upravit
     flash:
-        updated: Profil byl úspěšně aktualizován
+        updated: Profil byl úspěšně aktualizován.
 
 # Password change
 change_password:
     submit: Nastavit nové heslo
     flash:
-        success: Nové heslo bylo úspěšně nastaveno
+        success: Nové heslo bylo úspěšně nastaveno.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Návrat na předchozí stránku.
     submit: Registrovat se
     flash:
-        user_created: Váš účet byl úspěšně vytvořen
+        user_created: Váš účet byl úspěšně vytvořen.
     email:
         subject: Vítejte, %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Nastavit nové heslo
     flash:
-        success: Heslo bylo úspěšně změněno
+        success: Heslo bylo úspěšně změněno.
     email:
         subject: Zaslání zapomenutého hesla
         message: |

--- a/Resources/translations/FOSUserBundle.da.yml
+++ b/Resources/translations/FOSUserBundle.da.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Opret gruppe
     flash:
-        updated: Gruppen er blevet opdateret
-        created: Gruppen er blevet oprettet
-        deleted: Gruppen er blevet slettet
+        updated: Gruppen er blevet opdateret.
+        created: Gruppen er blevet oprettet.
+        deleted: Gruppen er blevet slettet.
 
 # Security
 security:
@@ -27,13 +27,13 @@ profile:
     edit:
         submit: Opdater
     flash:
-        updated: Profilen er blevet opdateret
+        updated: Profilen er blevet opdateret.
 
 # Password change
 change_password:
     submit: Skift adgangskode
     flash:
-        success: Adgangskoden er blevet opdateret
+        success: Adgangskoden er blevet opdateret.
 
 # Registration
 registration:
@@ -42,7 +42,7 @@ registration:
     #back: Back to the originating page.
     submit: Registrer
     flash:
-        user_created: Bruger er blevet oprettet
+        user_created: Bruger er blevet oprettet.
     email:
         subject: Velkommen %username%!
         message: |
@@ -64,7 +64,7 @@ resetting:
     reset:
         submit: Skift adgangskode
     flash:
-        success: Adgangskoden er blevet nulstillet
+        success: Adgangskoden er blevet nulstillet.
     email:
         subject: Velkommen %username%!
         message: |

--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Gruppe erstellen
     flash:
-        updated: Die Gruppe wurde aktualisiert
-        created: Die Gruppe wurde erstellt
-        deleted: Die Gruppe wurde gelöscht
+        updated: Die Gruppe wurde aktualisiert.
+        created: Die Gruppe wurde erstellt.
+        deleted: Die Gruppe wurde gelöscht.
 
 # Security
 "Bad credentials": Benutzername oder Passwort ungültig
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Benutzer aktualisieren
     flash:
-        updated: Das Benutzerprofil wurde aktualisiert
+        updated: Das Benutzerprofil wurde aktualisiert.
 
 # Password change
 change_password:
     submit: Passwort ändern
     flash:
-        success: Das Passwort wurde geändert
+        success: Das Passwort wurde geändert.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Zurück zur ursprünglichen Seite.
     submit: Registrieren
     flash:
-        user_created: Der Benutzer wurde erfolgreich erstellt
+        user_created: Der Benutzer wurde erfolgreich erstellt.
     email:
         subject: Willkommen %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Passwort ändern
     flash:
-        success: Das Passwort wurde erfolgreich zurückgesetzt
+        success: Das Passwort wurde erfolgreich zurückgesetzt.
     email:
         subject: Passwort zurücksetzen
         message: |

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Create group
     flash:
-        updated: The group has been updated
-        created: The group has been created
-        deleted: The group has been deleted
+        updated: The group has been updated.
+        created: The group has been created.
+        deleted: The group has been deleted.
 
 # Security
 "Bad credentials": Invalid username or password
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Update
     flash:
-        updated: The profile has been updated
+        updated: The profile has been updated.
 
 # Password change
 change_password:
     submit: Change password
     flash:
-        success: The password has been changed
+        success: The password has been changed.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Back to the originating page.
     submit: Register
     flash:
-        user_created: The user has been created successfully
+        user_created: The user has been created successfully.
     email:
         subject: Welcome %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Change password
     flash:
-        success: The password has been reset successfully
+        success: The password has been reset successfully.
     email:
         subject: Reset Password
         message: |

--- a/Resources/translations/FOSUserBundle.es.yml
+++ b/Resources/translations/FOSUserBundle.es.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Crear grupo
     flash:
-        updated: El grupo ha sido actualizado
-        created: El grupo ha sido creado
-        deleted: El grupo ha sido borrado
+        updated: El grupo ha sido actualizado.
+        created: El grupo ha sido creado.
+        deleted: El grupo ha sido borrado.
 
 # Security
 "Bad credentials": Nombre de usuario o Contraseña inválido
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Actualizar usuario
     flash:
-        updated: El perfil ha sido actualizado
+        updated: El perfil ha sido actualizado.
 
 # Password change
 change_password:
     submit: Cambiar contraseña
     flash:
-        success: La contraseña se ha cambiado con éxito
+        success: La contraseña se ha cambiado con éxito.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Volver a la página original.
     submit: Registrar
     flash:
-        user_created: El usuario se ha creado satisfactoriamente
+        user_created: El usuario se ha creado satisfactoriamente.
     email:
         subject: Bienvenido %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Cambiar contraseña
     flash:
-        success: La contraseña se ha cambiado con éxito
+        success: La contraseña se ha cambiado con éxito.
     email:
         subject: Bienvenido %username%!
         message : |

--- a/Resources/translations/FOSUserBundle.eu.yml
+++ b/Resources/translations/FOSUserBundle.eu.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Taldea sortu
     flash:
-        updated: Taldea eguneratua izan da
-        created: Taldea sortua izan da
-        deleted: Taldea ezabatua izan da
+        updated: Taldea eguneratua izan da.
+        created: Taldea sortua izan da.
+        deleted: Taldea ezabatua izan da.
 
 # Security
 security:
@@ -27,13 +27,13 @@ profile:
     edit:
         submit: Erabiltzailea eguneratu
     flash:
-        updated: Perfila eguneratua izan da
+        updated: Perfila eguneratua izan da.
 
 # Password change
 change_password:
     submit: Pasahitza aldatu
     flash:
-        success: Pasahitz ongi eguneratu da
+        success: Pasahitz ongi eguneratu da.
 
 # Registration
 registration:
@@ -42,7 +42,7 @@ registration:
     back: Itzuli.
     submit: Izena eman
     flash:
-        user_created: Erabiltzailea ongi sortu da
+        user_created: Erabiltzailea ongi sortu da.
     email:
         subject: Ongi etorri %username%!
         message: |
@@ -64,7 +64,7 @@ resetting:
     reset:
         submit: Pasahitza aldatu
     flash:
-        success: Pasahitza ongi aldatu da
+        success: Pasahitza ongi aldatu da.
     email:
         subject: Pasahitza berrezarri
         message : |

--- a/Resources/translations/FOSUserBundle.fi.yml
+++ b/Resources/translations/FOSUserBundle.fi.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Luo ryhmä
     flash:
-        updated: Ryhmä on päivitetty
-        created: Ryhmä on luotu
-        deleted: Ryhmä on poistettu
+        updated: Ryhmä on päivitetty.
+        created: Ryhmä on luotu.
+        deleted: Ryhmä on poistettu.
 
 # Security
 "Bad credentials": Epäkelpo käyttäjätunnus tai salasana
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Päivitä
     flash:
-        updated: Profiili on päivitetty
+        updated: Profiili on päivitetty.
 
 # Password change
 change_password:
     submit: Vaihda salasana
     flash:
-        success: Salasana on vaihdettu
+        success: Salasana on vaihdettu.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Takaisin alkuperäiselle sivulle.
     submit: Luo tunnus
     flash:
-        user_created: Käyttäjätunnus on luotu onnistuneesti
+        user_created: Käyttäjätunnus on luotu onnistuneesti.
     email:
         subject: Tervetuloa %username%!
         message: |
@@ -68,7 +68,7 @@ resetting:
     reset:
         submit: Vaihda salasana
     flash:
-        success: Salasana on alustettu onnistuneesti
+        success: Salasana on alustettu onnistuneesti.
     email:
         subject: Alusta salasana
         message: |

--- a/Resources/translations/FOSUserBundle.fr.yml
+++ b/Resources/translations/FOSUserBundle.fr.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Créer le groupe
     flash:
-        updated: Le groupe a été mis à jour
-        created: Le groupe a été créé
-        deleted: Le groupe a été supprimé
+        updated: Le groupe a été mis à jour.
+        created: Le groupe a été créé.
+        deleted: Le groupe a été supprimé.
 
 # Security
 "Bad credentials": Nom d'utilisateur ou mot de passe incorrect
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Mettre à jour
     flash:
-        updated: Le profil a été mis à jour
+        updated: Le profil a été mis à jour.
 
 # Password change
 change_password:
     submit: Modifier le mot de passe
     flash:
-        success: Le mot de passe a été modifié
+        success: Le mot de passe a été modifié.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Retour à la page d'origine.
     submit: Enregistrer
     flash:
-        user_created: L'utilisateur a été créé avec succès
+        user_created: L'utilisateur a été créé avec succès.
     email:
         subject: Bienvenue %username% !
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Modifier le mot de passe
     flash:
-        success: Le mot de passe a été réinitialisé avec succès
+        success: Le mot de passe a été réinitialisé avec succès.
     email:
         subject: Réinitialisation de votre mot de passe
         message: |

--- a/Resources/translations/FOSUserBundle.hr.yml
+++ b/Resources/translations/FOSUserBundle.hr.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Spremi grupu
     flash:
-        updated: Grupa je uspješno ažurirana
-        created: Grupa je uspješno kreirana
-        deleted: Grupa je uspješno spremljena
+        updated: Grupa je uspješno ažurirana.
+        created: Grupa je uspješno kreirana.
+        deleted: Grupa je uspješno spremljena.
 
 # Security
 "Bad credentials": Krivo korisničko ime ili lozinka
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Ažuriraj
     flash:
-        updated: Profil je uspješno ažuriran
+        updated: Profil je uspješno ažuriran.
 
 # Password change
 change_password:
     submit: Izmijeni lozinku
     flash:
-        success: Lozinka je uspješno spremljena
+        success: Lozinka je uspješno spremljena.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Natrag na polaznu stranicu.
     submit: Registracija
     flash:
-        user_created: Korisnički račun je uspješno kreiran
+        user_created: Korisnički račun je uspješno kreiran.
     email:
         subject: Aktivacija korisničkog računa
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Spremi lozinku
     flash:
-        success: Lozinka je uspješno spremljena
+        success: Lozinka je uspješno spremljena.
     email:
         subject: Promjena lozinke
         message: |

--- a/Resources/translations/FOSUserBundle.hu.yml
+++ b/Resources/translations/FOSUserBundle.hu.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Csoport létrehozása
     flash:
-        updated: A csoport frissítve
-        created: A csoport létrehozva
-        deleted: A csoport törölve
+        updated: A csoport frissítve.
+        created: A csoport létrehozva.
+        deleted: A csoport törölve.
 
 # Security
 "Bad credentials": "Helytelen felhasználónév vagy jelszó"
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Frissítés
     flash:
-        updated: A profil frissítve
+        updated: A profil frissítve.
 
 # Password change
 change_password:
     submit: Jelszó megváltoztazása
     flash:
-        success: A jelszó megváltoztatva
+        success: A jelszó megváltoztatva.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Vissza az előző oldalra.
     submit: Regisztráció
     flash:
-        user_created: A felhasználó sikeresen létrehozva
+        user_created: A felhasználó sikeresen létrehozva.
     email:
         subject: Üdvözöljük %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Jelszó megváltoztatása
     flash:
-        success: A jelszó sikeresen lecserélve
+        success: A jelszó sikeresen lecserélve.
     email:
         subject: Jelszó lecserélése
         message: |

--- a/Resources/translations/FOSUserBundle.it.yml
+++ b/Resources/translations/FOSUserBundle.it.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Crea gruppo
     flash:
-        updated: Il gruppo è stato aggiornato
-        created: Il gruppo è stato creato
-        deleted: Il gruppo è stato cancellato
+        updated: Il gruppo è stato aggiornato.
+        created: Il gruppo è stato creato.
+        deleted: Il gruppo è stato cancellato.
 
 # Security
 security:
@@ -27,13 +27,13 @@ profile:
     edit:
         submit: Aggiorna
     flash:
-        updated: Il profilo è stato aggiornato
+        updated: Il profilo è stato aggiornato.
 
 # Password change
 change_password:
     submit: Cambia password
     flash:
-        success: La password è stata cambiata
+        success: La password è stata cambiata.
 
 # Registration
 registration:
@@ -42,7 +42,7 @@ registration:
     back: Torna alla pagina d'origine.
     submit: Registra
     flash:
-        user_created: Utente creato con successo
+        user_created: Utente creato con successo.
     email:
         subject: Benvenuto %username%!
         message: |
@@ -64,7 +64,7 @@ resetting:
     reset:
         submit: Cambia password
     flash:
-        success: La password è stata resettata
+        success: La password è stata resettata.
     email:
         subject: Password reset
         message: |

--- a/Resources/translations/FOSUserBundle.lb.yml
+++ b/Resources/translations/FOSUserBundle.lb.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Grupp creéieren
     flash:
-        updated: D'Grupp gouf aktualiséiert
-        created: D'Grupp gouf creéiert
-        deleted: D'Grupp gouf geläscht
+        updated: D'Grupp gouf aktualiséiert.
+        created: D'Grupp gouf creéiert.
+        deleted: D'Grupp gouf geläscht.
 
 # Security
 security:
@@ -27,13 +27,13 @@ profile:
     edit:
         submit: Benotzer aktualiséieren
     flash:
-        updated: De Benotzerprofil gouf aktualiséiert
+        updated: De Benotzerprofil gouf aktualiséiert.
 
 # Password change
 change_password:
     submit: Passwuert ännern
     flash:
-        success: D'Passwuert gouf geännert
+        success: D'Passwuert gouf geännert.
 
 # Registration
 registration:
@@ -42,7 +42,7 @@ registration:
     #back: Back to the originating page.
     submit: Registréieren
     flash:
-        user_created: De Benotzer gouf erfollegräich creéiert
+        user_created: De Benotzer gouf erfollegräich creéiert.
     email:
         subject: Wëllkomm %username%!
         message: |
@@ -64,7 +64,7 @@ resetting:
     reset:
         submit: Passwuert ännern
     flash:
-        success: D'Passwuert gouf erfollegräich zeréckgesat
+        success: D'Passwuert gouf erfollegräich zeréckgesat.
     email:
         subject: Wëllkomm %username%!
         message: |

--- a/Resources/translations/FOSUserBundle.lt.yml
+++ b/Resources/translations/FOSUserBundle.lt.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Sukurti grupę
     flash:
-        updated: Grupė buvo atnaujinta
-        created: Grupė buvo sukurta
-        deleted: Grupė buvo ištrinta
+        updated: Grupė buvo atnaujinta.
+        created: Grupė buvo sukurta.
+        deleted: Grupė buvo ištrinta.
 
 # Security
 "Bad credentials": Neteisingas naudotojas arba slaptažodis
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Atnaujinti
     flash:
-        updated: Profilis buvo atnaujintas
+        updated: Profilis buvo atnaujintas.
 
 # Password change
 change_password:
     submit: Pakeisti slaptažodi
     flash:
-        success: slaptažodis buvo pakeistas
+        success: slaptažodis buvo pakeistas.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Gryžti i praeitą puslapi.
     submit: Registruotis
     flash:
-        user_created: Naudotojas buvo sukurtas sėkmingai
+        user_created: Naudotojas buvo sukurtas sėkmingai.
     email:
         subject: Sveiki %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Pakeisti slaptažodi
     flash:
-        success: Slaptažodis pakeistas sėkmingai
+        success: Slaptažodis pakeistas sėkmingai.
     email:
         subject: Nustatyti slaptažodi
         message: |

--- a/Resources/translations/FOSUserBundle.lv.yml
+++ b/Resources/translations/FOSUserBundle.lv.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Izveidot grupu
     flash:
-        updated: Grupa tika atjaunināta
-        created: Grupa tika izveidota
-        deleted: Grupa tika dzēsta
+        updated: Grupa tika atjaunināta.
+        created: Grupa tika izveidota.
+        deleted: Grupa tika dzēsta.
 
 # Security
 "Bad credentials": Nederīgs lietotājvārds vai parole
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Saglabāt
     flash:
-        updated: Profila izmaiņas tika saglabātas
+        updated: Profila izmaiņas tika saglabātas.
 
 # Password change
 change_password:
     submit: Nomainīt paroli
     flash:
-        success: Parole tika nomainīta
+        success: Parole tika nomainīta.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Atpakaļ uz sākotnējo lapu.
     submit: Reģistrēties
     flash:
-        user_created: Lietotājs tika izveidots
+        user_created: Lietotājs tika izveidots.
     email:
         subject: Sveiki, %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Nomainīt paroli
     flash:
-        success: Parole tika atiestatīta
+        success: Parole tika atiestatīta.
     email:
         subject: Paroles atiestatīšana
         message: |

--- a/Resources/translations/FOSUserBundle.nl.yml
+++ b/Resources/translations/FOSUserBundle.nl.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Groep aanmaken
     flash:
-        updated: De groep is bijgewerkt
-        created: De groep is aangemaakt
-        deleted: De groep is verwijderd
+        updated: De groep is bijgewerkt.
+        created: De groep is aangemaakt.
+        deleted: De groep is verwijderd.
 
 # Security
 "Bad credentials": Gebruikersnaam of wachtwoord ongeldig
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Bijwerken
     flash:
-        updated: Het profiel is bijgewerkt
+        updated: Het profiel is bijgewerkt.
 
 # Password change
 change_password:
     submit: Wachtwoord wijzigen
     flash:
-        success: Het wachtwoord is gewijzigd
+        success: Het wachtwoord is gewijzigd.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Terug naar de oorspronkelijke pagina.
     submit: Registreer
     flash:
-        user_created: De gebruiker is succesvol aangemaakt
+        user_created: De gebruiker is succesvol aangemaakt.
     email:
         subject: Welkom %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Wijzig wachtwoord
     flash:
-        success: Het wachtwoord is succesvol gereset
+        success: Het wachtwoord is succesvol gereset.
     email:
         subject: Reset wachtwoord
         message: |

--- a/Resources/translations/FOSUserBundle.pl.yml
+++ b/Resources/translations/FOSUserBundle.pl.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Utwórz grupę
     flash:
-        updated: Grupa została zaktualizowana
-        created: Grupa została utworzona
-        deleted: Grupa została usunięta
+        updated: Grupa została zaktualizowana.
+        created: Grupa została utworzona.
+        deleted: Grupa została usunięta.
 
 # Security
 "Bad credentials": Nieprawidłowa nazwa użytkownika lub hasło
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Edytuj użytkownika
     flash:
-        updated: Zapisano zmiany w profilu
+        updated: Zapisano zmiany w profilu.
 
 # Password change
 change_password:
     submit: Zmień hasło
     flash:
-        success: Hasło zostało zmienione
+        success: Hasło zostało zmienione.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Powrót do poprzedniej strony.
     submit: Zarejestruj
     flash:
-        user_created: Stworzono użytkownika
+        user_created: Stworzono użytkownika.
     email:
         subject: Witaj %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Zmień hasło
     flash:
-        success: Hasło zostało zresetowane
+        success: Hasło zostało zresetowane.
     email:
         subject: Resetowanie hasła
         message: |

--- a/Resources/translations/FOSUserBundle.pt_BR.yml
+++ b/Resources/translations/FOSUserBundle.pt_BR.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Criar Grupo
     flash:
-        updated: O grupo foi atualizado
-        created: O grupo foi criado
-        deleted: O grupo foi removido
+        updated: O grupo foi atualizado.
+        created: O grupo foi criado.
+        deleted: O grupo foi removido.
 
 # Security
 "Bad credentials": Usuário ou senha inválida

--- a/Resources/translations/FOSUserBundle.ro.yml
+++ b/Resources/translations/FOSUserBundle.ro.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Creează grup
     flash:
-        updated: Grupul a fost actualizat
-        created: Grupul a fost creat
-        deleted: Grupul a fost șters
+        updated: Grupul a fost actualizat.
+        created: Grupul a fost creat.
+        deleted: Grupul a fost șters.
 
 # Security
 security:
@@ -27,13 +27,13 @@ profile:
     edit:
         submit: Actualizează
     flash:
-        updated: Profilul a fost actualizat
+        updated: Profilul a fost actualizat.
 
 # Password change
 change_password:
     submit: Schimba parola
     flash:
-        success: Parola a fost schimbata
+        success: Parola a fost schimbata.
 
 # Registration
 registration:
@@ -42,7 +42,7 @@ registration:
     back: Inapoi la pagina de la care ai venit.
     submit: Inregistreaza-te
     flash:
-        user_created: Utilizatorul a fost creat cu succes
+        user_created: Utilizatorul a fost creat cu succes.
     email:
         subject: Bine ai venit %username%!
         message: |
@@ -64,7 +64,7 @@ resetting:
     reset:
         submit: Schimba parola
     flash:
-        success: Parola a fost resetata cu succes
+        success: Parola a fost resetata cu succes.
     email:
         subject: Resetare parola
         message: |

--- a/Resources/translations/FOSUserBundle.ru.yml
+++ b/Resources/translations/FOSUserBundle.ru.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Создать группу
     flash:
-        updated: Группа обновлена
-        created: Группа создана
-        deleted: Группа удалена
+        updated: Группа обновлена.
+        created: Группа создана.
+        deleted: Группа удалена.
 
 # Security
 "Bad credentials": Неправильное имя пользователя или пароль
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Обновить
     flash:
-        updated: Профиль пользователя обновлен
+        updated: Профиль пользователя обновлен.
 
 # Password change
 change_password:
     submit: Изменить пароль
     flash:
-        success: Пароль изменен
+        success: Пароль изменен.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Вернуться на предыдущую страницу.
     submit: Регистрация
     flash:
-        user_created: Пользователь успешно создан
+        user_created: Пользователь успешно создан.
     email:
         subject: Добро пожаловать, %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Изменить пароль
     flash:
-        success: Пароль успешно сброшен
+        success: Пароль успешно сброшен.
     email:
         subject: Сброс пароля
         message: |

--- a/Resources/translations/FOSUserBundle.sk.yml
+++ b/Resources/translations/FOSUserBundle.sk.yml
@@ -33,7 +33,7 @@ profile:
 change_password:
     submit: Zmena hesla
     flash:
-        success: Heslo bolo úspešne zmenené
+        success: Heslo bolo úspešne zmenené.
 
 # Registration
 registration:

--- a/Resources/translations/FOSUserBundle.sl.yml
+++ b/Resources/translations/FOSUserBundle.sl.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Shrani
     flash:
-        updated: Skupina je bila uspešno shranjena
-        created: Skupina je bila uspešno ustvarjena
-        deleted: Skupina je bila uspešno izbrisana
+        updated: Skupina je bila uspešno shranjena.
+        created: Skupina je bila uspešno ustvarjena.
+        deleted: Skupina je bila uspešno izbrisana.
 
 # Security
 "Bad credentials": Napačno uporabniško ime ali geslo
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Shrani
     flash:
-        updated: Profil je bil uspešno shranjen
+        updated: Profil je bil uspešno shranjen.
 
 # Password change
 change_password:
     submit: Spremeni geslo
     flash:
-        success: Geslo je bilo uspešno spremenjeno
+        success: Geslo je bilo uspešno spremenjeno.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Nazaj na prvotno stran.
     submit: Registracija
     flash:
-        user_created: Uporabnik je bil uspešno ustvarjen
+        user_created: Uporabnik je bil uspešno ustvarjen.
     email:
         subject: Aktivacija računa
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Spremeni geslo
     flash:
-        success: Geslo je bilo uspešno spremenjeno
+        success: Geslo je bilo uspešno spremenjeno.
     email:
         subject: Sprememba gesla
         message: |

--- a/Resources/translations/FOSUserBundle.sr_Latn.yml
+++ b/Resources/translations/FOSUserBundle.sr_Latn.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Kreiraj grupu
     flash:
-        updated: Grupa je ažurirana
-        created: Grupa je kreirana
-        deleted: Grupa je obrisana
+        updated: Grupa je ažurirana.
+        created: Grupa je kreirana.
+        deleted: Grupa je obrisana.
 
 # Security
 "Bad credentials": Nevalidno korisničko ime ili lozinka
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Ažuriraj
     flash:
-        updated: Profil je ažuriran
+        updated: Profil je ažuriran.
 
 # Password change
 change_password:
     submit: Izmeni lozinku
     flash:
-        success: Lozinka je izmenjena
+        success: Lozinka je izmenjena.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Nazad na prethodnu stranu.
     submit: Registruj se
     flash:
-        user_created: Korisnički nalog je uspešno kreiran
+        user_created: Korisnički nalog je uspešno kreiran.
     email:
         subject: Dobrodošli %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Izmeni lozinku
     flash:
-        success: Lozinka je uspešno resetovana
+        success: Lozinka je uspešno resetovana.
     email:
         subject: Resetovanje lozinke
         message: |

--- a/Resources/translations/FOSUserBundle.sv.yml
+++ b/Resources/translations/FOSUserBundle.sv.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Skapa grupp
     flash:
-        updated: Gruppen har uppdaterats
-        created: Gruppen har skapats
-        deleted: Gruppen har tagits bort
+        updated: Gruppen har uppdaterats.
+        created: Gruppen har skapats.
+        deleted: Gruppen har tagits bort.
 
 # Security
 security:
@@ -27,13 +27,13 @@ profile:
     edit:
         submit: Uppdatera
     flash:
-        updated: Profilen har uppdaterats
+        updated: Profilen har uppdaterats.
 
 # Password change
 change_password:
     submit: Ändra lösenord
     flash:
-        success: Lösenordet har ändrats
+        success: Lösenordet har ändrats.
 
 # Registration
 registration:
@@ -64,7 +64,7 @@ resetting:
     reset:
         submit: Ändra lösenord
     flash:
-        success: Lösenordet har återställts
+        success: Lösenordet har återställts.
     email:
         subject: Återställ lösenord
         message: |

--- a/Resources/translations/FOSUserBundle.tr.yml
+++ b/Resources/translations/FOSUserBundle.tr.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Grup Yarat
     flash:
-        updated: Grup Güncellendi
-        created: Grup Yaratıldı
-        deleted: Grup Silindi
+        updated: Grup Güncellendi.
+        created: Grup Yaratıldı.
+        deleted: Grup Silindi.
 
 # Security
 "Bad credentials": Geçersiz kullanıcı adı ya da parola
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Güncelle
     flash:
-        updated: Profil Güncellendi
+        updated: Profil Güncellendi.
 
 # Password change
 change_password:
     submit: Parolayı Değiştir
     flash:
-        success: Parola değiştirildi
+        success: Parola değiştirildi.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Asıl sayfaya geri dön.
     submit: Kayıt ol
     flash:
-        user_created: Kullanıcı başarıyla yaratıldı
+        user_created: Kullanıcı başarıyla yaratıldı.
     email:
         subject: Hoşgeldin %username%!
         message: |
@@ -70,7 +70,7 @@ resetting:
     reset:
         submit: Parolayı değiştir
     flash:
-        success: Parola başarıyla değiştirildi
+        success: Parola başarıyla değiştirildi.
     email:
         subject: Parola Yenileme
         message: |

--- a/Resources/translations/FOSUserBundle.uk.yml
+++ b/Resources/translations/FOSUserBundle.uk.yml
@@ -7,9 +7,9 @@ group:
     new:
         submit: Створити групу
     flash:
-        updated: Група оновлена
-        created: Група створена
-        deleted: Група видалена
+        updated: Група оновлена.
+        created: Група створена.
+        deleted: Група видалена.
 
 # Security
 "Bad credentials": "Невірне ім'я користувача або пароль"
@@ -32,13 +32,13 @@ profile:
     edit:
         submit: Оновити
     flash:
-        updated: Профіль користувача оновлено
+        updated: Профіль користувача оновлено.
 
 # Password change
 change_password:
     submit: Змінити пароль
     flash:
-        success: Пароль змінено
+        success: Пароль змінено.
 
 # Registration
 registration:
@@ -47,7 +47,7 @@ registration:
     back: Повернутися на попередню сторінку.
     submit: Реєстрація
     flash:
-        user_created: Користувач успішно створений
+        user_created: Користувач успішно створений.
     email:
         subject: Вітаємо %username%!
         message: |
@@ -69,7 +69,7 @@ resetting:
     reset:
         submit: Змінити пароль
     flash:
-        success: Пароль успішно скинуто
+        success: Пароль успішно скинуто.
     email:
         subject: Скидання пароля
         message: |


### PR DESCRIPTION
cause it seems that there is no trailing dot needed.
For pt_PT and et there is no translation for flash messages at all.
Also see #1601 