### PR TITLE
Fix PHPDoc return types on UserManagerInterface

### DIFF
--- a/Model/UserManagerInterface.php
+++ b/Model/UserManagerInterface.php
@@ -45,7 +45,7 @@ interface UserManagerInterface
      *
      * @param array $criteria
      *
-     * @return UserInterface
+     * @return UserInterface|null
      */
     public function findUserBy(array $criteria);
 
@@ -54,7 +54,7 @@ interface UserManagerInterface
      *
      * @param string $username
      *
-     * @return UserInterface or null if user does not exist
+     * @return UserInterface|null
      */
     public function findUserByUsername($username);
 
@@ -63,7 +63,7 @@ interface UserManagerInterface
      *
      * @param string $email
      *
-     * @return UserInterface or null if user does not exist
+     * @return UserInterface|null
      */
     public function findUserByEmail($email);
 
@@ -72,7 +72,7 @@ interface UserManagerInterface
      *
      * @param string $usernameOrEmail
      *
-     * @return UserInterface or null if user does not exist
+     * @return UserInterface|null
      */
     public function findUserByUsernameOrEmail($usernameOrEmail);
 
@@ -81,7 +81,7 @@ interface UserManagerInterface
      *
      * @param string $token
      *
-     * @return UserInterface or null if user does not exist
+     * @return UserInterface|null
      */
     public function findUserByConfirmationToken($token);
 


### PR DESCRIPTION
The null value is not correctly parsed on analyzers tool and IDEs.

Example with PHPStan:

```
Strict comparison using === between null and FOS\UserBundle\Model\UserInterface will always evaluate to false.
```