### PR TITLE
Enforce the min version of DoctrineBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "phpunit/phpunit": "~4.8|~5.0"
     },
     "conflict": {
+        "doctrine/doctrine-bundle": "<1.3",
         "symfony/doctrine-bridge": "<2.7"
     },
     "autoload": {


### PR DESCRIPTION
Avoids issues where the mapping is not loaded (see https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2072 about it)