### PR TITLE
Call Form::isValid() with an unsubmitted form is deprecated

### DIFF
--- a/Controller/ChangePasswordController.php
+++ b/Controller/ChangePasswordController.php
@@ -65,7 +65,7 @@ class ChangePasswordController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             /** @var $userManager UserManagerInterface */
             $userManager = $this->get('fos_user.user_manager');
 

--- a/Controller/GroupController.php
+++ b/Controller/GroupController.php
@@ -91,7 +91,7 @@ class GroupController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             /** @var $groupManager \FOS\UserBundle\Model\GroupManagerInterface */
             $groupManager = $this->get('fos_user.group_manager');
 
@@ -141,7 +141,7 @@ class GroupController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
             $dispatcher->dispatch(FOSUserEvents::GROUP_CREATE_SUCCESS, $event);
 

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -79,7 +79,7 @@ class ProfileController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             /** @var $userManager UserManagerInterface */
             $userManager = $this->get('fos_user.user_manager');
 

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -161,7 +161,7 @@ class ResettingController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
             $dispatcher->dispatch(FOSUserEvents::RESETTING_RESET_SUCCESS, $event);
 


### PR DESCRIPTION
Fixes https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2369