### PR TITLE
registration.form.name

### DIFF
--- a/Resources/doc/overriding_forms.rst
+++ b/Resources/doc/overriding_forms.rst
@@ -149,7 +149,7 @@ changing the registration form type in YAML.
         # ...
         registration:
             form:
-                type: app_user_registration
+                name: app_user_registration
 
 Note how the ``alias`` value used in your form type's service configuration tag
 is used in the bundle configuration to tell the FOSUserBundle to use your custom


### PR DESCRIPTION
the alias of your custom form needs to be defined on the ``name`` property rather than the ``type`` property of the form configuration.