### PR TITLE
removed extra dot in english translation

### DIFF
--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -43,7 +43,7 @@ registration:
         message: |
             Hello %username%!
 
-            To finish activating your account - please visit %confirmationUrl%.
+            To finish activating your account - please visit %confirmationUrl%
             
             This link can only be used once to validate your account.
 


### PR DESCRIPTION
this was causing confirmation token sent in the link for to newly registered user to be wrong