### PR TITLE
Update FOSUserBundle.en.yml

### DIFF
--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -43,7 +43,9 @@ registration:
         message: |
             Hello %username%!
 
-            To finish activating your account - please visit %confirmationUrl%
+            To finish activating your account - please visit %confirmationUrl%.
+            
+            This link can only be used once to validate your account.
 
             Regards,
             the Team.


### PR DESCRIPTION
Adding this text can prevent other clicks on the activation url as specified in #2371, unless the solution from @dmaicher in #2106 is merged