### PR TITLE
Redirect to login when resetting password with invalid / old token

### DIFF
--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -146,7 +146,7 @@ class ResettingController extends Controller
         $user = $userManager->findUserByConfirmationToken($token);
 
         if (null === $user) {
-            throw new NotFoundHttpException(sprintf('The user with "confirmation token" does not exist for value "%s"', $token));
+            return new RedirectResponse($this->container->get('router')->generate('fos_user_security_login'));
         }
 
         $event = new GetResponseUserEvent($user, $request);

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -23,7 +23,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Controller managing the resetting of the password.


### PR DESCRIPTION

If the reset password token has already been used, clicking the original link will produce 404 page, would be better just to redirect to login page