### PR TITLE
Add missing hasPreviousSession condition check in layout.html.twig documentation

### DIFF
--- a/Resources/doc/overriding_templates.rst
+++ b/Resources/doc/overriding_templates.rst
@@ -35,13 +35,15 @@ Here is the default ``layout.html.twig`` provided by the FOSUserBundle:
                 {% endif %}
             </div>
 
-            {% for type, messages in app.session.flashBag.all %}
-                {% for message in messages %}
-                    <div class="{{ type }}">
-                        {{ message|trans({}, 'FOSUserBundle') }}
-                    </div>
+            {% if app.request.hasPreviousSession %}
+                {% for type, messages in app.session.flashBag.all %}
+                    {% for message in messages %}
+                        <div class="{{ type }}">
+                            {{ message|trans({}, 'FOSUserBundle') }}
+                        </div>
+                    {% endfor %}
                 {% endfor %}
-            {% endfor %}
+            {% endif %}
 
             <div>
                 {% block fos_user_content %}


### PR DESCRIPTION
Documentation for `/Resources/views/layout.html.twig` is out of sync with real file content, this adds hasPreviousSession check