### PR TITLE
Allow to find user with username that looks like email

### DIFF
--- a/Model/UserManager.php
+++ b/Model/UserManager.php
@@ -64,7 +64,10 @@ abstract class UserManager implements UserManagerInterface
     public function findUserByUsernameOrEmail($usernameOrEmail)
     {
         if (preg_match('/^.+\@\S+\.\S+$/', $usernameOrEmail)) {
-            return $this->findUserByEmail($usernameOrEmail);
+            $user = $this->findUserByEmail($usernameOrEmail);
+            if ($user !== null) {
+                return $user;
+            }
         }
 
         return $this->findUserByUsername($usernameOrEmail);


### PR DESCRIPTION
This is especially useful for "switch user" functionality. Without this
patch it is not possible to impersonate a user with username
"bob@example.com" and email "robert@example.com"

Fixes #2500 

