### PR TITLE
Redirect to login when using confirmation link more than once

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -140,7 +140,7 @@ class RegistrationController extends AbstractController
         $user = $this->userManager->findUserByEmail($email);
 
         if (null === $user) {
-            throw new NotFoundHttpException(sprintf('The user with email "%s" does not exist', $email));
+            return new RedirectResponse($this->container->get('router')->generate('fos_user_security_login'));
         }
 
         return $this->render('@FOSUser/Registration/check_email.html.twig', array(


### PR DESCRIPTION
As done in #2653, it will solve #2106, #2420 and #2644 and will give a more coherent/convenient way to treat this misuse of activation link