### PR TITLE
Re-use e-mail confirmation link

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -138,17 +138,20 @@ class RegistrationController extends Controller
         /** @var $dispatcher EventDispatcherInterface */
         $dispatcher = $this->get('event_dispatcher');
 
-        $user->setConfirmationToken(null);
-        $user->setEnabled(true);
+        if ($user->isEnabled()) {
+            $response = new RedirectResponse('fos_user_registration_confirmed');
+        } else {
+            $user->setEnabled(true);
 
-        $event = new GetResponseUserEvent($user, $request);
-        $dispatcher->dispatch(FOSUserEvents::REGISTRATION_CONFIRM, $event);
+            $event = new GetResponseUserEvent($user, $request);
+            $dispatcher->dispatch(FOSUserEvents::REGISTRATION_CONFIRM, $event);
 
-        $userManager->updateUser($user);
+            $userManager->updateUser($user);
 
-        if (null === $response = $event->getResponse()) {
-            $url = $this->generateUrl('fos_user_registration_confirmed');
-            $response = new RedirectResponse($url);
+            if (null === $response = $event->getResponse()) {
+                $url = $this->generateUrl('fos_user_registration_confirmed');
+                $response = new RedirectResponse($url);
+            }
         }
 
         $dispatcher->dispatch(FOSUserEvents::REGISTRATION_CONFIRMED, new FilterUserResponseEvent($user, $request, $response));


### PR DESCRIPTION
This PR doesn't remove the confirmation token after the user confirms the registration. That would allow to click the confirmation link twice without any error message.

This should fix https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2106