### PR TITLE
Add missing retry_ttl to configuration reference

### DIFF
--- a/Resources/doc/configuration_reference.rst
+++ b/Resources/doc/configuration_reference.rst
@@ -39,6 +39,7 @@ All available configuration options are listed below with their default values.
                 name:               fos_user_registration_form
                 validation_groups:  [Registration, Default]
         resetting:
+            retry_ttl: 7200 # Value in seconds, logic will use as hours
             token_ttl: 86400
             email:
                 from_email: # Use this node only if you don't want the global email address for the resetting email


### PR DESCRIPTION
Update _fos_user.resetting.retry_ttl_ with default value _7200_

This documentation parameter is missing from [docs](https://symfony.com/doc/master/bundles/FOSUserBundle/configuration_reference.html) and the default [dependency injection configuration](https://github.com/XWB/FOSUserBundle/blob/ad993482bb04088a227323efbb0156beed25d186/DependencyInjection/Configuration.php#L169) is creating it with the default value.

See also that it is a bit weird that the param [only takes as hours](https://github.com/XWB/FOSUserBundle/blob/ad993482bb04088a227323efbb0156beed25d186/Controller/ResettingController.php#L125) instead allow seconds

`'tokenLifetime' => ceil($this->container->getParameter('fos_user.resetting.retry_ttl') / 3600),`

For the token lifetime in my opinion it should allow retry in seconds (for example if I want configure 30 seconds) (sometimes is needed to debug and avoid wait 1 hour for the same email).

