### PR TITLE
prevent DB connections inside constructor code

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Changelog
 * Add a timeout for the reset retry request.
 * Add Esperanto translations.
 * Fixed incorrect confirmation url.
+* [BC break] Use UserManager::getRepository() instead of UserManager::$repository
+* [BC break] Use UserManager::getClass() instead of UserManager::$class
 
 ### 2.0.0-beta2 (2017-01-31)
 

--- a/Doctrine/UserManager.php
+++ b/Doctrine/UserManager.php
@@ -28,12 +28,7 @@ class UserManager extends BaseUserManager
     /**
      * @var string
      */
-    protected $class;
-
-    /**
-     * @var ObjectRepository
-     */
-    protected $repository;
+    private $class;
 
     /**
      * Constructor.
@@ -48,10 +43,15 @@ class UserManager extends BaseUserManager
         parent::__construct($passwordUpdater, $canonicalFieldsUpdater);
 
         $this->objectManager = $om;
-        $this->repository = $om->getRepository($class);
+        $this->class = $class;
+    }
 
-        $metadata = $om->getClassMetadata($class);
-        $this->class = $metadata->getName();
+    /**
+     * @return ObjectRepository
+     */
+    protected function getRepository()
+    {
+        return $this->objectManager->getRepository($this->getClass());
     }
 
     /**
@@ -68,6 +68,11 @@ class UserManager extends BaseUserManager
      */
     public function getClass()
     {
+        if (false !== strpos($this->class, ':')) {
+            $metadata = $this->objectManager->getClassMetadata($this->class);
+            $this->class = $metadata->getName();
+        }
+
         return $this->class;
     }
 
@@ -76,7 +81,7 @@ class UserManager extends BaseUserManager
      */
     public function findUserBy(array $criteria)
     {
-        return $this->repository->findOneBy($criteria);
+        return $this->getRepository()->findOneBy($criteria);
     }
 
     /**
@@ -84,7 +89,7 @@ class UserManager extends BaseUserManager
      */
     public function findUsers()
     {
-        return $this->repository->findAll();
+        return $this->getRepository()->findAll();
     }
 
     /**

--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="fos_user.user_manager.default" class="FOS\UserBundle\Doctrine\UserManager" public="false" lazy="true">
+        <service id="fos_user.user_manager.default" class="FOS\UserBundle\Doctrine\UserManager" public="false">
             <argument type="service" id="fos_user.util.password_updater" />
             <argument type="service" id="fos_user.util.canonical_fields_updater" />
             <argument type="service" id="fos_user.object_manager" />


### PR DESCRIPTION
without this change Symfony will attempt a DB connection during a `cache:clear` call

it should however also be possible to move this logic to the DI config. I mostly did it as a quick proof of concept that the `cache:clear` issue is fixable.