### PR TITLE
adding note that CSRF protection has to be enabled in config

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -14,6 +14,7 @@ Prerequisites
 
 This version of the bundle requires Symfony 2.7+. If you are using an older
 Symfony version, please use the 1.3.x releases of the bundle.
+Note: Make sure that CSRF Protection is enabled in ``config.yml``.
 
 Translations
 ~~~~~~~~~~~~


### PR DESCRIPTION
This issue should be mentioned in the guide.
If CSRF Protection is disabled, Symfony won't find the CSRF-Token manager, implicating a missing package.
But all was needed was setting csrf_protection to true in config.yml.