### PR TITLE
Add missing setResponse() setter for FilterUserResponseEvent

### DIFF
--- a/Event/FilterUserResponseEvent.php
+++ b/Event/FilterUserResponseEvent.php
@@ -39,7 +39,7 @@ class FilterUserResponseEvent extends UserEvent
     {
         return $this->response;
     }
-    
+
     /**
      * Sets a new response object.
      *

--- a/Event/FilterUserResponseEvent.php
+++ b/Event/FilterUserResponseEvent.php
@@ -39,4 +39,14 @@ class FilterUserResponseEvent extends UserEvent
     {
         return $this->response;
     }
+    
+    /**
+     * Sets a new response object.
+     *
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
 }


### PR DESCRIPTION
Add the missing setter _setResponse_ for Response object in _FilterUserResponseEvent_ class.

Other filters like [FormEvent](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Event/FormEvent.php), [FilterGroupResponseEvent](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Event/FilterGroupResponseEvent.php) contains this setResponse when the object Response is present as attribute in the class.

Probably a good idea is add in [GetResponseGroupEvent](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Event/GetResponseGroupEvent.php) and [GetResponseUserEvent](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Event/GetResponseUserEvent.php) which is missing too. I could make another separate PR for that if you desire.

I am using the _setResponse()_ method in _FilterUserResponseEvent_ in a listener after capture the event _FOSUserEvents::RESETTING_RESET_COMPLETED_ creating a callback that sent to the admin an email notifing **which user has changed his password** (with option of know the new password or not). After all this, I redirect the response to a custom url, which is where I use the _setResponse() method_.

Without the method I have to fetch the Response object and set the target url:

```php
    $response = $event->getResponse();
    $response->setTargetUrl($url);
```

If I have this PR accepted, then I could write:

```php
    $response = $event->setResponse(new RedirectResponse($url));
```