### PR TITLE
Fix placeholder not being replaced when resetting password process

### DIFF
--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -102,7 +102,7 @@ class ResettingController extends Controller
             }
         }
 
-        return new RedirectResponse($this->generateUrl('fos_user_resetting_check_email', array('username' => $username)));
+        return new RedirectResponse($this->generateUrl('fos_user_resetting_check_email', array('email' => (string) $user->getEmail())));
     }
 
     /**
@@ -114,15 +114,16 @@ class ResettingController extends Controller
      */
     public function checkEmailAction(Request $request)
     {
-        $username = $request->query->get('username');
+        $email = $request->query->get('email');
 
-        if (empty($username)) {
+        if (empty($email)) {
             // the user does not come from the sendEmail action
             return new RedirectResponse($this->generateUrl('fos_user_resetting_request'));
         }
 
         return $this->render('@FOSUser/Resetting/check_email.html.twig', array(
             'tokenLifetime' => ceil($this->container->getParameter('fos_user.resetting.retry_ttl') / 3600),
+            'email' => $email
         ));
     }
 

--- a/Resources/views/Resetting/check_email.html.twig
+++ b/Resources/views/Resetting/check_email.html.twig
@@ -4,6 +4,6 @@
 
 {% block fos_user_content %}
 <p>
-{{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime})|nl2br }}
+{{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime, '%email%': email})|nl2br }}
 </p>
 {% endblock %}


### PR DESCRIPTION
Currently in friendsofsymfony/user-bundle (v2.0.1) when you reset the password using route /resetting/request you get the following:

<img width="882" alt="screen shot 2017-07-20 at 13 25 22" src="https://user-images.githubusercontent.com/400092/28417193-059bb82e-6d4f-11e7-92a3-dda6061ed616.png">

note the %email% placeholder is not exchanged, this is because Controller/ResettingController.php:124 is not passing in this value to be replaced, mainly because its not receiving it from controller/ResettingController.php:105

Once this PR is applied you can then reset your password by username or email and the placeholder it replaced correctly

