### PR TITLE
Make "mailer" service optional

### DIFF
--- a/DependencyInjection/Compiler/CheckForMailerPass.php
+++ b/DependencyInjection/Compiler/CheckForMailerPass.php
@@ -19,6 +19,8 @@ use Symfony\Flex\Recipe;
  * Checks to see if the mailer service exists.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
+ *
+ * @deprecated since 2.1, "mailer" service should be optional
  */
 class CheckForMailerPass implements CompilerPassInterface
 {

--- a/FOSUserBundle.php
+++ b/FOSUserBundle.php
@@ -14,7 +14,6 @@ namespace FOS\UserBundle;
 use Doctrine\Bundle\CouchDBBundle\DependencyInjection\Compiler\DoctrineCouchDBMappingsPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
-use FOS\UserBundle\DependencyInjection\Compiler\CheckForMailerPass;
 use FOS\UserBundle\DependencyInjection\Compiler\CheckForSessionPass;
 use FOS\UserBundle\DependencyInjection\Compiler\InjectRememberMeServicesPass;
 use FOS\UserBundle\DependencyInjection\Compiler\InjectUserCheckerPass;
@@ -38,7 +37,6 @@ class FOSUserBundle extends Bundle
         $container->addCompilerPass(new InjectUserCheckerPass());
         $container->addCompilerPass(new InjectRememberMeServicesPass());
         $container->addCompilerPass(new CheckForSessionPass());
-        $container->addCompilerPass(new CheckForMailerPass());
 
         $this->addRegisterMappingsPass($container);
     }

--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -11,34 +11,15 @@
 
 namespace FOS\UserBundle\Mailer;
 
-use FOS\UserBundle\Model\UserInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @deprecated TwigSwiftMailer class is deprecated since 2.1, use TwigMailer instead.
  */
-class TwigSwiftMailer implements MailerInterface
+class TwigSwiftMailer extends TwigMailer
 {
-    /**
-     * @var \Swift_Mailer
-     */
-    protected $mailer;
-
-    /**
-     * @var UrlGeneratorInterface
-     */
-    protected $router;
-
-    /**
-     * @var \Twig_Environment
-     */
-    protected $twig;
-
-    /**
-     * @var array
-     */
-    protected $parameters;
-
     /**
      * TwigSwiftMailer constructor.
      *
@@ -49,74 +30,10 @@ class TwigSwiftMailer implements MailerInterface
      */
     public function __construct(\Swift_Mailer $mailer, UrlGeneratorInterface $router, \Twig_Environment $twig, array $parameters)
     {
-        $this->mailer = $mailer;
-        $this->router = $router;
-        $this->twig = $twig;
-        $this->parameters = $parameters;
-    }
+        @trigger_error(sprintf(
+            '%s is deprecated, use %s instead.', __CLASS__, TwigMailer::class
+        ), E_USER_DEPRECATED);
 
-    /**
-     * {@inheritdoc}
-     */
-    public function sendConfirmationEmailMessage(UserInterface $user)
-    {
-        $template = $this->parameters['template']['confirmation'];
-        $url = $this->router->generate('fos_user_registration_confirm', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
-
-        $context = array(
-            'user' => $user,
-            'confirmationUrl' => $url,
-        );
-
-        $this->sendMessage($template, $context, $this->parameters['from_email']['confirmation'], (string) $user->getEmail());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function sendResettingEmailMessage(UserInterface $user)
-    {
-        $template = $this->parameters['template']['resetting'];
-        $url = $this->router->generate('fos_user_resetting_reset', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
-
-        $context = array(
-            'user' => $user,
-            'confirmationUrl' => $url,
-        );
-
-        $this->sendMessage($template, $context, $this->parameters['from_email']['resetting'], (string) $user->getEmail());
-    }
-
-    /**
-     * @param string $templateName
-     * @param array  $context
-     * @param array  $fromEmail
-     * @param string $toEmail
-     */
-    protected function sendMessage($templateName, $context, $fromEmail, $toEmail)
-    {
-        $template = $this->twig->load($templateName);
-        $subject = $template->renderBlock('subject', $context);
-        $textBody = $template->renderBlock('body_text', $context);
-
-        $htmlBody = '';
-
-        if ($template->hasBlock('body_html', $context)) {
-            $htmlBody = $template->renderBlock('body_html', $context);
-        }
-
-        $message = (new \Swift_Message())
-            ->setSubject($subject)
-            ->setFrom($fromEmail)
-            ->setTo($toEmail);
-
-        if (!empty($htmlBody)) {
-            $message->setBody($htmlBody, 'text/html')
-                ->addPart($textBody, 'text/plain');
-        } else {
-            $message->setBody($textBody);
-        }
-
-        $this->mailer->send($message);
+        parent::__construct($mailer, $router, $twig, $parameters);
     }
 }

--- a/Resources/config/mailer.xml
+++ b/Resources/config/mailer.xml
@@ -17,7 +17,7 @@
 
     <services>
         <service id="fos_user.mailer.default" class="FOS\UserBundle\Mailer\Mailer" public="false">
-            <argument type="service" id="mailer" />
+            <argument type="service" id="mailer" on-invalid="null" />
             <argument type="service" id="router" />
             <argument type="service" id="templating" />
             <argument type="collection">
@@ -31,8 +31,8 @@
             <tag name="fos_user.requires_swift" />
         </service>
 
-        <service id="fos_user.mailer.twig_swift" class="FOS\UserBundle\Mailer\TwigSwiftMailer" public="false">
-            <argument type="service" id="mailer" />
+        <service id="fos_user.mailer.twig_swift" class="FOS\UserBundle\Mailer\TwigMailer" public="false">
+            <argument type="service" id="mailer" on-invalid="null" />
             <argument type="service" id="router" />
             <argument type="service" id="twig" />
             <argument type="collection">

--- a/Tests/Mailer/TwigMailerTest.php
+++ b/Tests/Mailer/TwigMailerTest.php
@@ -11,19 +11,19 @@
 
 namespace FOS\UserBundle\Tests\Mailer;
 
-use FOS\UserBundle\Mailer\TwigSwiftMailer;
+use FOS\UserBundle\Mailer\TwigMailer;
 use PHPUnit\Framework\TestCase;
 use Swift_Mailer;
 use Swift_Transport_NullTransport;
 
-class TwigSwiftMailerTest extends TestCase
+class TwigMailerTest extends TestCase
 {
     /**
      * @dataProvider goodEmailProvider
      */
     public function testSendConfirmationEmailMessageWithGoodEmails($emailAddress)
     {
-        $mailer = $this->getTwigSwiftMailer();
+        $mailer = $this->getTwigMailer();
         $mailer->sendConfirmationEmailMessage($this->getUser($emailAddress));
 
         $this->assertTrue(true);
@@ -35,7 +35,7 @@ class TwigSwiftMailerTest extends TestCase
      */
     public function testSendConfirmationEmailMessageWithBadEmails($emailAddress)
     {
-        $mailer = $this->getTwigSwiftMailer();
+        $mailer = $this->getTwigMailer();
         $mailer->sendConfirmationEmailMessage($this->getUser($emailAddress));
     }
 
@@ -44,7 +44,7 @@ class TwigSwiftMailerTest extends TestCase
      */
     public function testSendResettingEmailMessageWithGoodEmails($emailAddress)
     {
-        $mailer = $this->getTwigSwiftMailer();
+        $mailer = $this->getTwigMailer();
         $mailer->sendResettingEmailMessage($this->getUser($emailAddress));
 
         $this->assertTrue(true);
@@ -56,7 +56,7 @@ class TwigSwiftMailerTest extends TestCase
      */
     public function testSendResettingEmailMessageWithBadEmails($emailAddress)
     {
-        $mailer = $this->getTwigSwiftMailer();
+        $mailer = $this->getTwigMailer();
         $mailer->sendResettingEmailMessage($this->getUser($emailAddress));
     }
 
@@ -78,9 +78,9 @@ class TwigSwiftMailerTest extends TestCase
         );
     }
 
-    private function getTwigSwiftMailer()
+    private function getTwigMailer()
     {
-        return new TwigSwiftMailer(
+        return new TwigMailer(
             new Swift_Mailer(
                 new Swift_Transport_NullTransport(
                     $this->getMockBuilder('Swift_Events_EventDispatcher')->getMock()


### PR DESCRIPTION
With this PR the `mailer` service will not be required any more while compiling Container. Both mailers will throw exceptions on sending email if `mailer` service was not available.

Also a compiler pass `CheckForMailerPass`, introduced in #2639 was deprecated, and i created a new class `TwigMailer` without type hint in first argument of constructor. Old `TwigSwiftMailer` was deprecated, i moved all properties and methods to a new class to avoid BC breaks.

This PR with #2708 will make creating a recipe for Symfony Flex easier