### PR TITLE
Add ISSUE_TEMPLATE with basic questions for bug and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+GitHub is reserved for bug reports and feature requests. 
+Please include one and only one of the below blocks
+in your new issue.
+-->
+
+<!--
+If you are filing a bug report, please remove the below feature
+request block and provide responses for all of the below items.
+-->
+
+**Symfony FOSUserBundle versions**:
+
+<!--
+You can run `composer info` in your project to get those informations
+-->
+
+**Description of the problem including expected versus actual behavior**:
+
+**Steps to reproduce**:
+ 1.
+ 2.
+ 3.
+
+**Provide logs (if relevant)**:
+
+<!--
+If you are filing a feature request, please remove the above bug
+report block and provide responses for all of the below items.
+-->
+
+**Describe the feature**:


### PR DESCRIPTION
Issues are often missing a lots of informations about how to reproduce a bug, the versions which are used, etc.

I think an Issue template can help and educate the new users about how to submit a proper bug or feature request, and make it easier for maintainers.