### PR TITLE
Move autowiring aliases to XML files

### DIFF
--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -84,12 +84,7 @@ class FOSUserExtension extends Extension
         $container->setAlias('fos_user.util.email_canonicalizer', $config['service']['email_canonicalizer']);
         $container->setAlias('fos_user.util.username_canonicalizer', $config['service']['username_canonicalizer']);
         $container->setAlias('fos_user.util.token_generator', $config['service']['token_generator']);
-        $container->setAlias('FOS\UserBundle\Util\TokenGeneratorInterface', new Alias('fos_user.util.token_generator', false));
         $container->setAlias('fos_user.user_manager', new Alias($config['service']['user_manager'], true));
-        $container->setAlias('FOS\UserBundle\Model\UserManagerInterface', new Alias('fos_user.user_manager', false));
-        $container->setAlias('FOS\UserBundle\Util\PasswordUpdaterInterface', new Alias('fos_user.util.password_updater', false));
-        $container->setAlias('FOS\UserBundle\Util\CanonicalFieldsUpdater', new Alias('fos_user.util.canonical_fields_updater', false));
-        $container->setAlias('FOS\UserBundle\Security\LoginManagerInterface', new Alias('fos_user.security.login_manager', false));
 
         if ($config['use_listener'] && isset(self::$doctrineDrivers[$config['db_driver']])) {
             $listenerDefinition = $container->getDefinition('fos_user.user_listener');

--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -12,6 +12,8 @@
             <argument>%fos_user.model.user.class%</argument>
         </service>
 
+        <service id="FOS\UserBundle\Model\UserManagerInterface" alias="fos_user.user_manager" public="false" />
+
         <!-- The factory is configured in the DI extension class to support more Symfony versions -->
         <service id="fos_user.object_manager" class="Doctrine\Common\Persistence\ObjectManager" public="false">
             <argument>%fos_user.model_manager_name%</argument>

--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -12,8 +12,6 @@
             <argument>%fos_user.model.user.class%</argument>
         </service>
 
-        <service id="FOS\UserBundle\Model\UserManagerInterface" alias="fos_user.user_manager" public="false" />
-
         <!-- The factory is configured in the DI extension class to support more Symfony versions -->
         <service id="fos_user.object_manager" class="Doctrine\Common\Persistence\ObjectManager" public="false">
             <argument>%fos_user.model_manager_name%</argument>

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -23,7 +23,7 @@
             <argument>null</argument> <!-- remember_me service -->
         </service>
 
-        <service id="FOS\UserBundle\Security\LoginManagerInterface" alias="fos_user.security.login_manager" />
+        <service id="FOS\UserBundle\Security\LoginManagerInterface" alias="fos_user.security.login_manager" public="false" />
 
         <service id="fos_user.user_provider.username" class="FOS\UserBundle\Security\UserProvider" public="false">
             <argument type="service" id="fos_user.user_manager" />

--- a/Resources/config/util.xml
+++ b/Resources/config/util.xml
@@ -31,6 +31,7 @@
 
         <service id="FOS\UserBundle\Util\CanonicalFieldsUpdater" alias="fos_user.util.canonical_fields_updater" public="false" />
 
+        <service id="FOS\UserBundle\Model\UserManagerInterface" alias="fos_user.user_manager" public="false" />
     </services>
 
 </container>

--- a/Resources/config/util.xml
+++ b/Resources/config/util.xml
@@ -16,15 +16,20 @@
 
         <service id="fos_user.util.token_generator.default" class="FOS\UserBundle\Util\TokenGenerator" public="false" />
 
+        <service id="FOS\UserBundle\Util\TokenGeneratorInterface" alias="fos_user.util.token_generator" public="false" />
+
         <service id="fos_user.util.password_updater" class="FOS\UserBundle\Util\PasswordUpdater" public="false">
             <argument type="service" id="security.encoder_factory" />
         </service>
+
+        <service id="FOS\UserBundle\Util\PasswordUpdaterInterface" alias="fos_user.util.password_updater" public="false" />
 
         <service id="fos_user.util.canonical_fields_updater" class="FOS\UserBundle\Util\CanonicalFieldsUpdater" public="false">
             <argument type="service" id="fos_user.util.username_canonicalizer" />
             <argument type="service" id="fos_user.util.email_canonicalizer" />
         </service>
 
+        <service id="FOS\UserBundle\Util\CanonicalFieldsUpdater" alias="fos_user.util.canonical_fields_updater" public="false" />
 
     </services>
 


### PR DESCRIPTION
Move aliases created in the FOSUserExtension to the proper XML service definition files.