### PR TITLE
Route missing in register.html.twig

### DIFF
--- a/Resources/views/Registration/register.html.twig
+++ b/Resources/views/Registration/register.html.twig
@@ -1,5 +1,5 @@
 {% extends "@FOSUser/layout.html.twig" %}
 
 {% block fos_user_content %}
-{% include "register_content.html.twig" %}
+{% include "@FOSUser/Registration/register_content.html.twig" %}
 {% endblock fos_user_content %}


### PR DESCRIPTION
The route to register_content.html.twig was incomplete and throws an error.