### PR TITLE
Typo in fos_user.profiler.controller service definition

### DIFF
--- a/Resources/config/profile.xml
+++ b/Resources/config/profile.xml
@@ -22,7 +22,7 @@
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="fos_user.profile.form.factory" />
             <argument type="service" id="fos_user.user_manager" />
-            <argument type="service" id="fos_user.user_manager" />
+            <argument type="service" id="fos_user.email_update_confirmation" />
             <argument type="service" id="translator" />
         </service>
     </services>


### PR DESCRIPTION
There is a typo in `fos_user.profiler.controller` service definition.

Because of a typo, this error occurs:

> Type error: Argument 4 passed to FOS\UserBundle\Controller\ProfileController::__construct() must be an instance of FOS\UserBundle\Services\EmailConfirmation\EmailUpdateConfirmation, instance of FOS\UserBundle\Doctrine\UserManager given, called in /srv/var/cache/dev/ContainerNJrSCSi/getFosUser_Profiler_ControllerService.php on line 10
