### PR TITLE
Update logging_by_username_or_email.rst

### DIFF
--- a/Resources/doc/logging_by_username_or_email.rst
+++ b/Resources/doc/logging_by_username_or_email.rst
@@ -1,4 +1,4 @@
-Logging by Username or Email
+Logging in by Username or Email
 ============================
 
 As of the version 1.3.0, the bundle provides a built-in user provider implementation


### PR DESCRIPTION
The way it was originally phrased it seemed like there were logs being captured for the username or email instead of it allowing the user to login with their username or email