### PR TITLE
Move some libs from "require-dev" to "require" section of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
         "symfony/twig-bundle": "^2.7 || ^3.0",
         "twig/twig": "^1.28 || ^2.0",
         "symfony/templating": "^2.7 || ^3.0",
-        "paragonie/random_compat": "^1 || ^2"
+        "paragonie/random_compat": "^1 || ^2",
+        "doctrine/doctrine-bundle": "^1.3",
+        "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
+        "symfony/console": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^1.3",
         "friendsofphp/php-cs-fixer": "^1.11",
-        "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
-        "symfony/console": "^2.7 || ^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/validator": "^2.7 || ^3.0",
         "symfony/yaml": "^2.7 || ^3.0",


### PR DESCRIPTION
Swiftmailer, Symfony Console and Doctrine Bundle dependencies are moved from "require-dev" to "require" section as theoretically they are required not only for dev installation.