### PR TITLE
Added missing directory to comment.

### DIFF
--- a/Resources/doc/adding_invitation_registration.rst
+++ b/Resources/doc/adding_invitation_registration.rst
@@ -182,7 +182,7 @@ Create the invitation field::
 Create the custom data transformer::
 
     <?php
-    // src/AppBundle/Form/InvitationToCodeTransformer.php
+    // src/AppBundle/Form/DataTransformer/InvitationToCodeTransformer.php
 
     namespace AppBundle\Form\DataTransformer;
 


### PR DESCRIPTION
It was confusing where the InvitationToCodeTransformer.php had to be placed as the comment stated the form folder and the namespace stated Form\DataTransformer as the directory. Putting the file in the form folder and following the rest of the guide caused an error to be thrown.