### PR TITLE
Hash confirmation token

### DIFF
--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -78,7 +78,8 @@ class ResettingController extends Controller
             if (null === $user->getConfirmationToken()) {
                 /** @var $tokenGenerator TokenGeneratorInterface */
                 $tokenGenerator = $this->get('fos_user.util.token_generator');
-                $user->setConfirmationToken($tokenGenerator->generateToken());
+                $user->setPlainConfirmationToken($tokenGenerator->generateToken());
+                $user->setConfirmationToken(hash('sha256', $user->getPlainConfirmationToken()));
             }
 
             /* Dispatch confirm event */

--- a/EventListener/EmailConfirmationListener.php
+++ b/EventListener/EmailConfirmationListener.php
@@ -63,7 +63,8 @@ class EmailConfirmationListener implements EventSubscriberInterface
 
         $user->setEnabled(false);
         if (null === $user->getConfirmationToken()) {
-            $user->setConfirmationToken($this->tokenGenerator->generateToken());
+            $user->setPlainConfirmationToken($this->tokenGenerator->generateToken());
+            $user->setConfirmationToken(hash('sha256', $user->getPlainConfirmationToken()));
         }
 
         $this->mailer->sendConfirmationEmailMessage($user);

--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -62,7 +62,7 @@ class Mailer implements MailerInterface
     public function sendConfirmationEmailMessage(UserInterface $user)
     {
         $template = $this->parameters['confirmation.template'];
-        $url = $this->router->generate('fos_user_registration_confirm', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
+        $url = $this->router->generate('fos_user_registration_confirm', array('token' => $user->getPlainConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
         $rendered = $this->templating->render($template, array(
             'user' => $user,
             'confirmationUrl' => $url,
@@ -76,7 +76,7 @@ class Mailer implements MailerInterface
     public function sendResettingEmailMessage(UserInterface $user)
     {
         $template = $this->parameters['resetting.template'];
-        $url = $this->router->generate('fos_user_resetting_reset', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
+        $url = $this->router->generate('fos_user_resetting_reset', array('token' => $user->getPlainConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
         $rendered = $this->templating->render($template, array(
             'user' => $user,
             'confirmationUrl' => $url,

--- a/Model/User.php
+++ b/Model/User.php
@@ -79,7 +79,14 @@ abstract class User implements UserInterface, GroupableInterface
     protected $lastLogin;
 
     /**
-     * Random string sent to the user email address in order to verify it.
+     * Confirmation token before hashing.
+     *
+     * @var string
+     */
+    protected $plainConfirmationToken;
+
+    /**
+     * Hashed token.
      *
      * @var string
      */
@@ -178,6 +185,7 @@ abstract class User implements UserInterface, GroupableInterface
     public function eraseCredentials()
     {
         $this->plainPassword = null;
+        $this->plainConfirmationToken = null;
     }
 
     /**
@@ -442,6 +450,24 @@ abstract class User implements UserInterface, GroupableInterface
     public function setConfirmationToken($confirmationToken)
     {
         $this->confirmationToken = $confirmationToken;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPlainConfirmationToken()
+    {
+        return $this->plainConfirmationToken;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPlainConfirmationToken($plainConfirmationToken)
+    {
+        $this->plainConfirmationToken = $plainConfirmationToken;
 
         return $this;
     }

--- a/Model/UserInterface.php
+++ b/Model/UserInterface.php
@@ -157,6 +157,22 @@ interface UserInterface extends AdvancedUserInterface, \Serializable
     public function setConfirmationToken($confirmationToken);
 
     /**
+     * Gets the plain confirmation token.
+     *
+     * @return string
+     */
+    public function getPlainConfirmationToken();
+
+    /**
+     * Sets the plain confirmation token.
+     *
+     * @param string $plainConfirmationToken
+     *
+     * @return self
+     */
+    public function setPlainConfirmationToken($plainConfirmationToken);
+
+    /**
      * Sets the timestamp that the user requested a password reset.
      *
      * @param null|\DateTime $date

--- a/Model/UserManager.php
+++ b/Model/UserManager.php
@@ -75,7 +75,7 @@ abstract class UserManager implements UserManagerInterface
      */
     public function findUserByConfirmationToken($token)
     {
-        return $this->findUserBy(array('confirmationToken' => $token));
+        return $this->findUserBy(array('confirmationToken' => hash('sha256', $token)));
     }
 
     /**
@@ -92,6 +92,7 @@ abstract class UserManager implements UserManagerInterface
     public function updatePassword(UserInterface $user)
     {
         $this->passwordUpdater->hashPassword($user);
+        $user->eraseCredentials();
     }
 
     /**


### PR DESCRIPTION
Fixes #1791 

There are a couple of solutions to tackle this problem:
- Hash the confirmation token with a salt
- Hash the confirmation token without salt (which IMO is enough)

I've chosen the second solution which I find much simpler, contains less BC breaks (though it's not relevant as it's a security feature ...), and adds a sufficient security layer.

Now I'm wondering whether I should add the user id in the URL so that the user is retrieved by it's id, and then we compare the hashes instead of directly searching by hash.

WDYT overall @stof @XWB ?