### PR TITLE
Inject firewall's UserChecker into LoginManager

### DIFF
--- a/DependencyInjection/Compiler/InjectUserCheckerPass.php
+++ b/DependencyInjection/Compiler/InjectUserCheckerPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Injects firewall's UserChecker into LoginManager.
+ *
+ * @author Gocha Ossinkine <ossinkine@ya.ru>
+ */
+class InjectUserCheckerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $firewallName = $container->getParameter('fos_user.firewall_name');
+        $loginManager = $container->getDefinition('fos_user.security.login_manager');
+
+        if ($container->hasAlias('security.user_checker.'.$firewallName)) {
+            $loginManager->replaceArgument(1, new Reference('security.user_checker.'.$firewallName));
+        }
+    }
+}

--- a/FOSUserBundle.php
+++ b/FOSUserBundle.php
@@ -15,6 +15,7 @@ use Doctrine\Bundle\CouchDBBundle\DependencyInjection\Compiler\DoctrineCouchDBMa
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
 use FOS\UserBundle\DependencyInjection\Compiler\InjectRememberMeServicesPass;
+use FOS\UserBundle\DependencyInjection\Compiler\InjectUserCheckerPass;
 use FOS\UserBundle\DependencyInjection\Compiler\ValidationPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -32,6 +33,7 @@ class FOSUserBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new ValidationPass());
+        $container->addCompilerPass(new InjectUserCheckerPass());
         $container->addCompilerPass(new InjectRememberMeServicesPass());
 
         $this->addRegisterMappingsPass($container);


### PR DESCRIPTION
I suppose to inject UserChecker specified in firewall settings into LoginManager.
For example I specified in security:
```
security:
    firewalls:
        main:
            pattern: ^/
            form_login:
                provider: fos_userbundle
                csrf_token_generator: security.csrf.token_manager
            logout:       true
            anonymous:    true
            user_checker: app.user_checker
```
I expect that LoginManager also will be use `@app.user_checker` service.