### PR TITLE
fix bug linked to repeatedType validation

### DIFF
--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -15,6 +15,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -72,6 +74,14 @@ class ChangePasswordFormType extends AbstractType
             'second_options' => array('label' => 'form.new_password_confirmation'),
             'invalid_message' => 'fos_user.password.mismatch',
         ));
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function(FormEvent $event) {
+            $data = $event->getData();
+            if (!is_array($data['plainPassword'])) {
+                $data['plainPassword'] = ['first' => null, 'second' => null];
+                $event->setData($data);
+            }
+        });
     }
 
     /**

--- a/Form/Type/ChangePasswordFormType.php
+++ b/Form/Type/ChangePasswordFormType.php
@@ -78,7 +78,10 @@ class ChangePasswordFormType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function(FormEvent $event) {
             $data = $event->getData();
             if (!is_array($data['plainPassword'])) {
-                $data['plainPassword'] = ['first' => null, 'second' => null];
+                $data['plainPassword'] = array(
+                    'first' => null,
+                    'second' => null,
+                );
                 $event->setData($data);
             }
         });

--- a/Form/Type/RegistrationFormType.php
+++ b/Form/Type/RegistrationFormType.php
@@ -60,7 +60,10 @@ class RegistrationFormType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function(FormEvent $event) {
             $data = $event->getData();
             if (!is_array($data['plainPassword'])) {
-                $data['plainPassword'] = ['first' => null, 'second' => null];
+                $data['plainPassword'] = array(
+                    'first' => null,
+                    'second' => null,
+                );
                 $event->setData($data);
             }
         });

--- a/Form/Type/RegistrationFormType.php
+++ b/Form/Type/RegistrationFormType.php
@@ -16,6 +16,8 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RegistrationFormType extends AbstractType
@@ -54,6 +56,14 @@ class RegistrationFormType extends AbstractType
                 'invalid_message' => 'fos_user.password.mismatch',
             ))
         ;
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function(FormEvent $event) {
+            $data = $event->getData();
+            if (!is_array($data['plainPassword'])) {
+                $data['plainPassword'] = ['first' => null, 'second' => null];
+                $event->setData($data);
+            }
+        });
     }
 
     /**

--- a/Form/Type/ResettingFormType.php
+++ b/Form/Type/ResettingFormType.php
@@ -55,7 +55,10 @@ class ResettingFormType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function(FormEvent $event) {
             $data = $event->getData();
             if (!is_array($data['plainPassword'])) {
-                $data['plainPassword'] = ['first' => null, 'second' => null];
+                $data['plainPassword'] = array(
+                    'first' => null,
+                    'second' => null,
+                );
                 $event->setData($data);
             }
         });

--- a/Form/Type/ResettingFormType.php
+++ b/Form/Type/ResettingFormType.php
@@ -15,6 +15,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ResettingFormType extends AbstractType
@@ -49,6 +51,14 @@ class ResettingFormType extends AbstractType
             'second_options' => array('label' => 'form.new_password_confirmation'),
             'invalid_message' => 'fos_user.password.mismatch',
         ));
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function(FormEvent $event) {
+            $data = $event->getData();
+            if (!is_array($data['plainPassword'])) {
+                $data['plainPassword'] = ['first' => null, 'second' => null];
+                $event->setData($data);
+            }
+        });
     }
 
     /**

--- a/Tests/Form/Type/ChangePasswordFormTypeTest.php
+++ b/Tests/Form/Type/ChangePasswordFormTypeTest.php
@@ -44,7 +44,7 @@ class ChangePasswordFormTypeTest extends ValidatorExtensionTypeTestCase
         $form = $this->factory->create(ChangePasswordFormType::class, $user);
         $formData = array(
             'current_password' => 'foo',
-            'plainPassword' => ''
+            'plainPassword' => '',
         );
         $form->submit($formData);
 

--- a/Tests/Form/Type/ChangePasswordFormTypeTest.php
+++ b/Tests/Form/Type/ChangePasswordFormTypeTest.php
@@ -36,6 +36,22 @@ class ChangePasswordFormTypeTest extends ValidatorExtensionTypeTestCase
         $this->assertSame('bar', $user->getPlainPassword());
     }
 
+    public function testSubmitWithInvalidRepeatedType()
+    {
+        $user = new TestUser();
+        $user->setPassword('foo');
+
+        $form = $this->factory->create(ChangePasswordFormType::class, $user);
+        $formData = array(
+            'current_password' => 'foo',
+            'plainPassword' => ''
+        );
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertNull($user->getPlainPassword());
+    }
+
     /**
      * @return array
      */

--- a/Tests/Form/Type/RegistrationFormTypeTest.php
+++ b/Tests/Form/Type/RegistrationFormTypeTest.php
@@ -38,6 +38,25 @@ class RegistrationFormTypeTest extends ValidatorExtensionTypeTestCase
         $this->assertSame('test', $user->getPlainPassword());
     }
 
+    public function testSubmitWithInvalidRepeatedType()
+    {
+        $user = new TestUser();
+
+        $form = $this->factory->create(RegistrationFormType::class, $user);
+        $formData = array(
+            'username' => 'bar',
+            'email' => 'john@doe.com',
+            'plainPassword' => '',
+        );
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame($user, $form->getData());
+        $this->assertSame('bar', $user->getUsername());
+        $this->assertSame('john@doe.com', $user->getEmail());
+        $this->assertNull($user->getPlainPassword());
+    }
+
     /**
      * @return array
      */

--- a/Tests/Form/Type/ResettingFormTypeTest.php
+++ b/Tests/Form/Type/ResettingFormTypeTest.php
@@ -34,6 +34,21 @@ class ResettingFormTypeTest extends ValidatorExtensionTypeTestCase
         $this->assertSame('test', $user->getPlainPassword());
     }
 
+    public function testSubmitWithInvalidRepeatedType()
+    {
+        $user = new TestUser();
+
+        $form = $this->factory->create(ResettingFormType::class, $user);
+        $formData = array(
+            'plainPassword' => ''
+        );
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame($user, $form->getData());
+        $this->assertNull($user->getPlainPassword());
+    }
+
     /**
      * @return array
      */

--- a/Tests/Form/Type/ResettingFormTypeTest.php
+++ b/Tests/Form/Type/ResettingFormTypeTest.php
@@ -40,7 +40,7 @@ class ResettingFormTypeTest extends ValidatorExtensionTypeTestCase
 
         $form = $this->factory->create(ResettingFormType::class, $user);
         $formData = array(
-            'plainPassword' => ''
+            'plainPassword' => '',
         );
         $form->submit($formData);
 


### PR DESCRIPTION
Hi,

I'm using FOSUserBundle in a project as json api, by doing tests I noticed that I can pass an empty plainPassword instead of an array containing first and second attributes like that:

``` php
{
	"plainPassword": ""
}
```
by doing that, no validation constraint will catch it, so I did some research and found it a bug in symfony (3.3 for me), for more information see here : [issue 21242](https://github.com/symfony/symfony/issues/21242)

In this PR, I add a listener and I force an array with null values if any one given, like this the validation constraint NotBlank will be triggered and the form will not be valid.

Feedbacks are welcome