### PR TITLE
fix for #2678 non-existent service "fos_user.email_update_confirmation"

### DIFF
--- a/Resources/config/profile.xml
+++ b/Resources/config/profile.xml
@@ -22,7 +22,7 @@
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="fos_user.profile.form.factory" />
             <argument type="service" id="fos_user.user_manager" />
-            <argument type="service" id="fos_user.email_update_confirmation" />
+            <argument type="service" id="fos_user.email_update_confirmation" on-invalid="null" />
             <argument type="service" id="translator" />
         </service>
     </services>


### PR DESCRIPTION
if this is set in config:
fos_user: registration: confirmation: enabled: false

Then will get ServiceNotFoundException:
The service "fos_user.profiler.controller" has a dependency on a non-existent service "fos_user.email_update_confirmation".

This is because in FOSUserExtension -> loadProfile, 'profile_email_update_listener.xml' (which contains the service: fos_user.email_update_confirmation) is not loaded if above config is set to false, however fos_user.profiler.controller service always requires the fos_user.email_update_confirmation service.

So lets set fos_user.email_update_confirmation service to optional?