### PR TITLE
add email update confirmation feature

### DIFF
--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -14,6 +14,7 @@ namespace FOS\UserBundle\Controller;
 use FOS\UserBundle\Event\FilterUserResponseEvent;
 use FOS\UserBundle\Event\FormEvent;
 use FOS\UserBundle\Event\GetResponseUserEvent;
+use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\Form\Factory\FactoryInterface;
 use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Model\User;
@@ -26,7 +27,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use FOS\UserBundle\Event\UserEvent;
 use Symfony\Component\Translation\Translator;
 
 /**
@@ -111,7 +111,8 @@ class ProfileController extends Controller
      * Confirm user`s email update.
      *
      * @param Request $request
-     * @param string $token
+     * @param string  $token
+     *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
     public function confirmEmailUpdateAction(Request $request, $token)
@@ -151,8 +152,8 @@ class ProfileController extends Controller
         $userManager->updateUser($user);
 
         $event = new UserEvent($user, $request);
-        $this->get('event_dispatcher')->dispatch( FOSUserEvents::EMAIL_UPDATE_SUCCESS, $event);
+        $this->get('event_dispatcher')->dispatch(FOSUserEvents::EMAIL_UPDATE_SUCCESS, $event);
 
-        return $this->redirect($this->generateUrl("fos_user_profile_show"));
+        return $this->redirect($this->generateUrl('fos_user_profile_show'));
     }
 }

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -129,8 +129,8 @@ class ProfileController extends Controller
             throw $this->createNotFoundException($translator->trans('email_update.error.message', array(), 'FOSUserBundle'));
         }
 
-        // Show invalid token message and redirect if users id does not match
-        if ($user->getId() !== $this->getUser()->getId()) {
+        // Show invalid token message if the user id found via token does not match the current users id (e.g. anon. or other user)
+        if (!($this->getUser() instanceof UserInterface) || ($user->getId() !== $this->getUser()->getId())) {
             /** @var Translator $translator */
             $translator = $this->get('translator');
             throw new AccessDeniedException($translator->trans('email_update.error.message', array(), 'FOSUserBundle'));

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -16,14 +16,18 @@ use FOS\UserBundle\Event\FormEvent;
 use FOS\UserBundle\Event\GetResponseUserEvent;
 use FOS\UserBundle\Form\Factory\FactoryInterface;
 use FOS\UserBundle\FOSUserEvents;
+use FOS\UserBundle\Model\User;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
+use FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use FOS\UserBundle\Event\UserEvent;
+use Symfony\Component\Translation\Translator;
 
 /**
  * Controller managing the user profile.
@@ -101,5 +105,54 @@ class ProfileController extends Controller
         return $this->render('@FOSUser/Profile/edit.html.twig', array(
             'form' => $form->createView(),
         ));
+    }
+
+    /**
+     * Confirm user`s email update.
+     *
+     * @param Request $request
+     * @param string $token
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function confirmEmailUpdateAction(Request $request, $token)
+    {
+        $userManager = $this->container->get('fos_user.user_manager');
+
+        /** @var User $user */
+        $user = $userManager->findUserByConfirmationToken($token);
+
+        // If user was not found throw 404 exception
+        if (!$user) {
+            /** @var Translator $translator */
+            $translator = $this->get('translator');
+            throw $this->createNotFoundException($translator->trans('email_update.error.message', array(), 'FOSUserBundle'));
+        }
+
+        // Show invalid token message and redirect if users id does not match
+        if ($user->getId() !== $this->getUser()->getId()) {
+            /** @var Translator $translator */
+            $translator = $this->get('translator');
+            throw new AccessDeniedException($translator->trans('email_update.error.message', array(), 'FOSUserBundle'));
+        }
+
+        /** @var EmailUpdateConfirmation $emailUpdateConfirmation */
+        $emailUpdateConfirmation = $this->get('fos_user.email_update_confirmation');
+
+        $emailUpdateConfirmation->setUser($user);
+
+        $newEmail = $emailUpdateConfirmation->fetchEncryptedEmailFromConfirmationLink($request->get('target'));
+
+        // Update user email
+        if ($newEmail) {
+            $user->setConfirmationToken($emailUpdateConfirmation->getEmailConfirmedToken());
+            $user->setEmail($newEmail);
+        }
+
+        $userManager->updateUser($user);
+
+        $event = new UserEvent($user, $request);
+        $this->get('event_dispatcher')->dispatch( FOSUserEvents::EMAIL_UPDATE_SUCCESS, $event);
+
+        return $this->redirect($this->generateUrl("fos_user_profile_show"));
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -113,6 +113,7 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->booleanNode('enabled')->defaultFalse()->end()
+                                ->scalarNode('cypher_method')->defaultNull()->end()
                                 ->scalarNode('email_template')->defaultValue('@FOSUser/Profile/email_update_confirmation.txt.twig')->end()
                             ->end()
                         ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -109,6 +109,13 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->arrayNode('email_update_confirmation')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('enabled')->defaultFalse()->end()
+                                ->scalarNode('email_template')->defaultValue('@FOSUser/Profile/email_update_confirmation.txt.twig')->end()
+                            ->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -93,6 +93,11 @@ class FOSUserExtension extends Extension
             }
         }
 
+        if (array_key_exists('profile', $config) && $config['profile']['email_update_confirmation'] && $config['profile']['email_update_confirmation']['enabled']) {
+            $listenerDefinition = $container->getDefinition('fos_user.email_update_listener');
+            $listenerDefinition->addTag(self::$doctrineDrivers[$config['db_driver']]['tag']);
+        }
+
         if ($config['use_username_form_type']) {
             $loader->load('username_form_type.xml');
         }
@@ -135,6 +140,8 @@ class FOSUserExtension extends Extension
     private function loadProfile(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         $loader->load('profile.xml');
+
+        $container->setParameter('fos_user.email_update_confirmation.template', $config['email_update_confirmation']['email_template']);
 
         $this->remapParametersNamespaces($config, $container, array(
             'form' => 'fos_user.profile.form.%s',

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -142,6 +142,7 @@ class FOSUserExtension extends Extension
         $loader->load('profile.xml');
 
         $container->setParameter('fos_user.email_update_confirmation.template', $config['email_update_confirmation']['email_template']);
+        $container->setParameter('fos_user.email_update_confirmation.cypher_method', $config['email_update_confirmation']['cypher_method']);
 
         $this->remapParametersNamespaces($config, $container, array(
             'form' => 'fos_user.profile.form.%s',

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -93,11 +93,6 @@ class FOSUserExtension extends Extension
             }
         }
 
-        if (array_key_exists('profile', $config) && $config['profile']['email_update_confirmation'] && $config['profile']['email_update_confirmation']['enabled']) {
-            $listenerDefinition = $container->getDefinition('fos_user.email_update_listener');
-            $listenerDefinition->addTag(self::$doctrineDrivers[$config['db_driver']]['tag']);
-        }
-
         if ($config['use_username_form_type']) {
             $loader->load('username_form_type.xml');
         }

--- a/Doctrine/EmailUpdateListener.php
+++ b/Doctrine/EmailUpdateListener.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace FOS\UserBundle\Doctrine;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use FOS\UserBundle\Model\UserInterface;
+use FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+
+/**
+ * Class EmailUpdateListener
+ * @package FOS\UserBundle\Doctrine
+ */
+class EmailUpdateListener implements EventSubscriber
+{
+    /**
+     * @var EmailUpdateConfirmation
+     */
+    private $emailUpdateConfirmation;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * Constructor
+     *
+     * @param ContainerInterface $container
+     * @param RequestStack $requestStack
+     */
+    public function __construct(ContainerInterface $container, RequestStack $requestStack)
+    {
+        $this->container = $container;
+        $this->requestStack = $requestStack;
+    }
+
+    public function getSubscribedEvents()
+    {
+        return array(
+            'preUpdate',
+        );
+    }
+
+    /**
+     * Pre update listener based on doctrine common
+     *
+     * @param LifecycleEventArgs $args
+     */
+    public function preUpdate(LifecycleEventArgs $args)
+    {
+        $object = $args->getObject();
+
+        if ($object instanceof UserInterface && $args instanceof PreUpdateEventArgs) {
+
+            $user = $object;
+
+            if (null === $this->emailUpdateConfirmation) {
+                $this->emailUpdateConfirmation = $this->container->get('fos_user.email_update_confirmation');
+            }
+
+            if($user->getConfirmationToken() != $this->emailUpdateConfirmation->getEmailConfirmedToken() && isset($args->getEntityChangeSet()['email'])){
+
+                $oldEmail = $args->getEntityChangeSet()['email'][0];
+                $newEmail = $args->getEntityChangeSet()['email'][1];
+
+                $user->setEmail($oldEmail);
+
+                // Configure email confirmation
+                $this->emailUpdateConfirmation->setUser($user);
+                $this->emailUpdateConfirmation->setEmail($newEmail);
+                $this->emailUpdateConfirmation->setConfirmationRoute('fos_user_update_email_confirm');
+                $this->emailUpdateConfirmation->getMailer()->sendUpdateEmailConfirmation(
+                    $user,
+                    $this->emailUpdateConfirmation->generateConfirmationLink($this->requestStack->getCurrentRequest()),
+                    $newEmail
+                );
+            }
+
+            if($user->getConfirmationToken() == $this->emailUpdateConfirmation->getEmailConfirmedToken()){
+
+                $user->setConfirmationToken(null);
+            }
+        }
+    }
+
+}

--- a/Doctrine/EmailUpdateListener.php
+++ b/Doctrine/EmailUpdateListener.php
@@ -2,10 +2,7 @@
 
 namespace FOS\UserBundle\Doctrine;
 
-use Doctrine\Common\EventSubscriber;
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -14,17 +11,12 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * Class EmailUpdateListener
  * @package FOS\UserBundle\Doctrine
  */
-class EmailUpdateListener implements EventSubscriber
+class EmailUpdateListener
 {
     /**
      * @var EmailUpdateConfirmation
      */
     private $emailUpdateConfirmation;
-
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
 
     /**
      * @var RequestStack
@@ -34,38 +26,27 @@ class EmailUpdateListener implements EventSubscriber
     /**
      * Constructor
      *
-     * @param ContainerInterface $container
+     * @param EmailUpdateConfirmation $emailUpdateConfirmation
      * @param RequestStack $requestStack
      */
-    public function __construct(ContainerInterface $container, RequestStack $requestStack)
+    public function __construct(EmailUpdateConfirmation $emailUpdateConfirmation, RequestStack $requestStack)
     {
-        $this->container = $container;
+        $this->emailUpdateConfirmation = $emailUpdateConfirmation;
         $this->requestStack = $requestStack;
-    }
-
-    public function getSubscribedEvents()
-    {
-        return array(
-            'preUpdate',
-        );
     }
 
     /**
      * Pre update listener based on doctrine common
      *
-     * @param LifecycleEventArgs $args
+     * @param PreUpdateEventArgs $args
      */
-    public function preUpdate(LifecycleEventArgs $args)
+    public function preUpdate(PreUpdateEventArgs $args)
     {
         $object = $args->getObject();
 
         if ($object instanceof UserInterface && $args instanceof PreUpdateEventArgs) {
 
             $user = $object;
-
-            if (null === $this->emailUpdateConfirmation) {
-                $this->emailUpdateConfirmation = $this->container->get('fos_user.email_update_confirmation');
-            }
 
             if($user->getConfirmationToken() != $this->emailUpdateConfirmation->getEmailConfirmedToken() && isset($args->getEntityChangeSet()['email'])){
 

--- a/Doctrine/EmailUpdateListener.php
+++ b/Doctrine/EmailUpdateListener.php
@@ -10,7 +10,6 @@ use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-
 /**
  * Class EmailUpdateListener
  * @package FOS\UserBundle\Doctrine
@@ -92,5 +91,4 @@ class EmailUpdateListener implements EventSubscriber
             }
         }
     }
-
 }

--- a/Doctrine/EmailUpdateListener.php
+++ b/Doctrine/EmailUpdateListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FOS\UserBundle\Doctrine;
 
 use Doctrine\ORM\Event\PreUpdateEventArgs;
@@ -8,8 +17,7 @@ use FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Class EmailUpdateListener
- * @package FOS\UserBundle\Doctrine
+ * Class EmailUpdateListener.
  */
 class EmailUpdateListener
 {
@@ -24,10 +32,10 @@ class EmailUpdateListener
     private $requestStack;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param EmailUpdateConfirmation $emailUpdateConfirmation
-     * @param RequestStack $requestStack
+     * @param RequestStack            $requestStack
      */
     public function __construct(EmailUpdateConfirmation $emailUpdateConfirmation, RequestStack $requestStack)
     {
@@ -36,7 +44,7 @@ class EmailUpdateListener
     }
 
     /**
-     * Pre update listener based on doctrine common
+     * Pre update listener based on doctrine common.
      *
      * @param PreUpdateEventArgs $args
      */
@@ -45,11 +53,9 @@ class EmailUpdateListener
         $object = $args->getObject();
 
         if ($object instanceof UserInterface && $args instanceof PreUpdateEventArgs) {
-
             $user = $object;
 
-            if($user->getConfirmationToken() != $this->emailUpdateConfirmation->getEmailConfirmedToken() && isset($args->getEntityChangeSet()['email'])){
-
+            if ($user->getConfirmationToken() != $this->emailUpdateConfirmation->getEmailConfirmedToken() && isset($args->getEntityChangeSet()['email'])) {
                 $oldEmail = $args->getEntityChangeSet()['email'][0];
                 $newEmail = $args->getEntityChangeSet()['email'][1];
 
@@ -66,8 +72,7 @@ class EmailUpdateListener
                 );
             }
 
-            if($user->getConfirmationToken() == $this->emailUpdateConfirmation->getEmailConfirmedToken()){
-
+            if ($user->getConfirmationToken() == $this->emailUpdateConfirmation->getEmailConfirmedToken()) {
                 $user->setConfirmationToken(null);
             }
         }

--- a/EventListener/FlashListener.php
+++ b/EventListener/FlashListener.php
@@ -30,6 +30,8 @@ class FlashListener implements EventSubscriberInterface
         FOSUserEvents::PROFILE_EDIT_COMPLETED => 'profile.flash.updated',
         FOSUserEvents::REGISTRATION_COMPLETED => 'registration.flash.user_created',
         FOSUserEvents::RESETTING_RESET_COMPLETED => 'resetting.flash.success',
+        FOSUserEvents::EMAIL_UPDATE_SUCCESS => 'email_update.flash.success',
+        FOSUserEvents::EMAIL_UPDATE_INITIALIZE => 'email_update.flash.info'
     );
 
     /**
@@ -67,6 +69,8 @@ class FlashListener implements EventSubscriberInterface
             FOSUserEvents::PROFILE_EDIT_COMPLETED => 'addSuccessFlash',
             FOSUserEvents::REGISTRATION_COMPLETED => 'addSuccessFlash',
             FOSUserEvents::RESETTING_RESET_COMPLETED => 'addSuccessFlash',
+            FOSUserEvents::EMAIL_UPDATE_SUCCESS => 'addSuccessFlash',
+            FOSUserEvents::EMAIL_UPDATE_INITIALIZE => 'addInfoFlash',
         );
     }
 
@@ -84,6 +88,19 @@ class FlashListener implements EventSubscriberInterface
     }
 
     /**
+     * @param Event  $event
+     * @param string $eventName
+     */
+    public function addInfoFlash(Event $event, $eventName)
+    {
+        if (!isset(self::$successMessages[$eventName])) {
+            throw new \InvalidArgumentException('This event does not correspond to a known flash message');
+        }
+
+        $this->session->getFlashBag()->add('info', $this->trans(self::$successMessages[$eventName]));
+    }
+
+  /**
      * @param string$message
      * @param array $params
      *

--- a/EventListener/FlashListener.php
+++ b/EventListener/FlashListener.php
@@ -31,7 +31,7 @@ class FlashListener implements EventSubscriberInterface
         FOSUserEvents::REGISTRATION_COMPLETED => 'registration.flash.user_created',
         FOSUserEvents::RESETTING_RESET_COMPLETED => 'resetting.flash.success',
         FOSUserEvents::EMAIL_UPDATE_SUCCESS => 'email_update.flash.success',
-        FOSUserEvents::EMAIL_UPDATE_INITIALIZE => 'email_update.flash.info'
+        FOSUserEvents::EMAIL_UPDATE_INITIALIZE => 'email_update.flash.info',
     );
 
     /**
@@ -100,7 +100,7 @@ class FlashListener implements EventSubscriberInterface
         $this->session->getFlashBag()->add('info', $this->trans(self::$successMessages[$eventName]));
     }
 
-  /**
+    /**
      * @param string$message
      * @param array $params
      *

--- a/FOSUserEvents.php
+++ b/FOSUserEvents.php
@@ -318,4 +318,22 @@ final class FOSUserEvents
      * @Event("FOS\UserBundle\Event\UserEvent")
      */
     const USER_DEMOTED = 'fos_user.user.demoted';
+
+  /**
+     * The EMAIL_UPDATE_INITIALIZE event occurs when the email update process is initialized.
+     *
+     * This event allows you to access the user and to add some behaviour after email update is initialized..
+     *
+     * @Event("FOS\UserBundle\Event\UserEvent")
+     */
+    const EMAIL_UPDATE_INITIALIZE = 'fos_user.update_email.initialize';
+
+    /**
+     * The EMAIL_UPDATE_SUCCESS event occurs when the email was successfully updated through confirmation link.
+     *
+     * This event allows you to access the user and to add some behaviour after email was confirmed and updated..
+     *
+     * @Event("FOS\UserBundle\Event\UserEvent")
+     */
+    const EMAIL_UPDATE_SUCCESS = 'fos_user.update_email.success';
 }

--- a/FOSUserEvents.php
+++ b/FOSUserEvents.php
@@ -319,7 +319,7 @@ final class FOSUserEvents
      */
     const USER_DEMOTED = 'fos_user.user.demoted';
 
-  /**
+    /**
      * The EMAIL_UPDATE_INITIALIZE event occurs when the email update process is initialized.
      *
      * This event allows you to access the user and to add some behaviour after email update is initialized..

--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -85,6 +85,23 @@ class Mailer implements MailerInterface
     }
 
     /**
+     * Send confirmation link to specified new user email.
+     * @param UserInterface $user
+     * @param string $confirmationUrl
+     * @param string $toEmail
+     */
+    public function sendUpdateEmailConfirmation(UserInterface $user, $confirmationUrl, $toEmail)
+    {
+        $template = $this->parameters['template']['email_updating'];
+        $rendered = $this->templating->render($template, array(
+            'user'            => $user,
+            'confirmationUrl' => $confirmationUrl
+        ));
+
+        $this->sendEmailMessage($rendered, $this->parameters['from_email']['resetting'], $toEmail);
+    }
+
+    /**
      * @param string       $renderedTemplate
      * @param array|string $fromEmail
      * @param array|string $toEmail

--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -86,16 +86,17 @@ class Mailer implements MailerInterface
 
     /**
      * Send confirmation link to specified new user email.
+     *
      * @param UserInterface $user
-     * @param string $confirmationUrl
-     * @param string $toEmail
+     * @param string        $confirmationUrl
+     * @param string        $toEmail
      */
     public function sendUpdateEmailConfirmation(UserInterface $user, $confirmationUrl, $toEmail)
     {
         $template = $this->parameters['template']['email_updating'];
         $rendered = $this->templating->render($template, array(
-            'user'            => $user,
-            'confirmationUrl' => $confirmationUrl
+            'user' => $user,
+            'confirmationUrl' => $confirmationUrl,
         ));
 
         $this->sendEmailMessage($rendered, $this->parameters['from_email']['resetting'], $toEmail);

--- a/Mailer/MailerInterface.php
+++ b/Mailer/MailerInterface.php
@@ -31,4 +31,14 @@ interface MailerInterface
      * @param UserInterface $user
      */
     public function sendResettingEmailMessage(UserInterface $user);
+
+    /**
+     * Send an email to a user to confirm the changed email address.
+     *
+     * @param UserInterface $user
+     * @param string $confirmationUrl
+     * @param string $toEmail
+     */
+    public function sendUpdateEmailConfirmation(UserInterface $user, $confirmationUrl, $toEmail);
+
 }

--- a/Mailer/MailerInterface.php
+++ b/Mailer/MailerInterface.php
@@ -36,9 +36,8 @@ interface MailerInterface
      * Send an email to a user to confirm the changed email address.
      *
      * @param UserInterface $user
-     * @param string $confirmationUrl
-     * @param string $toEmail
+     * @param string        $confirmationUrl
+     * @param string        $toEmail
      */
     public function sendUpdateEmailConfirmation(UserInterface $user, $confirmationUrl, $toEmail);
-
 }

--- a/Mailer/NoopMailer.php
+++ b/Mailer/NoopMailer.php
@@ -37,4 +37,12 @@ class NoopMailer implements MailerInterface
     {
         // nothing happens.
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendUpdateEmailConfirmation(UserInterface $user, $confirmationUrl, $toEmail)
+    {
+        // nothing happens.
+    }
 }

--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -119,4 +119,22 @@ class TwigSwiftMailer implements MailerInterface
 
         $this->mailer->send($message);
     }
+
+    /**
+     * Send confirmation link to specified new user email.
+     * @param UserInterface $user
+     * @param $confirmationUrl
+     * @param $toEmail
+     * @return bool
+     */
+    public function sendUpdateEmailConfirmation(UserInterface $user, $confirmationUrl, $toEmail)
+    {
+        $template = $this->parameters['template']['email_updating'];
+        $context = array(
+            'user'            => $user,
+            'confirmationUrl' => $confirmationUrl
+        );
+
+        $this->sendMessage($template, $context, $this->parameters['from_email']['confirmation'], $toEmail);
+    }
 }

--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -122,17 +122,19 @@ class TwigSwiftMailer implements MailerInterface
 
     /**
      * Send confirmation link to specified new user email.
+     *
      * @param UserInterface $user
      * @param $confirmationUrl
      * @param $toEmail
+     *
      * @return bool
      */
     public function sendUpdateEmailConfirmation(UserInterface $user, $confirmationUrl, $toEmail)
     {
         $template = $this->parameters['template']['email_updating'];
         $context = array(
-            'user'            => $user,
-            'confirmationUrl' => $confirmationUrl
+            'user' => $user,
+            'confirmationUrl' => $confirmationUrl,
         );
 
         $this->sendMessage($template, $context, $this->parameters['from_email']['confirmation'], $toEmail);

--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -21,6 +21,11 @@
             <argument type="service" id="fos_user.util.password_updater" />
             <argument type="service" id="fos_user.util.canonical_fields_updater" />
         </service>
+
+        <service id="fos_user.email_update_listener" class="FOS\UserBundle\Doctrine\EmailUpdateListener" public="false">
+            <argument type="service" id="service_container" />
+            <argument type="service" id="request_stack" />
+        </service>
     </services>
 
 </container>

--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -23,8 +23,9 @@
         </service>
 
         <service id="fos_user.email_update_listener" class="FOS\UserBundle\Doctrine\EmailUpdateListener" public="false">
-            <argument type="service" id="service_container" />
+            <argument type="service" id="fos_user.email_update_confirmation"/>
             <argument type="service" id="request_stack" />
+            <tag name="doctrine.event_listener" event="preUpdate" lazy="true" />
         </service>
     </services>
 

--- a/Resources/config/email_confirmation.xml
+++ b/Resources/config/email_confirmation.xml
@@ -12,6 +12,20 @@
             <argument type="service" id="router" />
             <argument type="service" id="session" />
         </service>
+
+        <service id="fos_user.email_encryption" class="FOS\UserBundle\Services\EmailConfirmation\EmailEncryption">
+        </service>
+
+        <service id="fos_user.email_update_confirmation" class="FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation">
+            <argument type="service" id="router" />
+            <argument type="service" id="fos_user.util.token_generator" />
+            <argument type="service" id="fos_user.mailer" />
+            <argument type="service" id="fos_user.email_encryption" />
+            <argument type="service" id="event_dispatcher" />
+        </service>
+
+        <service id="fos_user.email_encryption" class="FOS\UserBundle\Services\EmailConfirmation\EmailEncryption">
+        </service>
     </services>
 
 </container>

--- a/Resources/config/email_confirmation.xml
+++ b/Resources/config/email_confirmation.xml
@@ -14,6 +14,7 @@
         </service>
 
         <service id="fos_user.email_encryption" class="FOS\UserBundle\Services\EmailConfirmation\EmailEncryption">
+            <argument>%fos_user.email_update_confirmation.cypher_method%</argument>
         </service>
 
         <service id="fos_user.email_update_confirmation" class="FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation">

--- a/Resources/config/email_confirmation.xml
+++ b/Resources/config/email_confirmation.xml
@@ -14,6 +14,7 @@
         </service>
 
         <service id="fos_user.email_encryption" class="FOS\UserBundle\Services\EmailConfirmation\EmailEncryption">
+            <argument type="service" id="validator"/>
             <argument>%fos_user.email_update_confirmation.cypher_method%</argument>
         </service>
 
@@ -25,8 +26,6 @@
             <argument type="service" id="event_dispatcher" />
         </service>
 
-        <service id="fos_user.email_encryption" class="FOS\UserBundle\Services\EmailConfirmation\EmailEncryption">
-        </service>
     </services>
 
 </container>

--- a/Resources/config/mailer.xml
+++ b/Resources/config/mailer.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="fos_user.resetting.email.template">@FOSUser/Resetting/email.txt.twig</parameter>
         <parameter key="fos_user.registration.confirmation.template">@FOSUser/Registration/email.txt.twig</parameter>
+        <parameter key="fos_user.email_update_confirmation.template">@FOSUser/Profile/email_update_confirmation.txt.twig</parameter>
     </parameters>
 
     <services>
@@ -17,6 +18,7 @@
             <argument type="collection">
                 <argument key="confirmation.template">%fos_user.registration.confirmation.template%</argument>
                 <argument key="resetting.template">%fos_user.resetting.email.template%</argument>
+                <argument key="email_updating.template">%fos_user.email_update_confirmation.template%</argument>
                 <argument key="from_email" type="collection">
                     <argument key="confirmation">%fos_user.registration.confirmation.from_email%</argument>
                     <argument key="resetting">%fos_user.resetting.email.from_email%</argument>
@@ -32,6 +34,7 @@
                 <argument key="template" type="collection">
                     <argument key="confirmation">%fos_user.registration.confirmation.template%</argument>
                     <argument key="resetting">%fos_user.resetting.email.template%</argument>
+                    <argument key="email_updating">%fos_user.email_update_confirmation.template%</argument>
                 </argument>
                 <argument key="from_email" type="collection">
                     <argument key="confirmation">%fos_user.registration.confirmation.from_email%</argument>

--- a/Resources/config/routing/all.xml
+++ b/Resources/config/routing/all.xml
@@ -18,4 +18,7 @@
     <import
         resource="@FOSUserBundle/Resources/config/routing/change_password.xml"
         prefix="/profile" />
+    <import
+        resource="@FOSUserBundle/Resources/config/routing/update_email.xml"
+        prefix="/profile" />
 </routes>

--- a/Resources/config/routing/profile.xml
+++ b/Resources/config/routing/profile.xml
@@ -12,4 +12,8 @@
         <default key="_controller">FOSUserBundle:Profile:edit</default>
     </route>
 
+    <route id="fos_user_update_email_confirm" path="/confirm-email-update/{token}" methods="GET">
+        <default key="_controller">FOSUserBundle:Profile:confirmEmailUpdate</default>
+    </route>
+
 </routes>

--- a/Resources/config/routing/update_email.xml
+++ b/Resources/config/routing/update_email.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="fos_user_update_email_confirm" path="/confirm-email-update/{token}" methods="GET">
+        <default key="_controller">FOSUserBundle:Profile:confirmEmailUpdate</default>
+    </route>
+
+</routes>

--- a/Resources/doc/configuration_reference.rst
+++ b/Resources/doc/configuration_reference.rst
@@ -22,6 +22,9 @@ All available configuration options are listed below with their default values.
                 type:               FOS\UserBundle\Form\Type\ProfileFormType # or 'fos_user_profile' on Symfony < 2.8
                 name:               fos_user_profile_form
                 validation_groups:  [Profile, Default]
+            email_update_confirmation:
+                enabled:            false # change to force confirmation of changed email by sending a confirmation link to the new address.
+                email_template:     '@FOSUser/Profile/email_update_confirmation.txt.twig'
         change_password:
             form:
                 type:               FOS\UserBundle\Form\Type\ChangePasswordFormType # or 'fos_user_change_password' on Symfony < 2.8

--- a/Resources/doc/configuration_reference.rst
+++ b/Resources/doc/configuration_reference.rst
@@ -25,6 +25,7 @@ All available configuration options are listed below with their default values.
             email_update_confirmation:
                 enabled:            false # change to force confirmation of changed email by sending a confirmation link to the new address.
                 email_template:     '@FOSUser/Profile/email_update_confirmation.txt.twig'
+                cypher_method:      null # the cypher method to be used to encrypt/decrypt the email confirmation tokens. See http://php.net/manual/function.openssl-get-cipher-methods.php
         change_password:
             form:
                 type:               FOS\UserBundle\Form\Type\ChangePasswordFormType # or 'fos_user_change_password' on Symfony < 2.8

--- a/Resources/doc/emails.rst
+++ b/Resources/doc/emails.rst
@@ -44,6 +44,15 @@ To enable it, update your configuration as follows:
             email_update_confirmation:
                 enabled: true
 
+When clicking the confirmation-link, the user has to be logged in. For the best
+user experience it is recommended to protect the url of the route `fos_user_update_email_confirm`
+in the security configuration.
+
+.. code-block:: yaml
+security:
+    access_control:
+        - { path: "/{YOUR-PREFIX}/profile/confirm-email-update/{token}", roles: IS_AUTHENTICATED_REMEMBERED }
+
 
 Password Reset
 --------------

--- a/Resources/doc/emails.rst
+++ b/Resources/doc/emails.rst
@@ -24,6 +24,27 @@ To enable it, update your configuration as follows:
             confirmation:
                 enabled: true
 
+Confirmation of Changed Email
+-----------------------------
+
+When a user changes her email address on the edit profile page,
+the bundle can send a confirmation email to the new address. The
+new address will only be activated / written to the database once
+the user clicks on the confirmation link in the confirmation email.
+
+Requiring email update confirmation is turned off by default.
+To enable it, update your configuration as follows:
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    fos_user:
+        # ...
+        profile:
+            email_update_confirmation:
+                enabled: true
+
+
 Password Reset
 --------------
 

--- a/Resources/translations/FOSUserBundle.de.yml
+++ b/Resources/translations/FOSUserBundle.de.yml
@@ -27,6 +27,21 @@ change_password:
     submit: 'Passwort ändern'
     flash:
         success: 'Das Passwort wurde geändert.'
+email_update:
+    flash:
+        info: 'Bitte überprüfen Sie das Postfach der neuen Email-Adresse und klicken Sie den Link im Bestätigungsmail.'
+        success: 'Email-Adresse wurde erfolgreich aktualisiert.'
+    error:
+        message: 'Ungültiger Bestätigungslink. Email-Adresse konnte nicht aktualisiert werden.'
+    email:
+        subject: 'Neue Email-Adresse Aktivierung bestätigen.'
+        message: |
+            Hallo %username%!
+
+            Um Ihre neue Email-Adresse zu aktivieren, besuchen Sie bitten den folgenden Link: %confirmationUrl%
+
+            Freundliche Grüße,
+            das Team.
 registration:
     check_email: 'Eine E-Mail wurde an %email% gesendet. Sie enthält einen Link, den Sie anklicken müssen, um Ihr Benutzerkonto zu bestätigen.'
     confirmed: 'Glückwunsch %username%, Ihr Benutzerkonto ist jetzt bestätigt.'

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -36,7 +36,7 @@ email_update:
         info: 'Please check the inbox of your new email address and click the link in the confirmation email.'
         success: 'E-mail was successfully updated'
     error:
-        message: : 'Invalid confirmation link. Can not update the email address.'
+        message: 'Invalid confirmation link. Can not update the email address.'
     email:
         subject: 'Confirm the activation of the new email address.'
         message: |

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -31,6 +31,22 @@ change_password:
     flash:
         success: 'The password has been changed.'
 
+email_update:
+    flash:
+        info: 'Please check the inbox of your new email address and click the link in the confirmation email.'
+        success: 'E-mail was successfully updated'
+    error:
+        message: : 'Invalid confirmation link. Can not update the email address.'
+    email:
+        subject: 'Confirm the activation of the new email address.'
+        message: |
+            Hello %username%!
+
+            To activate your new email address - please visit %confirmationUrl%
+
+            Kind regards,
+            the Team.
+
 registration:
     check_email: |
         An email has been sent to %email%. It contains an activation link you must click to activate your account.

--- a/Resources/views/Profile/email_update_confirmation.txt.twig
+++ b/Resources/views/Profile/email_update_confirmation.txt.twig
@@ -1,0 +1,13 @@
+{% trans_default_domain 'FOSUserBundle' %}
+{% block subject %}
+{%- autoescape false %}
+{{ 'email_update.email.subject'|trans }}
+{%- endautoescape %}
+{% endblock %}
+
+{% block body_text %}
+{% autoescape false %}
+{{ 'email_update.email.message'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
+{% endautoescape %}
+{% endblock %}
+{% block body_html %}{% endblock %}

--- a/Resources/views/Profile/email_update_confirmation.txt.twig
+++ b/Resources/views/Profile/email_update_confirmation.txt.twig
@@ -1,13 +1,9 @@
 {% trans_default_domain 'FOSUserBundle' %}
 {% block subject %}
-{%- autoescape false %}
 {{ 'email_update.email.subject'|trans }}
-{%- endautoescape %}
 {% endblock %}
 
 {% block body_text %}
-{% autoescape false %}
 {{ 'email_update.email.message'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
-{% endautoescape %}
 {% endblock %}
 {% block body_html %}{% endblock %}

--- a/Services/EmailConfirmation/EmailEncryption.php
+++ b/Services/EmailConfirmation/EmailEncryption.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace FOS\UserBundle\Services\EmailConfirmation;
+
+use FOS\UserBundle\Services\EmailConfirmation\Interfaces\EmailEncryptionInterface;
+
+/**
+ * Class EmailEncryption
+ *
+ * Use this class for encryption/decryption of email value based on specified
+ * token.
+ *
+ * @package FOS\UserBundle\Services\EmailConfirmation
+ */
+class EmailEncryption implements EmailEncryptionInterface
+{
+
+    /**
+     * @var string $cipher
+     */
+    private $cipher = 'rijndael-128';
+
+    /**
+     * @var string $mcryptMode
+     */
+    private $mcryptMode = 'cbc';
+
+    /**
+     * @var string User confirmation token. Use for email encryption
+     */
+    private $userConfirmationToken;
+
+    /**
+     * @var string Email value to be encrypted
+     */
+    private $email;
+
+    /**
+     * EmailEncryption constructor.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Encrypt email value with specified user confirmation token.
+     *
+     * @return string Encrypted email
+     */
+    public function encryptEmailValue()
+    {
+        $iv = mcrypt_create_iv($this->getMcryptIvSize(), MCRYPT_RAND);
+
+        $encryptedEmail = mcrypt_encrypt(
+            $this->cipher,
+            $this->getConfirmationToken(),
+            $this->email,
+            $this->mcryptMode,
+            $iv
+        );
+
+        $encryptedEmail = $iv . $encryptedEmail;
+
+        return base64_encode($encryptedEmail);
+    }
+
+    /**
+     * Decrypt email value with specified user confirmation token.
+     *
+     * @param string $encryptedEmail
+     *
+     * @return string Decrypted email.
+     */
+    public function decryptEmailValue($encryptedEmail)
+    {
+        $preparedEncryptedEmail = base64_decode($encryptedEmail);
+
+        $ivSize = $this->getMcryptIvSize();
+
+        // Select IV part from encrypted value
+        $ivDec = substr($preparedEncryptedEmail, 0, $ivSize);
+
+        // Select email part from encrypted value
+        $preparedEncryptedEmail = substr($preparedEncryptedEmail, $ivSize);
+
+        $decryptedEmail = mcrypt_decrypt(
+            $this->cipher,
+            $this->getConfirmationToken(),
+            $preparedEncryptedEmail,
+            $this->mcryptMode,
+            $ivDec
+        );
+
+        // Trim decrypted email from nul byte before return
+        $email = rtrim($decryptedEmail, "\0");
+        
+        if(!preg_match('/^.+\@\S+\.\S+$/', $email)){
+
+            throw new \InvalidArgumentException('Wrong email format was provided for decryptEmailValue function');
+        }
+        
+        return $email;
+    }
+
+    /**
+     * Set user confirmation token. Will be used for email encryption/decryption.
+     * User confirmation token size should be either 16, 24 or 32 byte.
+     *
+     * @param string $userConfirmationToken
+     * @return $this
+     */
+    public function setUserConfirmationToken($userConfirmationToken)
+    {
+        if (!$userConfirmationToken || !is_string($userConfirmationToken)) {
+            throw new \InvalidArgumentException(
+                'Invalid user confirmation token value.'
+            );
+        }
+
+        $this->userConfirmationToken = $userConfirmationToken;
+
+        return $this;
+    }
+
+    /**
+     * Set email value to be encrypted.
+     *
+     * @param string $email
+     * @return $this
+     */
+    public function setEmail($email)
+    {
+        if (!is_string($email)) {
+            throw new \InvalidArgumentException(
+                'Email to be encrypted should a string. '
+                . gettype($email) . ' given.'
+            );
+        }
+
+        $this->email = trim($email);
+
+        return $this;
+    }
+
+    /**
+     * Get confirmation token.
+     *
+     * @return string
+     */
+    public function getConfirmationToken()
+    {
+        if (!$this->userConfirmationToken) {
+            throw new \InvalidArgumentException(
+                'User confirmation token should be specified.'
+            );
+        }
+
+        // Generate the random binary string based on hashed hexadecimal token
+        return pack('H*', hash('sha256', $this->userConfirmationToken));
+    }
+
+    /**
+     * Return IV size.
+     *
+     * @return int
+     */
+    protected function getMcryptIvSize()
+    {
+        return mcrypt_get_iv_size($this->cipher, $this->mcryptMode);
+    }
+}

--- a/Services/EmailConfirmation/EmailEncryption.php
+++ b/Services/EmailConfirmation/EmailEncryption.php
@@ -1,21 +1,28 @@
 <?php
 
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FOS\UserBundle\Services\EmailConfirmation;
 
 use FOS\UserBundle\Services\EmailConfirmation\Interfaces\EmailEncryptionInterface;
 
 /**
- * Class EmailEncryption
+ * Class EmailEncryption.
  *
  * Use this class for encryption/decryption of email value based on specified
  * token.
- *
- * @package FOS\UserBundle\Services\EmailConfirmation
  */
 class EmailEncryption implements EmailEncryptionInterface
 {
     /**
-     * @var string $encryptionMode
+     * @var string
      */
     private $encryptionMode;
 
@@ -31,11 +38,12 @@ class EmailEncryption implements EmailEncryptionInterface
 
     /**
      * EmailEncryption cypher method (see http://php.net/manual/function.openssl-get-cipher-methods.php ).
+     *
      * @param string $mode
      */
     public function __construct($mode = null)
     {
-        if(!$mode) {
+        if (!$mode) {
             $mode = openssl_get_cipher_methods(false)[0];
         }
         $this->encryptionMode = $mode;
@@ -58,7 +66,7 @@ class EmailEncryption implements EmailEncryptionInterface
             $iv
         );
 
-        $encryptedEmail = base64_encode($iv . $encryptedEmail);
+        $encryptedEmail = base64_encode($iv.$encryptedEmail);
 
         return $encryptedEmail;
     }
@@ -68,7 +76,7 @@ class EmailEncryption implements EmailEncryptionInterface
      *
      * @param string $encryptedEmail
      *
-     * @return string Decrypted email.
+     * @return string Decrypted email
      */
     public function decryptEmailValue($encryptedEmail)
     {
@@ -91,11 +99,11 @@ class EmailEncryption implements EmailEncryptionInterface
 
         // Trim decrypted email from nul byte before return
         $email = rtrim($decryptedEmail, "\0");
-        
+
         if (!preg_match('/^.+\@\S+\.\S+$/', $email)) {
             throw new \InvalidArgumentException('Wrong email format was provided for decryptEmailValue function');
         }
-        
+
         return $email;
     }
 
@@ -104,6 +112,7 @@ class EmailEncryption implements EmailEncryptionInterface
      * User confirmation token size should be either 16, 24 or 32 byte.
      *
      * @param string $userConfirmationToken
+     *
      * @return $this
      */
     public function setUserConfirmationToken($userConfirmationToken)
@@ -123,6 +132,7 @@ class EmailEncryption implements EmailEncryptionInterface
      * Set email value to be encrypted.
      *
      * @param string $email
+     *
      * @return $this
      */
     public function setEmail($email)
@@ -130,7 +140,7 @@ class EmailEncryption implements EmailEncryptionInterface
         if (!is_string($email)) {
             throw new \InvalidArgumentException(
                 'Email to be encrypted should a string. '
-                . gettype($email) . ' given.'
+                .gettype($email).' given.'
             );
         }
 

--- a/Services/EmailConfirmation/EmailEncryption.php
+++ b/Services/EmailConfirmation/EmailEncryption.php
@@ -48,7 +48,7 @@ class EmailEncryption implements EmailEncryptionInterface
      * EmailEncryption cypher method (see http://php.net/manual/function.openssl-get-cipher-methods.php ).
      *
      * @param ValidatorInterface $validator
-     * @param string $mode
+     * @param string             $mode
      */
     public function __construct(ValidatorInterface $validator, $mode = null)
     {

--- a/Services/EmailConfirmation/EmailUpdateConfirmation.php
+++ b/Services/EmailConfirmation/EmailUpdateConfirmation.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace FOS\UserBundle\Services\EmailConfirmation;
+
+use FOS\UserBundle\Model\User;
+use FOS\UserBundle\Util\TokenGenerator;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use FOS\UserBundle\Mailer\TwigSwiftMailer;
+use FOS\UserBundle\Services\EmailConfirmation\Interfaces\EmailEncryptionInterface;
+use FOS\UserBundle\Services\EmailConfirmation\Interfaces\EmailUpdateConfirmationInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use FOS\UserBundle\FOSUserEvents;
+use FOS\UserBundle\Event\UserEvent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Class EmailUpdateConfirmation
+ * @package FOS\UserBundle\Services\EmailConfirmation
+ */
+class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
+{
+
+    const EMAIL_CONFIRMED = 'email_confirmed';
+
+    /**
+     * @var TwigSwiftMailer
+     */
+    private $mailer;
+    /**
+     * @var Router
+     */
+    private $router;
+
+    /**
+     * @var TokenGenerator
+     */
+    private $tokenGenerator;
+
+    /**
+     * @var EmailEncryptionInterface
+     */
+    private $emailEncryption;
+
+    /**
+     * @var User
+     */
+    private $user;
+
+    /**
+     * @var string Email to be confirmed
+     */
+    private $email;
+
+    /**
+     * @var string Route for confirmation link
+     */
+    private $confirmationRoute;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * EmailUpdateConfirmation constructor.
+     *
+     * @param Router $router
+     * @param TokenGenerator $tokenGenerator
+     * @param TwigSwiftMailer $mailer
+     * @param EmailEncryptionInterface $emailEncryption
+     */
+    public function __construct(
+        Router $router,
+        TokenGenerator $tokenGenerator,
+        TwigSwiftMailer $mailer,
+        EmailEncryptionInterface $emailEncryption,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->router = $router;
+
+        $this->tokenGenerator = $tokenGenerator;
+
+        $this->mailer = $mailer;
+
+        $this->emailEncryption = $emailEncryption;
+
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Get $mailer.
+     *
+     * @return TwigSwiftMailer $mailer
+     */
+    public function getMailer()
+    {
+        return $this->mailer;
+    }
+
+    /**
+     * Generate new confirmation link for new email based on user confirmation
+     * token and hashed new user email.
+     * @param Request $request
+     * @return string
+     */
+    public function generateConfirmationLink(Request $request)
+    {
+        $this->emailEncryption->setUserConfirmationToken(
+            $this->getUserConfirmationToken()
+        );
+
+        $encryptedEmail = $this->emailEncryption->encryptEmailValue();
+
+        $confirmationParams = array('token'  => $this->user->getConfirmationToken(), 'target' => $encryptedEmail);
+
+        $event = new UserEvent($this->user, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::EMAIL_UPDATE_INITIALIZE, $event);
+
+        return $this->router->generate(
+            $this->confirmationRoute,
+            $confirmationParams,
+            RouterInterface::ABSOLUTE_URL
+        );
+    }
+
+    /**
+     * Fetch email value from hashed part of confirmation link.
+     *
+     * @param string $hashedEmail
+     * @return string Encrypted email
+     */
+    public function fetchEncryptedEmailFromConfirmationLink($hashedEmail)
+    {
+        //replace spaces with plus sign from hash, which could be replaced in url
+        $hashedEmail = str_replace(' ', '+', $hashedEmail);
+
+        $this->emailEncryption->setUserConfirmationToken(
+            $this->getUserConfirmationToken()
+        );
+
+        $email = $this->emailEncryption->decryptEmailValue($hashedEmail);
+
+        return $email;
+    }
+
+    /**
+     * Set user class instance.
+     *
+     * @param User $user
+     * @return $this
+     */
+    public function setUser(User $user)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * Set new user email to be confirmed. Email value should be already
+     * validated.
+     *
+     * @param string $email
+     * @return $this
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+
+        $this->emailEncryption->setEmail($this->email);
+
+        return $this;
+    }
+
+    /**
+     * Set route to be used for confirmation ling generation. This route should
+     * contain path to confirmation action.
+     *
+     * @param string $confirmationRoute
+     * @return $this
+     */
+    public function setConfirmationRoute($confirmationRoute)
+    {
+        $this->confirmationRoute = $confirmationRoute;
+
+        return $this;
+    }
+
+
+    /**
+     * Get or create new user confirmation token.
+     *
+     * @return string
+     */
+    protected function getUserConfirmationToken()
+    {
+        // Generate new token if it's not set
+        if (!$this->user->getConfirmationToken()) {
+
+            $this->user->setConfirmationToken(
+                $this->tokenGenerator->generateToken()
+            );
+        }
+
+        return $this->user->getConfirmationToken();
+    }
+
+    /**
+     * Get token which indicates that email was confirmed.
+     *
+     * @return string
+     */
+    public function getEmailConfirmedToken()
+    {
+        return base64_encode(self::EMAIL_CONFIRMED);
+    }
+}

--- a/Services/EmailConfirmation/EmailUpdateConfirmation.php
+++ b/Services/EmailConfirmation/EmailUpdateConfirmation.php
@@ -14,8 +14,7 @@ namespace FOS\UserBundle\Services\EmailConfirmation;
 use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Mailer\MailerInterface;
-use FOS\UserBundle\Mailer\TwigSwiftMailer;
-use FOS\UserBundle\Model\User;
+use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Services\EmailConfirmation\Interfaces\EmailEncryptionInterface;
 use FOS\UserBundle\Services\EmailConfirmation\Interfaces\EmailUpdateConfirmationInterface;
 use FOS\UserBundle\Util\TokenGenerator;
@@ -51,7 +50,7 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
     private $emailEncryption;
 
     /**
-     * @var User
+     * @var UserInterface
      */
     private $user;
 
@@ -158,11 +157,11 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
     /**
      * Set user class instance.
      *
-     * @param User $user
+     * @param UserInterface $user
      *
      * @return $this
      */
-    public function setUser(User $user)
+    public function setUser(UserInterface $user)
     {
         $this->user = $user;
 

--- a/Services/EmailConfirmation/EmailUpdateConfirmation.php
+++ b/Services/EmailConfirmation/EmailUpdateConfirmation.php
@@ -2,6 +2,7 @@
 
 namespace FOS\UserBundle\Services\EmailConfirmation;
 
+use FOS\UserBundle\Mailer\MailerInterface;
 use FOS\UserBundle\Model\User;
 use FOS\UserBundle\Util\TokenGenerator;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
@@ -20,7 +21,6 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
 {
-
     const EMAIL_CONFIRMED = 'email_confirmed';
 
     /**
@@ -67,13 +67,13 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
      *
      * @param Router $router
      * @param TokenGenerator $tokenGenerator
-     * @param TwigSwiftMailer $mailer
+     * @param MailerInterface $mailer
      * @param EmailEncryptionInterface $emailEncryption
      */
     public function __construct(
         Router $router,
         TokenGenerator $tokenGenerator,
-        TwigSwiftMailer $mailer,
+        MailerInterface $mailer,
         EmailEncryptionInterface $emailEncryption,
         EventDispatcherInterface $eventDispatcher
     ) {
@@ -186,7 +186,6 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
 
         return $this;
     }
-
 
     /**
      * Get or create new user confirmation token.

--- a/Services/EmailConfirmation/EmailUpdateConfirmation.php
+++ b/Services/EmailConfirmation/EmailUpdateConfirmation.php
@@ -1,23 +1,31 @@
 <?php
 
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FOS\UserBundle\Services\EmailConfirmation;
 
+use FOS\UserBundle\Event\UserEvent;
+use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Mailer\MailerInterface;
-use FOS\UserBundle\Model\User;
-use FOS\UserBundle\Util\TokenGenerator;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use FOS\UserBundle\Mailer\TwigSwiftMailer;
+use FOS\UserBundle\Model\User;
 use FOS\UserBundle\Services\EmailConfirmation\Interfaces\EmailEncryptionInterface;
 use FOS\UserBundle\Services\EmailConfirmation\Interfaces\EmailUpdateConfirmationInterface;
+use FOS\UserBundle\Util\TokenGenerator;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use FOS\UserBundle\FOSUserEvents;
-use FOS\UserBundle\Event\UserEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
- * Class EmailUpdateConfirmation
- * @package FOS\UserBundle\Services\EmailConfirmation
+ * Class EmailUpdateConfirmation.
  */
 class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
 {
@@ -65,9 +73,9 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
     /**
      * EmailUpdateConfirmation constructor.
      *
-     * @param Router $router
-     * @param TokenGenerator $tokenGenerator
-     * @param MailerInterface $mailer
+     * @param Router                   $router
+     * @param TokenGenerator           $tokenGenerator
+     * @param MailerInterface          $mailer
      * @param EmailEncryptionInterface $emailEncryption
      */
     public function __construct(
@@ -101,7 +109,9 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
     /**
      * Generate new confirmation link for new email based on user confirmation
      * token and hashed new user email.
+     *
      * @param Request $request
+     *
      * @return string
      */
     public function generateConfirmationLink(Request $request)
@@ -112,7 +122,7 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
 
         $encryptedEmail = $this->emailEncryption->encryptEmailValue();
 
-        $confirmationParams = array('token'  => $this->user->getConfirmationToken(), 'target' => $encryptedEmail);
+        $confirmationParams = array('token' => $this->user->getConfirmationToken(), 'target' => $encryptedEmail);
 
         $event = new UserEvent($this->user, $request);
         $this->eventDispatcher->dispatch(FOSUserEvents::EMAIL_UPDATE_INITIALIZE, $event);
@@ -128,6 +138,7 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
      * Fetch email value from hashed part of confirmation link.
      *
      * @param string $hashedEmail
+     *
      * @return string Encrypted email
      */
     public function fetchEncryptedEmailFromConfirmationLink($hashedEmail)
@@ -148,6 +159,7 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
      * Set user class instance.
      *
      * @param User $user
+     *
      * @return $this
      */
     public function setUser(User $user)
@@ -162,6 +174,7 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
      * validated.
      *
      * @param string $email
+     *
      * @return $this
      */
     public function setEmail($email)
@@ -178,6 +191,7 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
      * contain path to confirmation action.
      *
      * @param string $confirmationRoute
+     *
      * @return $this
      */
     public function setConfirmationRoute($confirmationRoute)
@@ -196,7 +210,6 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
     {
         // Generate new token if it's not set
         if (!$this->user->getConfirmationToken()) {
-
             $this->user->setConfirmationToken(
                 $this->tokenGenerator->generateToken()
             );

--- a/Services/EmailConfirmation/EmailUpdateConfirmation.php
+++ b/Services/EmailConfirmation/EmailUpdateConfirmation.php
@@ -32,7 +32,7 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
     const EMAIL_CONFIRMED = 'email_confirmed';
 
     /**
-     * @var TwigSwiftMailer
+     * @var MailerInterface
      */
     private $mailer;
     /**
@@ -99,7 +99,7 @@ class EmailUpdateConfirmation implements EmailUpdateConfirmationInterface
     /**
      * Get $mailer.
      *
-     * @return TwigSwiftMailer $mailer
+     * @return MailerInterface
      */
     public function getMailer()
     {

--- a/Services/EmailConfirmation/Interfaces/EmailEncryptionInterface.php
+++ b/Services/EmailConfirmation/Interfaces/EmailEncryptionInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FOS\UserBundle\Services\EmailConfirmation\Interfaces;
+
+/**
+ * Interface EmailEncryptionInterface
+ *
+ * @package FOS\UserBundle\Services\EmailConfirmation\Interfaces
+ */
+interface EmailEncryptionInterface
+{
+    /**
+     * @return string Encrypted email value
+     */
+    public function encryptEmailValue();
+
+    /**
+     * @param string $encryptedEmail Encrypted email value
+     *
+     * @return string Decrypted email value
+     */
+    public function decryptEmailValue($encryptedEmail);
+
+    /**
+     * @param string $email Email to be encrypt/decrypt
+     * @return $this
+     */
+    public function setEmail($email);
+
+    /**
+     * @param string $userConfirmationToken
+     * @return $this
+     */
+    public function setUserConfirmationToken($userConfirmationToken);
+}

--- a/Services/EmailConfirmation/Interfaces/EmailEncryptionInterface.php
+++ b/Services/EmailConfirmation/Interfaces/EmailEncryptionInterface.php
@@ -1,11 +1,18 @@
 <?php
 
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FOS\UserBundle\Services\EmailConfirmation\Interfaces;
 
 /**
- * Interface EmailEncryptionInterface
- *
- * @package FOS\UserBundle\Services\EmailConfirmation\Interfaces
+ * Interface EmailEncryptionInterface.
  */
 interface EmailEncryptionInterface
 {
@@ -23,12 +30,14 @@ interface EmailEncryptionInterface
 
     /**
      * @param string $email Email to be encrypt/decrypt
+     *
      * @return $this
      */
     public function setEmail($email);
 
     /**
      * @param string $userConfirmationToken
+     *
      * @return $this
      */
     public function setUserConfirmationToken($userConfirmationToken);

--- a/Services/EmailConfirmation/Interfaces/EmailUpdateConfirmationInterface.php
+++ b/Services/EmailConfirmation/Interfaces/EmailUpdateConfirmationInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace FOS\UserBundle\Services\EmailConfirmation\Interfaces;
+
+use FOS\UserBundle\Model\User;
+
+/**
+ * Interface EmailUpdateConfirmationInterface
+ * @package FOS\UserBundle\Services\EmailConfirmation\Interfaces
+ */
+interface EmailUpdateConfirmationInterface
+{
+
+    /**
+     * @param string $hashedEmail
+     * @return string
+     */
+    public function fetchEncryptedEmailFromConfirmationLink($hashedEmail);
+
+    /**
+     * @param User $user
+     * @return $this
+     */
+    public function setUser(User $user);
+
+    /**
+     * @param string $email
+     * @return $this
+     */
+    public function setEmail($email);
+
+    /**
+     * @param string $confirmationRoute
+     * @return $this
+     */
+    public function setConfirmationRoute($confirmationRoute);
+}

--- a/Services/EmailConfirmation/Interfaces/EmailUpdateConfirmationInterface.php
+++ b/Services/EmailConfirmation/Interfaces/EmailUpdateConfirmationInterface.php
@@ -10,7 +10,6 @@ use FOS\UserBundle\Model\User;
  */
 interface EmailUpdateConfirmationInterface
 {
-
     /**
      * @param string $hashedEmail
      * @return string

--- a/Services/EmailConfirmation/Interfaces/EmailUpdateConfirmationInterface.php
+++ b/Services/EmailConfirmation/Interfaces/EmailUpdateConfirmationInterface.php
@@ -11,7 +11,7 @@
 
 namespace FOS\UserBundle\Services\EmailConfirmation\Interfaces;
 
-use FOS\UserBundle\Model\User;
+use FOS\UserBundle\Model\UserInterface;
 
 /**
  * Interface EmailUpdateConfirmationInterface.
@@ -26,11 +26,11 @@ interface EmailUpdateConfirmationInterface
     public function fetchEncryptedEmailFromConfirmationLink($hashedEmail);
 
     /**
-     * @param User $user
+     * @param UserInterface $user
      *
      * @return $this
      */
-    public function setUser(User $user);
+    public function setUser(UserInterface $user);
 
     /**
      * @param string $email

--- a/Services/EmailConfirmation/Interfaces/EmailUpdateConfirmationInterface.php
+++ b/Services/EmailConfirmation/Interfaces/EmailUpdateConfirmationInterface.php
@@ -1,35 +1,47 @@
 <?php
 
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FOS\UserBundle\Services\EmailConfirmation\Interfaces;
 
 use FOS\UserBundle\Model\User;
 
 /**
- * Interface EmailUpdateConfirmationInterface
- * @package FOS\UserBundle\Services\EmailConfirmation\Interfaces
+ * Interface EmailUpdateConfirmationInterface.
  */
 interface EmailUpdateConfirmationInterface
 {
     /**
      * @param string $hashedEmail
+     *
      * @return string
      */
     public function fetchEncryptedEmailFromConfirmationLink($hashedEmail);
 
     /**
      * @param User $user
+     *
      * @return $this
      */
     public function setUser(User $user);
 
     /**
      * @param string $email
+     *
      * @return $this
      */
     public function setEmail($email);
 
     /**
      * @param string $confirmationRoute
+     *
      * @return $this
      */
     public function setConfirmationRoute($confirmationRoute);

--- a/Tests/DependencyInjection/FOSUserExtensionTest.php
+++ b/Tests/DependencyInjection/FOSUserExtensionTest.php
@@ -248,6 +248,7 @@ class FOSUserExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter('@FOSUser/Registration/email.txt.twig', 'fos_user.registration.confirmation.template');
         $this->assertParameter('@FOSUser/Resetting/email.txt.twig', 'fos_user.resetting.email.template');
         $this->assertParameter('@FOSUser/Profile/email_update_confirmation.txt.twig', 'fos_user.email_update_confirmation.template');
+        $this->assertParameter(null, 'fos_user.email_update_confirmation.cypher_method');
         $this->assertParameter(array('admin@acme.org' => 'Acme Corp'), 'fos_user.resetting.email.from_email');
         $this->assertParameter(86400, 'fos_user.resetting.token_ttl');
     }

--- a/Tests/DependencyInjection/FOSUserExtensionTest.php
+++ b/Tests/DependencyInjection/FOSUserExtensionTest.php
@@ -247,6 +247,7 @@ class FOSUserExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter(array('admin@acme.org' => 'Acme Corp'), 'fos_user.registration.confirmation.from_email');
         $this->assertParameter('@FOSUser/Registration/email.txt.twig', 'fos_user.registration.confirmation.template');
         $this->assertParameter('@FOSUser/Resetting/email.txt.twig', 'fos_user.resetting.email.template');
+        $this->assertParameter('@FOSUser/Profile/email_update_confirmation.txt.twig', 'fos_user.email_update_confirmation.template');
         $this->assertParameter(array('admin@acme.org' => 'Acme Corp'), 'fos_user.resetting.email.from_email');
         $this->assertParameter(86400, 'fos_user.resetting.token_ttl');
     }

--- a/Tests/EventListener/FlashListenerTest.php
+++ b/Tests/EventListener/FlashListenerTest.php
@@ -44,4 +44,9 @@ class FlashListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->listener->addSuccessFlash($this->event, FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
     }
+
+    public function testAddInfoFlash()
+    {
+        $this->listener->addInfoFlash($this->event, FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
+    }
 }

--- a/Tests/Services/EmailEncryptionTest.php
+++ b/Tests/Services/EmailEncryptionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace FOS\UserBundle\Tests\Util;
+
+use FOS\UserBundle\Services\EmailConfirmation\EmailEncryption;
+
+class EmailEncryptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEncryptDecryptEmail()
+    {
+        $emailEncryption = new EmailEncryption();
+        $emailEncryption->setEmail('foo@example.com');
+        $emailEncryption->setUserConfirmationToken('test_token');
+
+        $encryptedEmail = $emailEncryption->encryptEmailValue();
+        $this->assertEquals('foo@example.com', $emailEncryption->decryptEmailValue($encryptedEmail));
+    }
+
+    public function testDecryptFromWrongEmailFormat()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $emailEncryption = new EmailEncryption();
+        $emailEncryption->setEmail('fooexample.com');
+        $emailEncryption->setUserConfirmationToken('test_token');
+
+        $encryptedEmail = $emailEncryption->encryptEmailValue();
+        $emailEncryption->decryptEmailValue($encryptedEmail);
+    }
+
+    public function testIntegerIsSetInsteadOfEmailString()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $emailEncryption = new EmailEncryption();
+        $emailEncryption->setEmail(123);
+    }
+
+    public function testIntegerIsSetInsteadOfConfirmationTokenString()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $emailEncryption = new EmailEncryption();
+        $emailEncryption->setUserConfirmationToken(123);
+    }
+
+    public function testNullIsSetInsteadOfConfirmationTokenString()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $emailEncryption = new EmailEncryption();
+        $emailEncryption->setUserConfirmationToken(null);
+    }
+
+    public function testGetConfirmationToken()
+    {
+        $emailEncryption = new EmailEncryption();
+        $emailEncryption->setUserConfirmationToken('test_token');
+
+        $confirmationToken = $emailEncryption->getConfirmationToken();
+        $expectedConfirmationToken = pack('H*', hash('sha256', 'test_token'));
+        $this->assertEquals($expectedConfirmationToken, $confirmationToken);
+
+    }
+
+    public function testGetConfirmationTokenIfUserConfirmationTokenIsNotSet()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $emailEncryption = new EmailEncryption();
+        $emailEncryption->getConfirmationToken();
+    }
+}

--- a/Tests/Services/EmailEncryptionTest.php
+++ b/Tests/Services/EmailEncryptionTest.php
@@ -24,13 +24,13 @@ class EmailEncryptionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->emailValidator =  $this->getMockBuilder('Symfony\Component\Validator\Validator\RecursiveValidator')->disableOriginalConstructor()->getMock();
+        $this->emailValidator = $this->getMockBuilder('Symfony\Component\Validator\Validator\RecursiveValidator')->disableOriginalConstructor()->getMock();
         $this->constraintViolationList = new ConstraintViolationList(array($this->getMockBuilder('Symfony\Component\Validator\ConstraintViolation')->disableOriginalConstructor()->getMock()));
     }
 
     public function testEncryptDecryptEmail()
     {
-        $this->emailValidator->expects($this->once())->method("validate")->will($this->returnValue($this->constraintViolationList));
+        $this->emailValidator->expects($this->once())->method('validate')->will($this->returnValue($this->constraintViolationList));
         $this->constraintViolationList->remove(0);
         $emailEncryption = new EmailEncryption($this->emailValidator);
         $emailEncryption->setEmail('foo@example.com');
@@ -45,7 +45,7 @@ class EmailEncryptionTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecryptFromWrongEmailFormat()
     {
-        $this->emailValidator->expects($this->once())->method("validate")->will($this->returnValue($this->constraintViolationList));
+        $this->emailValidator->expects($this->once())->method('validate')->will($this->returnValue($this->constraintViolationList));
         $emailEncryption = new EmailEncryption($this->emailValidator);
         $emailEncryption->setEmail('fooexample.com');
         $emailEncryption->setUserConfirmationToken('test_token');

--- a/Tests/Services/EmailEncryptionTest.php
+++ b/Tests/Services/EmailEncryptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FOS\UserBundle\Tests\Util;
 
 use FOS\UserBundle\Services\EmailConfirmation\EmailEncryption;
@@ -13,7 +22,7 @@ class EmailEncryptionTest extends \PHPUnit_Framework_TestCase
         $emailEncryption->setUserConfirmationToken('test_token');
 
         $encryptedEmail = $emailEncryption->encryptEmailValue();
-        $this->assertEquals('foo@example.com', $emailEncryption->decryptEmailValue($encryptedEmail));
+        $this->assertSame('foo@example.com', $emailEncryption->decryptEmailValue($encryptedEmail));
     }
 
     public function testDecryptFromWrongEmailFormat()
@@ -56,8 +65,7 @@ class EmailEncryptionTest extends \PHPUnit_Framework_TestCase
 
         $confirmationToken = $emailEncryption->getConfirmationToken();
         $expectedConfirmationToken = pack('H*', hash('sha256', 'test_token'));
-        $this->assertEquals($expectedConfirmationToken, $confirmationToken);
-
+        $this->assertSame($expectedConfirmationToken, $confirmationToken);
     }
 
     public function testGetConfirmationTokenIfUserConfirmationTokenIsNotSet()

--- a/Tests/Services/EmailUpdateConfirmationTest.php
+++ b/Tests/Services/EmailUpdateConfirmationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+
+namespace FOS\UserBundle\Tests\Util;
+
+use FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation;
+use FOS\UserBundle\Services\EmailConfirmation\EmailEncryption;
+
+class EmailUpdateConfirmationTest extends \PHPUnit_Framework_TestCase
+{
+
+    private $provider;
+    private $router;
+    private $tokenGenerator;
+    private $mailer;
+    private $emailEncryption;
+    private $eventDispatcher;
+    private $emailUpdateConfirmation;
+    private $user;
+    
+
+    protected function setUp()
+    {
+        $this->provider = $this->getMockBuilder('Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface')->getMock();
+        $this->user = $this->getMockBuilder('FOS\UserBundle\Model\User')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $this->router = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Routing\Router')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->tokenGenerator = $this->getMockBuilder('FOS\UserBundle\Util\TokenGenerator')->disableOriginalConstructor()->getMock();
+        $this->mailer = $this->getMockBuilder('FOS\UserBundle\Mailer\TwigSwiftMailer')->disableOriginalConstructor()->getMock();
+        $this->emailEncryption = new EmailEncryption();
+        $this->eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+
+        $this->emailUpdateConfirmation = new EmailUpdateConfirmation($this->router, $this->tokenGenerator, $this->mailer, $this->emailEncryption, $this->eventDispatcher);
+        $this->user->expects($this->any())
+            ->method('getConfirmationToken')
+            ->will($this->returnValue('test_token'));
+        $this->emailUpdateConfirmation->setUser($this->user);
+    }
+
+    public function testFetchEncryptedEmailFromConfirmationLinkMethod()
+    {
+        $emailEncryption = new EmailEncryption();
+        $emailEncryption->setEmail('foo@example.com');
+        $emailEncryption->setUserConfirmationToken('test_token');
+
+        $encryptedEmail = $emailEncryption->encryptEmailValue();
+
+        $email = $this->emailUpdateConfirmation->fetchEncryptedEmailFromConfirmationLink($encryptedEmail);
+        $this->assertEquals('foo@example.com', $email);
+    }
+
+    public function testFetchEncryptedEmailWithSpacesInsteadOfPlusSigns()
+    {
+        $encryptedEmail = 'dlx/ nzDXuaRWJ8q3STRneuZtkjGvyIY m4Z4pkT1SM=';
+        $email = $this->emailUpdateConfirmation->fetchEncryptedEmailFromConfirmationLink($encryptedEmail);
+        $this->assertEquals('foo@example.com', $email);
+    }
+}

--- a/Tests/Services/EmailUpdateConfirmationTest.php
+++ b/Tests/Services/EmailUpdateConfirmationTest.php
@@ -49,9 +49,9 @@ class EmailUpdateConfirmationTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->emailValidator =  $this->getMockBuilder('Symfony\Component\Validator\Validator\RecursiveValidator')->disableOriginalConstructor()->getMock();
+        $this->emailValidator = $this->getMockBuilder('Symfony\Component\Validator\Validator\RecursiveValidator')->disableOriginalConstructor()->getMock();
         $this->constraintViolationList = new ConstraintViolationList(array());
-        $this->emailValidator->expects($this->once())->method("validate")->will($this->returnValue($this->constraintViolationList));
+        $this->emailValidator->expects($this->once())->method('validate')->will($this->returnValue($this->constraintViolationList));
 
         $this->provider = $this->getMockBuilder('Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface')->getMock();
         $this->user = $this->getMockBuilder('FOS\UserBundle\Model\User')

--- a/Tests/Services/EmailUpdateConfirmationTest.php
+++ b/Tests/Services/EmailUpdateConfirmationTest.php
@@ -1,12 +1,20 @@
 <?php
 
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace FOS\UserBundle\Tests\Util;
 
 use FOS\UserBundle\Mailer\MailerInterface;
 use FOS\UserBundle\Model\User;
-use FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation;
 use FOS\UserBundle\Services\EmailConfirmation\EmailEncryption;
+use FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation;
 use FOS\UserBundle\Util\TokenGenerator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
@@ -14,25 +22,23 @@ use Symfony\Component\Routing\RouterInterface;
 
 class EmailUpdateConfirmationTest extends \PHPUnit_Framework_TestCase
 {
-
-    /** @var  ExpressionFunctionProviderInterface */
+    /** @var ExpressionFunctionProviderInterface */
     private $provider;
-    /** @var  RouterInterface */
+    /** @var RouterInterface */
     private $router;
-    /** @var  TokenGenerator */
+    /** @var TokenGenerator */
     private $tokenGenerator;
-    /** @var  MailerInterface */
+    /** @var MailerInterface */
     private $mailer;
-    /** @var  EmailEncryption */
+    /** @var EmailEncryption */
     private $emailEncryption;
-    /** @var  EventDispatcher */
+    /** @var EventDispatcher */
     private $eventDispatcher;
-    /** @var  EmailUpdateConfirmation */
+    /** @var EmailUpdateConfirmation */
     private $emailUpdateConfirmation;
-    /** @var  User */
+    /** @var User */
     private $user;
-    private $cypher_method = "AES-128-CBC";
-
+    private $cypher_method = 'AES-128-CBC';
 
     protected function setUp()
     {
@@ -65,6 +71,6 @@ class EmailUpdateConfirmationTest extends \PHPUnit_Framework_TestCase
         $encryptedEmail = $emailEncryption->encryptEmailValue();
 
         $email = $this->emailUpdateConfirmation->fetchEncryptedEmailFromConfirmationLink($encryptedEmail);
-        $this->assertEquals('foo@example.com', $email);
+        $this->assertSame('foo@example.com', $email);
     }
 }

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -4,7 +4,7 @@ Upgrade instruction
 This document describes the changes needed when upgrading because of a BC
 break. For the full list of changes, please look at the Changelog file.
 
-## 2.0.1 to dev-master
+## dev-master => 2.1.0
 
 ### MailerInterface
 For the implementation of [Confirmation of Changed Email](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Resources/doc/emails.rst#confirmation-of-changed-email)-feature, 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -4,6 +4,17 @@ Upgrade instruction
 This document describes the changes needed when upgrading because of a BC
 break. For the full list of changes, please look at the Changelog file.
 
+## 2.0.1 to dev-master
+
+### MailerInterface
+For the implementation of [Confirmation of Changed Email](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Resources/doc/emails.rst#confirmation-of-changed-email)-feature, 
+the `FOSUserBundle/Mailer/MailerInterface` received a new method. 
+
+`public function sendUpdateEmailConfirmation(UserInterface $user, $confirmationUrl, $toEmail);`
+
+If you use your own implementation of the `MailerInterface` and it does not inherit from one of the 
+implementations in `FOSUserBundle/Mailer`, then you will need to implement the new function as well.
+
 ## 2.0.0-alpha3 to 2.0.0-beta1
 
 Methods and properties removed from `FOS\UserBundle\Model\User`


### PR DESCRIPTION
This PR allows to require the confirmation of
changed email-addresses, by clicking on a
link, before the new address is written to
the database.

This PR does not require a db change. ;-)