### PR TITLE
Fix dependency error on a non-existent argument when registration or resetting feature is disabled

### DIFF
--- a/Resources/config/mailer.xml
+++ b/Resources/config/mailer.xml
@@ -7,6 +7,12 @@
     <parameters>
         <parameter key="fos_user.resetting.email.template">@FOSUser/Resetting/email.txt.twig</parameter>
         <parameter key="fos_user.registration.confirmation.template">@FOSUser/Registration/email.txt.twig</parameter>
+        <parameter key="fos_user.registration.confirmation.from_email" type="collection">
+            <parameter key="no-registration@acme.com">Acme Ltd</parameter>
+        </parameter>
+        <parameter key="fos_user.resetting.email.from_email" type="collection">
+            <parameter key="no-resetting@acme.com">Acme Ltd</parameter>
+        </parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
If _resetting_ feature is disabled, error `The service "fos_user.mailer.default" has a dependency on a non-existent parameter "fos_user.resetting.email.from_email"` is occured, when trying to send email.

A similar error occured when _registration_ feature is disabled, but for `fos_user.registration.confirmation.from_email` parameter.

This PR fixes this bug