### PR TITLE
Add autocomplete hints for password inputs

### DIFF
--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -55,11 +55,19 @@ class ChangePasswordFormType extends AbstractType
                 new NotBlank(),
                 new UserPassword($constraintsOptions),
             ),
+            'attr' =>  array(
+                'autcomplete' => 'current-password',
+            ),
         ));
 
         $builder->add('plainPassword', RepeatedType::class, array(
             'type' => PasswordType::class,
-            'options' => array('translation_domain' => 'FOSUserBundle'),
+            'options' => array(
+                'translation_domain' => 'FOSUserBundle',
+                'attr' =>  array(
+                    'autcomplete' => 'new-password',
+                ),
+            ),
             'first_options' => array('label' => 'form.new_password'),
             'second_options' => array('label' => 'form.new_password_confirmation'),
             'invalid_message' => 'fos_user.password.mismatch',

--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -55,7 +55,7 @@ class ChangePasswordFormType extends AbstractType
                 new NotBlank(),
                 new UserPassword($constraintsOptions),
             ),
-            'attr' =>  array(
+            'attr' => array(
                 'autcomplete' => 'current-password',
             ),
         ));
@@ -64,7 +64,7 @@ class ChangePasswordFormType extends AbstractType
             'type' => PasswordType::class,
             'options' => array(
                 'translation_domain' => 'FOSUserBundle',
-                'attr' =>  array(
+                'attr' => array(
                     'autcomplete' => 'new-password',
                 ),
             ),

--- a/Form/Type/ProfileFormType.php
+++ b/Form/Type/ProfileFormType.php
@@ -57,6 +57,9 @@ class ProfileFormType extends AbstractType
                 new NotBlank(),
                 new UserPassword($constraintsOptions),
             ),
+            'attr' => array(
+                'autocomplete' => 'current-password',
+            ),
         ));
     }
 

--- a/Form/Type/RegistrationFormType.php
+++ b/Form/Type/RegistrationFormType.php
@@ -43,7 +43,12 @@ class RegistrationFormType extends AbstractType
             ->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
             ->add('plainPassword', RepeatedType::class, array(
                 'type' => PasswordType::class,
-                'options' => array('translation_domain' => 'FOSUserBundle'),
+                'options' => array(
+                    'translation_domain' => 'FOSUserBundle',
+                    'attr' => array(
+                        'autocomplete' => 'new-password',
+                    ),
+                ),
                 'first_options' => array('label' => 'form.password'),
                 'second_options' => array('label' => 'form.password_confirmation'),
                 'invalid_message' => 'fos_user.password.mismatch',

--- a/Form/Type/ResettingFormType.php
+++ b/Form/Type/ResettingFormType.php
@@ -39,7 +39,12 @@ class ResettingFormType extends AbstractType
     {
         $builder->add('plainPassword', RepeatedType::class, array(
             'type' => PasswordType::class,
-            'options' => array('translation_domain' => 'FOSUserBundle'),
+            'options' => array(
+                'translation_domain' => 'FOSUserBundle',
+                'attr' => array(
+                    'autocomplete' => 'new-password',
+                ),
+            ),
             'first_options' => array('label' => 'form.new_password'),
             'second_options' => array('label' => 'form.new_password_confirmation'),
             'invalid_message' => 'fos_user.password.mismatch',

--- a/Resources/views/Security/login_content.html.twig
+++ b/Resources/views/Security/login_content.html.twig
@@ -10,10 +10,10 @@
     {% endif %}
 
     <label for="username">{{ 'security.login.username'|trans }}</label>
-    <input type="text" id="username" name="_username" value="{{ last_username }}" required="required" />
+    <input type="text" id="username" name="_username" value="{{ last_username }}" required="required" autocomplete="username" />
 
     <label for="password">{{ 'security.login.password'|trans }}</label>
-    <input type="password" id="password" name="_password" required="required" />
+    <input type="password" id="password" name="_password" required="required" autocomplete="current-password" />
 
     <input type="checkbox" id="remember_me" name="_remember_me" value="on" />
     <label for="remember_me">{{ 'security.login.remember_me'|trans }}</label>

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,11 @@
             "/Tests/"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "FOS\\UserBundle\\Tests\\": "/Tests/"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.1.x-dev"


### PR DESCRIPTION
Chrome / Chromium supports autocomplete hints for password fields to enable new password generation, autocomplete et cetera.

This pull requests adds these hints.

See: 

* https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands
* https://www.chromium.org/developers/design-documents/password-generation

This is my first PR here, so if you have any feedback please add. 