### PR TITLE
Add missing setResponse() setter for GetResponseGroupEvent

### DIFF
--- a/Event/GetResponseGroupEvent.php
+++ b/Event/GetResponseGroupEvent.php
@@ -35,4 +35,14 @@ class GetResponseGroupEvent extends GroupEvent
     {
         return $this->response;
     }
+
+    /**
+     * Sets a new response object.
+     *
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
 }


### PR DESCRIPTION
Add missing setResponse() setter for GetResponseGroupEvent. Follows the mentioned in PR https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2606