### PR TITLE
Fix PHPUnit version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/validator": "^2.7 || ^3.0",
         "symfony/yaml": "^2.7 || ^3.0",
-        "phpunit/phpunit": "~4.8.35|~5.4.3"
+        "phpunit/phpunit": "^4.8.35|^5.4.3"
     },
     "conflict": {
         "doctrine/doctrine-bundle": "<1.3",


### PR DESCRIPTION
This issue was brought up here: https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2639#discussion_r152905232

Basically, with `~` we would deny upgrading to PHPUnit 5.5+, and we shouldn't, since PHPUnit follows semver and we can go up to the latest minor without issues.