### PR TITLE
Description improved with "from_email" explanation

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -359,11 +359,12 @@ of datastore you are using.
             user-class="AppBundle\Entity\User"
         />
 
-Only three configuration values are required to use the bundle:
+Only four configuration's node are required to use the bundle:
 
 * The type of datastore you are using (``orm``, ``mongodb`` or ``couchdb``).
 * The firewall name which you configured in Step 4.
 * The fully qualified class name (FQCN) of the ``User`` class which you created in Step 3.
+* The default email address to use when the bundle send a registration confirmation to the user.
 
 .. note::
 


### PR DESCRIPTION
Since FOSUserBundle implements the "from_email" configuration's node, the description of the minimum required configuration was not up-to-date. In theory, it's the entry point for a new developer who wants to use the bundle so this detail can prevent from something goes wrong.