### PR TITLE
Make sure their is no new line in email subject

### DIFF
--- a/Resources/views/Registration/email.txt.twig
+++ b/Resources/views/Registration/email.txt.twig
@@ -1,8 +1,9 @@
 {% block subject %}
-{% autoescape false %}
+{%- autoescape false -%}
 {{ 'registration.email.subject'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}
-{% endautoescape %}
+{%- endautoescape -%}
 {% endblock %}
+
 {% block body_text %}
 {% autoescape false %}
 {{ 'registration.email.message'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}

--- a/Resources/views/Resetting/email.txt.twig
+++ b/Resources/views/Resetting/email.txt.twig
@@ -1,8 +1,9 @@
 {% block subject %}
-{% autoescape false %}
+{%- autoescape false -%}
 {{ 'resetting.email.subject'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}
-{% endautoescape %}
+{%- endautoescape -%}
 {% endblock %}
+
 {% block body_text %}
 {% autoescape false %}
 {{ 'resetting.email.message'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}, 'FOSUserBundle') }}


### PR DESCRIPTION
Fix #1747.

Remove any new line in the subject block for TwigSwiftMailer rendering but still let a new line for the default Mailer. Could also be merged for 1.3.