### PR TITLE
Clarifying that role changes don't apply until the user logs out.

### DIFF
--- a/Command/DemoteUserCommand.php
+++ b/Command/DemoteUserCommand.php
@@ -46,10 +46,10 @@ EOT
     {
         if ($super) {
             $manipulator->demote($username);
-            $output->writeln(sprintf('User "%s" has been demoted as a simple user.', $username));
+            $output->writeln(sprintf('User "%s" has been demoted as a simple user. This change will not apply until the user logs out and back in again.', $username));
         } else {
             if ($manipulator->removeRole($username, $role)) {
-                $output->writeln(sprintf('Role "%s" has been removed from user "%s".', $role, $username));
+                $output->writeln(sprintf('Role "%s" has been removed from user "%s". This change will not apply until the user logs out and back in again.', $role, $username));
             } else {
                 $output->writeln(sprintf('User "%s" didn\'t have "%s" role.', $username, $role));
             }

--- a/Command/PromoteUserCommand.php
+++ b/Command/PromoteUserCommand.php
@@ -48,10 +48,10 @@ EOT
     {
         if ($super) {
             $manipulator->promote($username);
-            $output->writeln(sprintf('User "%s" has been promoted as a super administrator.', $username));
+            $output->writeln(sprintf('User "%s" has been promoted as a super administrator. This change will not apply until the user logs out and back in again.', $username));
         } else {
             if ($manipulator->addRole($username, $role)) {
-                $output->writeln(sprintf('Role "%s" has been added to user "%s".', $role, $username));
+                $output->writeln(sprintf('Role "%s" has been added to user "%s". This change will not apply until the user logs out and back in again.', $role, $username));
             } else {
                 $output->writeln(sprintf('User "%s" did already have "%s" role.', $username, $role));
             }


### PR DESCRIPTION
This change adds a note to the command output that users must log out for promotions and demotions to be applied.

See: https://github.com/FriendsOfSymfony/FOSUserBundle/issues/1679