### PR TITLE
.php_cs: Remove 'Tests/Fixtures' from exclusion list

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,7 +13,6 @@ Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
 
 $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->in(array(__DIR__))
-    ->exclude(array('Tests/Fixtures'))
 ;
 
 return Symfony\CS\Config\Config::create()


### PR DESCRIPTION
This directory does not exist: https://github.com/FriendsOfSymfony/FOSUserBundle/tree/master/Tests