### PR TITLE
Add setUserData() Methods to allow sending our own data to templates

### DIFF
--- a/Controller/ChangePasswordController.php
+++ b/Controller/ChangePasswordController.php
@@ -86,6 +86,15 @@ class ChangePasswordController extends Controller
 
         return $this->render('@FOSUser/ChangePassword/change_password.html.twig', array(
             'form' => $form->createView(),
+            'data' => $this->setUserData(),
         ));
+    }
+
+    /*
+     * Method to override to send data to the template
+     */
+    public function setUserData()
+    {
+        return array();
     }
 }

--- a/Controller/GroupController.php
+++ b/Controller/GroupController.php
@@ -42,6 +42,7 @@ class GroupController extends Controller
 
         return $this->render('@FOSUser/Group/list.html.twig', array(
             'groups' => $groups,
+            'data' => $this->setUserData(),
         ));
     }
 
@@ -58,6 +59,7 @@ class GroupController extends Controller
 
         return $this->render('@FOSUser/Group/show.html.twig', array(
             'group' => $group,
+            'data' => $this->setUserData(),
         ));
     }
 
@@ -113,6 +115,7 @@ class GroupController extends Controller
         return $this->render('@FOSUser/Group/edit.html.twig', array(
             'form' => $form->createView(),
             'group_name' => $group->getName(),
+            'data' => $this->setUserData(),
         ));
     }
 
@@ -159,6 +162,7 @@ class GroupController extends Controller
 
         return $this->render('@FOSUser/Group/new.html.twig', array(
             'form' => $form->createView(),
+            'data' => $this->setUserData(),
         ));
     }
 
@@ -205,5 +209,13 @@ class GroupController extends Controller
         }
 
         return $group;
+    }
+
+    /*
+     * Method to override to send data to the template
+     */
+    public function setUserData()
+    {
+        return array();
     }
 }

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -44,6 +44,7 @@ class ProfileController extends Controller
 
         return $this->render('@FOSUser/Profile/show.html.twig', array(
             'user' => $user,
+            'data' => $this->setUserData(),
         ));
     }
 
@@ -100,6 +101,15 @@ class ProfileController extends Controller
 
         return $this->render('@FOSUser/Profile/edit.html.twig', array(
             'form' => $form->createView(),
+            'data' => $this->setUserData(),
         ));
+    }
+
+    /*
+     * Method to override to send data to the template
+     */
+    public function setUserData()
+    {
+        return array();
     }
 }

--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -90,6 +90,7 @@ class RegistrationController extends Controller
 
         return $this->render('@FOSUser/Registration/register.html.twig', array(
             'form' => $form->createView(),
+            'data' => $this->setUserData(),
         ));
     }
 
@@ -113,6 +114,7 @@ class RegistrationController extends Controller
 
         return $this->render('@FOSUser/Registration/check_email.html.twig', array(
             'user' => $user,
+            'data' => $this->setUserData(),
         ));
     }
 
@@ -169,6 +171,7 @@ class RegistrationController extends Controller
         return $this->render('@FOSUser/Registration/confirmed.html.twig', array(
             'user' => $user,
             'targetUrl' => $this->getTargetUrlFromSession(),
+            'data' => $this->setUserData(),
         ));
     }
 
@@ -182,5 +185,13 @@ class RegistrationController extends Controller
         if ($this->get('session')->has($key)) {
             return $this->get('session')->get($key);
         }
+    }
+
+    /*
+     * Method to override to send data to the template
+     */
+    public function setUserData()
+    {
+        return array();
     }
 }

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -38,7 +38,9 @@ class ResettingController extends Controller
      */
     public function requestAction()
     {
-        return $this->render('@FOSUser/Resetting/request.html.twig');
+        return $this->render('@FOSUser/Resetting/request.html.twig', array(
+            'data' => $this->setUserData(),
+        ));
     }
 
     /**
@@ -123,6 +125,7 @@ class ResettingController extends Controller
 
         return $this->render('@FOSUser/Resetting/check_email.html.twig', array(
             'tokenLifetime' => ceil($this->container->getParameter('fos_user.resetting.retry_ttl') / 3600),
+            'data' => $this->setUserData(),
         ));
     }
 
@@ -183,6 +186,15 @@ class ResettingController extends Controller
         return $this->render('@FOSUser/Resetting/reset.html.twig', array(
             'token' => $token,
             'form' => $form->createView(),
+            'data' => $this->setUserData(),
         ));
+    }
+
+    /*
+     * Method to override to send data to the template
+     */
+    public function setUserData()
+    {
+        return array();
     }
 }

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -71,6 +71,8 @@ class SecurityController extends Controller
      */
     protected function renderLogin(array $data)
     {
+        $data['data'] = $this->setUserData();
+
         return $this->render('@FOSUser/Security/login.html.twig', $data);
     }
 
@@ -82,5 +84,13 @@ class SecurityController extends Controller
     public function logoutAction()
     {
         throw new \RuntimeException('You must activate the logout in your security firewall configuration.');
+    }
+
+    /*
+     * Method to override to send data to the template
+     */
+    public function setUserData()
+    {
+        return array();
     }
 }

--- a/Resources/doc/overriding_controllers.rst
+++ b/Resources/doc/overriding_controllers.rst
@@ -132,3 +132,33 @@ the base controller and adds logging a new user registration to it.
     to override and instead extend ContainerAware or the Controller class
     provided by the FrameworkBundle then you must implement all of the methods
     of the FOSUserBundle controller that you are overriding.
+
+Send data to templates
+----------------------
+
+If you need to send specific data to the templates but don't want to override
+the main method, just proceed as above to override the Controller and then,
+override the method `setUserData()` by providing an array which will be available as
+`data` in the templates.
+
+.. code-block:: php
+
+    <?php
+    // src/AppBundle/Controller/RegistrationController.php
+
+    namespace AppBundle\Controller;
+
+    use Symfony\Component\HttpFoundation\RedirectResponse;
+    use FOS\UserBundle\Controller\RegistrationController as BaseController;
+    use Symfony\Component\HttpFoundation\Request;
+
+    class RegistrationController extends BaseController
+    {
+        public function setUserData()
+        {
+            return array(
+                //Accessible as data.value in Templates rendered by RegistrationController
+                'value' => 'my value',
+            );
+        }
+    }


### PR DESCRIPTION
Answers to #2146 and replaces #2587 which is a little bit messy...

For the time being, if we need to send our own data to the templates, we need to overwrite the Default Controllers Methods, which is bad, as we lose all further improvements to these methods, unless by following and maintaining them.
We can't use the `parent::showAction()` (for example) because it renders the template, so too late to provide our data.

In the `SecurityController` the `renderLogin()` has everything to avoid that!
We can override the renderLogin(), set the data we need and call the parent Action.
```
//In Overriding Controller
protected function renderLogin(array $data)
{
    $data['gravatar'] = $this->getParameter('bundle_name.gravatar');

    return parent::renderLogin($data);
}
```
The goal of this PR is to add this possibility to all rendering templates, by calling a dedicated method `setUserData()` that will provide `array $data` to templates. Like this, we just need to override this method to have accessible data in our overriding templates.
No BC Break, cost nothing, simplifies access to data, and keep us from overriding the main Controller's method.