### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/Command/ActivateUserCommandTest.php
+++ b/Tests/Command/ActivateUserCommandTest.php
@@ -12,11 +12,12 @@
 namespace FOS\UserBundle\Tests\Command;
 
 use FOS\UserBundle\Command\ActivateUserCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class ActivateUserCommandTest extends \PHPUnit_Framework_TestCase
+class ActivateUserCommandTest extends TestCase
 {
     public function testExecute()
     {

--- a/Tests/Command/ChangePasswordCommandTest.php
+++ b/Tests/Command/ChangePasswordCommandTest.php
@@ -12,11 +12,12 @@
 namespace FOS\UserBundle\Tests\Command;
 
 use FOS\UserBundle\Command\ChangePasswordCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class ChangePasswordCommandTest extends \PHPUnit_Framework_TestCase
+class ChangePasswordCommandTest extends TestCase
 {
     public function testExecute()
     {

--- a/Tests/Command/CreateUserCommandTest.php
+++ b/Tests/Command/CreateUserCommandTest.php
@@ -12,11 +12,12 @@
 namespace FOS\UserBundle\Tests\Command;
 
 use FOS\UserBundle\Command\CreateUserCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class CreateUserCommandTest extends \PHPUnit_Framework_TestCase
+class CreateUserCommandTest extends TestCase
 {
     public function testExecute()
     {

--- a/Tests/Command/DeactivateUserCommandTest.php
+++ b/Tests/Command/DeactivateUserCommandTest.php
@@ -12,11 +12,12 @@
 namespace FOS\UserBundle\Tests\Command;
 
 use FOS\UserBundle\Command\DeactivateUserCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class DeactivateUserCommandTest extends \PHPUnit_Framework_TestCase
+class DeactivateUserCommandTest extends TestCase
 {
     public function testExecute()
     {

--- a/Tests/Command/DemoteUserCommandTest.php
+++ b/Tests/Command/DemoteUserCommandTest.php
@@ -12,11 +12,12 @@
 namespace FOS\UserBundle\Tests\Command;
 
 use FOS\UserBundle\Command\DemoteUserCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class DemoteUserCommandTest extends \PHPUnit_Framework_TestCase
+class DemoteUserCommandTest extends TestCase
 {
     public function testExecute()
     {

--- a/Tests/Command/PromoteUserCommandTest.php
+++ b/Tests/Command/PromoteUserCommandTest.php
@@ -12,11 +12,12 @@
 namespace FOS\UserBundle\Tests\Command;
 
 use FOS\UserBundle\Command\PromoteUserCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class PromoteUserCommandTest extends \PHPUnit_Framework_TestCase
+class PromoteUserCommandTest extends TestCase
 {
     public function testExecute()
     {

--- a/Tests/DependencyInjection/FOSUserExtensionTest.php
+++ b/Tests/DependencyInjection/FOSUserExtensionTest.php
@@ -13,10 +13,11 @@ namespace FOS\UserBundle\Tests\DependencyInjection;
 
 use FOS\UserBundle\DependencyInjection\FOSUserExtension;
 use FOS\UserBundle\Util\LegacyFormHelper;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Parser;
 
-class FOSUserExtensionTest extends \PHPUnit_Framework_TestCase
+class FOSUserExtensionTest extends TestCase
 {
     /** @var ContainerBuilder */
     protected $configuration;

--- a/Tests/Doctrine/UserManagerTest.php
+++ b/Tests/Doctrine/UserManagerTest.php
@@ -13,8 +13,9 @@ namespace FOS\UserBundle\Tests\Doctrine;
 
 use FOS\UserBundle\Doctrine\UserManager;
 use FOS\UserBundle\Model\User;
+use PHPUnit\Framework\TestCase;
 
-class UserManagerTest extends \PHPUnit_Framework_TestCase
+class UserManagerTest extends TestCase
 {
     const USER_CLASS = 'FOS\UserBundle\Tests\Doctrine\DummyUser';
 

--- a/Tests/EventListener/AuthenticationListenerTest.php
+++ b/Tests/EventListener/AuthenticationListenerTest.php
@@ -14,9 +14,10 @@ namespace FOS\UserBundle\Tests\EventListener;
 use FOS\UserBundle\Event\FilterUserResponseEvent;
 use FOS\UserBundle\EventListener\AuthenticationListener;
 use FOS\UserBundle\FOSUserEvents;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class AuthenticationListenerTest extends \PHPUnit_Framework_TestCase
+class AuthenticationListenerTest extends TestCase
 {
     const FIREWALL_NAME = 'foo';
 

--- a/Tests/EventListener/FlashListenerTest.php
+++ b/Tests/EventListener/FlashListenerTest.php
@@ -13,9 +13,10 @@ namespace FOS\UserBundle\Tests\EventListener;
 
 use FOS\UserBundle\EventListener\FlashListener;
 use FOS\UserBundle\FOSUserEvents;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\Event;
 
-class FlashListenerTest extends \PHPUnit_Framework_TestCase
+class FlashListenerTest extends TestCase
 {
     /** @var Event */
     private $event;

--- a/Tests/Mailer/MailerTest.php
+++ b/Tests/Mailer/MailerTest.php
@@ -12,11 +12,12 @@
 namespace FOS\UserBundle\Tests\Mailer;
 
 use FOS\UserBundle\Mailer\Mailer;
+use PHPUnit\Framework\TestCase;
 use Swift_Events_EventDispatcher;
 use Swift_Mailer;
 use Swift_Transport_NullTransport;
 
-class MailerTest extends \PHPUnit_Framework_TestCase
+class MailerTest extends TestCase
 {
     /**
      * @dataProvider goodEmailProvider

--- a/Tests/Mailer/TwigSwiftMailerTest.php
+++ b/Tests/Mailer/TwigSwiftMailerTest.php
@@ -12,10 +12,11 @@
 namespace FOS\UserBundle\Tests\Mailer;
 
 use FOS\UserBundle\Mailer\TwigSwiftMailer;
+use PHPUnit\Framework\TestCase;
 use Swift_Mailer;
 use Swift_Transport_NullTransport;
 
-class TwigSwiftMailerTest extends \PHPUnit_Framework_TestCase
+class TwigSwiftMailerTest extends TestCase
 {
     /**
      * @dataProvider goodEmailProvider

--- a/Tests/Model/UserManagerTest.php
+++ b/Tests/Model/UserManagerTest.php
@@ -12,8 +12,9 @@
 namespace FOS\UserBundle\Tests\Model;
 
 use FOS\UserBundle\Model\UserManager;
+use PHPUnit\Framework\TestCase;
 
-class UserManagerTest extends \PHPUnit_Framework_TestCase
+class UserManagerTest extends TestCase
 {
     /**
      * @var UserManager

--- a/Tests/Model/UserTest.php
+++ b/Tests/Model/UserTest.php
@@ -12,8 +12,9 @@
 namespace FOS\UserBundle\Tests\Model;
 
 use FOS\UserBundle\Model\User;
+use PHPUnit\Framework\TestCase;
 
-class UserTest extends \PHPUnit_Framework_TestCase
+class UserTest extends TestCase
 {
     public function testUsername()
     {

--- a/Tests/Routing/RoutingTest.php
+++ b/Tests/Routing/RoutingTest.php
@@ -11,11 +11,12 @@
 
 namespace FOS\UserBundle\Tests\Routing;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RouteCollection;
 
-class RoutingTest extends \PHPUnit_Framework_TestCase
+class RoutingTest extends TestCase
 {
     /**
      * @dataProvider loadRoutingProvider

--- a/Tests/Security/EmailUserProviderTest.php
+++ b/Tests/Security/EmailUserProviderTest.php
@@ -12,8 +12,9 @@
 namespace FOS\UserBundle\Tests\Security;
 
 use FOS\UserBundle\Security\EmailUserProvider;
+use PHPUnit\Framework\TestCase;
 
-class EmailUserProviderTest extends \PHPUnit_Framework_TestCase
+class EmailUserProviderTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/Tests/Security/LoginManagerTest.php
+++ b/Tests/Security/LoginManagerTest.php
@@ -12,9 +12,10 @@
 namespace FOS\UserBundle\Tests\Security;
 
 use FOS\UserBundle\Security\LoginManager;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class LoginManagerTest extends \PHPUnit_Framework_TestCase
+class LoginManagerTest extends TestCase
 {
     public function testLogInUserWithRequestStack()
     {

--- a/Tests/Security/UserProviderTest.php
+++ b/Tests/Security/UserProviderTest.php
@@ -12,8 +12,9 @@
 namespace FOS\UserBundle\Tests\Security;
 
 use FOS\UserBundle\Security\UserProvider;
+use PHPUnit\Framework\TestCase;
 
-class UserProviderTest extends \PHPUnit_Framework_TestCase
+class UserProviderTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/Tests/Util/CanonicalFieldsUpdaterTest.php
+++ b/Tests/Util/CanonicalFieldsUpdaterTest.php
@@ -13,8 +13,9 @@ namespace FOS\UserBundle\Tests\Util;
 
 use FOS\UserBundle\Tests\TestUser;
 use FOS\UserBundle\Util\CanonicalFieldsUpdater;
+use PHPUnit\Framework\TestCase;
 
-class CanonicalFieldsUpdaterTest extends \PHPUnit_Framework_TestCase
+class CanonicalFieldsUpdaterTest extends TestCase
 {
     /**
      * @var CanonicalFieldsUpdater

--- a/Tests/Util/CanonicalizerTest.php
+++ b/Tests/Util/CanonicalizerTest.php
@@ -12,8 +12,9 @@
 namespace FOS\UserBundle\Tests\Util;
 
 use FOS\UserBundle\Util\Canonicalizer;
+use PHPUnit\Framework\TestCase;
 
-class CanonicalizerTest extends \PHPUnit_Framework_TestCase
+class CanonicalizerTest extends TestCase
 {
     /**
      * @dataProvider canonicalizeProvider

--- a/Tests/Util/PasswordUpdaterTest.php
+++ b/Tests/Util/PasswordUpdaterTest.php
@@ -13,8 +13,9 @@ namespace FOS\UserBundle\Tests\Util;
 
 use FOS\UserBundle\Tests\TestUser;
 use FOS\UserBundle\Util\PasswordUpdater;
+use PHPUnit\Framework\TestCase;
 
-class PasswordUpdaterTest extends \PHPUnit_Framework_TestCase
+class PasswordUpdaterTest extends TestCase
 {
     /**
      * @var PasswordUpdater

--- a/Tests/Util/UserManipulatorTest.php
+++ b/Tests/Util/UserManipulatorTest.php
@@ -14,8 +14,9 @@ namespace FOS\UserBundle\Tests\Util;
 use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Tests\TestUser;
 use FOS\UserBundle\Util\UserManipulator;
+use PHPUnit\Framework\TestCase;
 
-class UserManipulatorTest extends \PHPUnit_Framework_TestCase
+class UserManipulatorTest extends TestCase
 {
     public function testCreate()
     {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/validator": "^2.7 || ^3.0",
         "symfony/yaml": "^2.7 || ^3.0",
-        "phpunit/phpunit": "~4.8|~5.0"
+        "phpunit/phpunit": "~4.8.35|~5.4.3"
     },
     "conflict": {
         "doctrine/doctrine-bundle": "<1.3",


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`~5.4.3`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.4.md#543---2016-06-09), that support this namespace.