### PR TITLE
Fix BC break in 1.3.7

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -184,7 +184,7 @@ abstract class User implements UserInterface, GroupableInterface
         $data = unserialize($serialized);
         // add a few extra elements in the array to ensure that we have enough keys when unserializing
         // older data which does not include all properties.
-        $data = array_merge($data, array_fill(0, 2, null));
+        $data = array_merge($data, array_fill(0, 4, null));
 
         list(
             $this->password,


### PR DESCRIPTION
After upgrading from 1.3.6 to 1.3.7 I get an error when unserializing an old session:
**Notice: Undefined offset: 11** in Model/User.php line 202.

This BC break was caused by #1936 that added 4 new values, but the BC padding in `unserialize()` only a pads with 2 nulls.