### PR TITLE
Remove old translation for "invalid_username"

### DIFF
--- a/Resources/translations/FOSUserBundle.gl.yml
+++ b/Resources/translations/FOSUserBundle.gl.yml
@@ -58,7 +58,6 @@ resetting:
     password_already_requested: O contrasinal para este usuario solicitouse xa dentro das 24 horas.
     check_email: Enviouse un email %email%. Contén un enlace de activación que deberás premer para restablecelo teu contrasinal.
     request:
-        invalid_username: O usuario ou dirección de correo "%username%" non existe.
         username: Nome de usuario
         submit: Restablecer contrasinal
     reset:


### PR DESCRIPTION
The translation was removed in 2.0.0-beta1 (2016-11-29):

> [BC break] The translation key `resetting.request.invalid_username` has been removed.