### PR TITLE
correct return type in docblock for UserInterface::isPasswordRequestN…

### DIFF
--- a/Model/UserInterface.php
+++ b/Model/UserInterface.php
@@ -170,7 +170,7 @@ interface UserInterface extends AdvancedUserInterface, \Serializable
      *
      * @param int $ttl Requests older than this many seconds will be considered expired
      *
-     * @return int
+     * @return bool
      */
     public function isPasswordRequestNonExpired($ttl);
 


### PR DESCRIPTION
…onExpired()

(Apply to 2.0.x branch - already in master.)