### PR TITLE
make FormFactory service public

### DIFF
--- a/Resources/config/registration.xml
+++ b/Resources/config/registration.xml
@@ -6,7 +6,7 @@
 
     <services>
 
-        <service id="fos_user.registration.form.factory" class="FOS\UserBundle\Form\Factory\FormFactory">
+        <service id="fos_user.registration.form.factory" class="FOS\UserBundle\Form\Factory\FormFactory" public="true">
             <argument type="service" id="form.factory" />
             <argument>%fos_user.registration.form.name%</argument>
             <argument>%fos_user.registration.form.type%</argument>


### PR DESCRIPTION
make FormFactory service public so this works in symfony 4:

$formFactory = $this->get('fos_user.registration.form.factory');

from doc: https://symfony.com/doc/master/bundles/FOSUserBundle/overriding_controllers.html