### PR TITLE
SwiftMailer 6 compatibility

### DIFF
--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -96,7 +96,7 @@ class Mailer implements MailerInterface
         $subject = array_shift($renderedLines);
         $body = implode("\n", $renderedLines);
 
-        $message = \Swift_Message::newInstance()
+        $message = (new \Swift_Message())
             ->setSubject($subject)
             ->setFrom($fromEmail)
             ->setTo($toEmail)

--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -105,7 +105,7 @@ class TwigSwiftMailer implements MailerInterface
             $htmlBody = $template->renderBlock('body_html', $context);
         }
 
-        $message = \Swift_Message::newInstance()
+        $message = (new \Swift_Message())
             ->setSubject($subject)
             ->setFrom($fromEmail)
             ->setTo($toEmail);

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.3",
         "friendsofphp/php-cs-fixer": "^1.11",
-        "swiftmailer/swiftmailer": "^4.3 || ^5.0",
+        "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
         "symfony/console": "^2.7 || ^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/validator": "^2.7 || ^3.0",


### PR DESCRIPTION
In SwiftMailer 6, the static `::newInstance` methods have been removed. This PR changes calls to `::newInstance()` to direct constructor calls.