### PR TITLE
Avoid complaining about the missing session when no features are needing it

### DIFF
--- a/DependencyInjection/Compiler/CheckForSessionPass.php
+++ b/DependencyInjection/Compiler/CheckForSessionPass.php
@@ -27,7 +27,7 @@ class CheckForSessionPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->has('session')) {
+        if ($container->has('fos_user.session') && !$container->has('session')) {
             $message = 'FOSUserBundle requires the "session" service to be available.';
 
             if (class_exists(Recipe::class)) {

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -41,6 +41,7 @@ class FOSUserExtension extends Extension
     );
 
     private $mailerNeeded = false;
+    private $sessionNeeded = false;
 
     /**
      * {@inheritdoc}
@@ -78,6 +79,7 @@ class FOSUserExtension extends Extension
         }
 
         if ($config['use_flash_notifications']) {
+            $this->sessionNeeded = true;
             $loader->load('flash_notifications.xml');
         }
 
@@ -129,6 +131,11 @@ class FOSUserExtension extends Extension
 
         if ($this->mailerNeeded) {
             $container->setAlias('fos_user.mailer', $config['service']['mailer']);
+        }
+
+        if ($this->sessionNeeded) {
+            // Use a private alias rather than a parameter, to avoid leaking it at runtime (the private alias will be removed)
+            $container->setAlias('fos_user.session', new Alias('session', false));
         }
     }
 
@@ -203,6 +210,7 @@ class FOSUserExtension extends Extension
     private function loadRegistration(array $config, ContainerBuilder $container, XmlFileLoader $loader, array $fromEmail)
     {
         $loader->load('registration.xml');
+        $this->sessionNeeded = true;
 
         if ($config['confirmation']['enabled']) {
             $this->mailerNeeded = true;


### PR DESCRIPTION
There are only 2 places in FOSUserBundle requiring the session:

- the registration layer
- the flash listener setting some flash messages.

Both of them can be disabled, and so the session would not be needed in such case.

I have a project with 2 kernels. One of them is enabling FOSUserBundle only for the user provider it implements, and disables all other features (to create a stateless API). Requiring the session in this case is hurting me for nothing.