### PR TITLE
Max length matches entity

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -17,7 +17,7 @@
             <constraint name="Length">
                 <option name="min">2</option>
                 <option name="minMessage">fos_user.username.short</option>
-                <option name="max">255</option>
+                <option name="max">180</option>
                 <option name="maxMessage">fos_user.username.long</option>
                 <option name="groups">
                     <value>Registration</value>
@@ -37,7 +37,7 @@
             <constraint name="Length">
                 <option name="min">2</option>
                 <option name="minMessage">fos_user.email.short</option>
-                <option name="max">254</option>
+                <option name="max">180</option>
                 <option name="maxMessage">fos_user.email.long</option>
                 <option name="groups">
                     <value>Registration</value>


### PR DESCRIPTION
The max length was different in validation and database structure. If one would set his username to have 181 chars, then the validation would let it pass, but there would be a database error.