### PR TITLE
Changes in SecurityController.php and login_content.html.twig

### DIFF
--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -53,7 +53,16 @@ class SecurityController extends Controller
             ? $this->get('security.csrf.token_manager')->getToken('authenticate')->getValue()
             : null;
 
+         $form = $this->createFormBuilder()
+            ->add('_username', TextType::class, array('data' => $lastUsername))
+            ->add('_password', PasswordType::class)
+            ->add('_remember_me', CheckboxType::class, array('required' => false))
+            ->add('_submit', SubmitType::class)
+            ->getForm()
+            ->createView();
+
         return $this->renderLogin(array(
+            'form' => $form,
             'last_username' => $lastUsername,
             'error' => $error,
             'csrf_token' => $csrfToken,

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -16,6 +16,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 
 class SecurityController extends Controller
 {

--- a/Resources/views/Security/login_content.html.twig
+++ b/Resources/views/Security/login_content.html.twig
@@ -9,14 +9,11 @@
         <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
     {% endif %}
 
-    <label for="username">{{ 'security.login.username'|trans }}</label>
-    <input type="text" id="username" name="_username" value="{{ last_username }}" required="required" />
+    {{ form_row(form._username, {'full_name': '_username', 'label': 'security.login.username'|trans}) }}
 
-    <label for="password">{{ 'security.login.password'|trans }}</label>
-    <input type="password" id="password" name="_password" required="required" />
+    {{ form_row(form._password, {'full_name': '_password', 'label': 'security.login.password'|trans}) }}
 
-    <input type="checkbox" id="remember_me" name="_remember_me" value="on" />
-    <label for="remember_me">{{ 'security.login.remember_me'|trans }}</label>
+    {{ form_row(form._remember_me, {'full_name': '_remember_me', value: "on", 'label': 'security.login.remember_me'|trans}) }}
 
-    <input type="submit" id="_submit" name="_submit" value="{{ 'security.login.submit'|trans }}" />
+    {{ form_row(form._submit, {'label': 'security.login.submit'|trans}) }}
 </form>


### PR DESCRIPTION
When you try to use a common design in your forms and you try to use form_row, form_widget or form_label in login form (login_content.html.twig) you can't use it because controller don't send a form view, with these changes you can use form_row, form_widget, form_label, etc., and you can avoid repeat html.