### PR TITLE
Translate registration confirm error message

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -163,7 +163,7 @@ class RegistrationController extends Controller
         $user = $userManager->findUserByConfirmationToken($token);
 
         if (null === $user) {
-            throw new NotFoundHttpException(sprintf('The user with confirmation token "%s" does not exist', $token));
+            throw new NotFoundHttpException($this->translator->trans('registration.confirm.error_message', array('token' => $token), 'FOSUserBundle'));
         }
 
         $dispatcher = $this->eventDispatcher;

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -48,6 +48,8 @@ email_update:
             the Team.
 
 registration:
+    confirm:
+        error_message: 'The user with confirmation token "%token%" does not exist'
     check_email: |
         An email has been sent to %email%. It contains an activation link you must click to activate your account.
     confirmed: 'Congrats %username%, your account is now activated.'

--- a/Resources/translations/FOSUserBundle.es.yml
+++ b/Resources/translations/FOSUserBundle.es.yml
@@ -28,6 +28,8 @@ change_password:
     flash:
         success: 'La contraseña se ha cambiado con éxito.'
 registration:
+    confirm:
+        error_message: 'El usuario con token de confirmación "%token%" no existe'
     check_email: 'Se ha enviado un correo electrónico a %email%. Contiene un enlace de activación al que debes acceder para activar tu cuenta.'
     confirmed: 'Felicidades %username%, tu cuenta está ahora confirmada.'
     back: 'Volver a la página original.'


### PR DESCRIPTION
This is a small change as error message for Registration controller in confirm action that enable to use the translator in the 404 error message when the token doesn't belong to any user.