### PR TITLE
Remove dot for confirmationUrl (see #2452)

### DIFF
--- a/Resources/translations/FOSUserBundle.fr.yml
+++ b/Resources/translations/FOSUserBundle.fr.yml
@@ -39,7 +39,7 @@ registration:
         message: |
             Bonjour %username% !
 
-            Pour valider votre compte utilisateur, merci de vous rendre sur %confirmationUrl%.
+            Pour valider votre compte utilisateur, merci de vous rendre sur %confirmationUrl%
             
             Ce lien ne peut être utilisé qu'une seule fois pour valider votre compte.
 


### PR DESCRIPTION
The dot may cause a problem for the confirmation url, see https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2452