### PR TITLE
Fix the configuration of controllers for Symfony 2.8

### DIFF
--- a/Resources/config/change_password.xml
+++ b/Resources/config/change_password.xml
@@ -21,6 +21,9 @@
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="fos_user.change_password.form.factory" />
             <argument type="service" id="fos_user.user_manager" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
         </service>
     </services>
 

--- a/Resources/config/group.xml
+++ b/Resources/config/group.xml
@@ -21,6 +21,9 @@
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="fos_user.group.form.factory" />
             <argument type="service" id="fos_user.group_manager" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
         </service>
     </services>
 

--- a/Resources/config/profile.xml
+++ b/Resources/config/profile.xml
@@ -22,6 +22,9 @@
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="fos_user.profile.form.factory" />
             <argument type="service" id="fos_user.user_manager" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
         </service>
     </services>
 

--- a/Resources/config/registration.xml
+++ b/Resources/config/registration.xml
@@ -23,6 +23,9 @@
             <argument type="service" id="fos_user.registration.form.factory" />
             <argument type="service" id="fos_user.user_manager" />
             <argument type="service" id="security.token_storage" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
         </service>
     </services>
 

--- a/Resources/config/resetting.xml
+++ b/Resources/config/resetting.xml
@@ -31,6 +31,9 @@
             <argument type="service" id="fos_user.util.token_generator" />
             <argument type="service" id="fos_user.mailer" />
             <argument>%fos_user.resetting.retry_ttl%</argument>
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
         </service>
     </services>
 

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -35,6 +35,9 @@
 
         <service id="fos_user.security.controller" class="FOS\UserBundle\Controller\SecurityController" public="true">
             <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
         </service>
     </services>
 


### PR DESCRIPTION
Symfony 2.8 does not inject the container in ContainerAware controllers defined as services, unlike recent 3.x versions.

Closes #2737 
Closes #2738 