### PR TITLE
group name utf8mb4 compatibility fix

### DIFF
--- a/Resources/config/doctrine-mapping/Group.orm.xml
+++ b/Resources/config/doctrine-mapping/Group.orm.xml
@@ -6,7 +6,7 @@
 
     <mapped-superclass name="FOS\UserBundle\Model\Group">
 
-        <field name="name" column="name" type="string" length="255" unique="true" />
+        <field name="name" column="name" type="string" length="180" unique="true" />
 
         <field name="roles" column="roles" type="array" />
 

--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -85,7 +85,7 @@
             <constraint name="Length">
                 <option name="min">2</option>
                 <option name="minMessage">fos_user.group.short</option>
-                <option name="max">255</option>
+                <option name="max">180</option>
                 <option name="maxMessage">fos_user.group.long</option>
                 <option name="groups">Registration</option>
             </constraint>


### PR DESCRIPTION
when using utf8mb4 collation, the group names unique index would also be too long..
see #1919