### PR TITLE
Update Japanese translations

### DIFF
--- a/Resources/translations/FOSUserBundle.ja.yml
+++ b/Resources/translations/FOSUserBundle.ja.yml
@@ -41,13 +41,18 @@ registration:
 
             アカウントを有効化するには、次の確認 URL へアクセスしてください %confirmationUrl%
 
+            このリンクは一度しか使用できません。
 
             開発チーム
 
 resetting:
-#    check_email: '%email% 宛にメールを送信しました。メールに記載された確認 URL にアクセスして、アカウントを有効化してください。'
+    check_email: |
+        メールが送信されました。送信されたリンクをクリックしてパスワードをリセットして下さい。
+        注意：パスワードのリセットは %tokenLifetime% 時間のあいだに一度しか要求できません。
+
+        もしメールが届かない場合は、迷惑メールフォルダをご確認いただき、その上で再度やり直して下さい。
     request:
-        username: ユーザー名かメールアドレス
+        username: ユーザー名またはメールアドレス
         submit: パスワードのリセット
     reset:
         submit: パスワードの変更
@@ -63,6 +68,7 @@ resetting:
 
             開発チーム
 
+# Global strings
 layout:
     logout: ログアウト
     login: ログイン


### PR DESCRIPTION
Fix for #2419.
`validators.ja.yml` seems to need no updates.