### PR TITLE
Fixed controller as services

### DIFF
--- a/Resources/config/change_password.xml
+++ b/Resources/config/change_password.xml
@@ -25,6 +25,8 @@
                 <argument type="service" id="service_container" />
             </call>
         </service>
+
+        <service id="FOS\UserBundle\Controller\ChangePasswordController" alias="fos_user.change_password.controller" public="true" />
     </services>
 
 </container>

--- a/Resources/config/profile.xml
+++ b/Resources/config/profile.xml
@@ -26,6 +26,8 @@
                 <argument type="service" id="service_container" />
             </call>
         </service>
+
+        <service id="FOS\UserBundle\Controller\ProfileController" alias="fos_user.profile.controller" public="true" />
     </services>
 
 </container>

--- a/Resources/config/registration.xml
+++ b/Resources/config/registration.xml
@@ -27,6 +27,8 @@
                 <argument type="service" id="service_container" />
             </call>
         </service>
+
+        <service id="FOS\UserBundle\Controller\RegistrationController" alias="fos_user.registration.controller" public="true" />
     </services>
 
 </container>

--- a/Resources/config/resetting.xml
+++ b/Resources/config/resetting.xml
@@ -35,6 +35,8 @@
                 <argument type="service" id="service_container" />
             </call>
         </service>
+
+        <service id="FOS\UserBundle\Controller\ResettingController" alias="fos_user.resetting.controller" public="true" />
     </services>
 
 </container>

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -43,6 +43,8 @@
                 <argument type="service" id="service_container" />
             </call>
         </service>
+
+        <service id="FOS\UserBundle\Controller\SecurityController" alias="fos_user.security.controller" public="true" />
     </services>
 
 </container>


### PR DESCRIPTION
Targeting 2.1 broken upgrade.

Introduced in #2639 controller as services with a constructor are not resolved when using `forward` or overriding routes definition with a short controller syntax, since the resolver instantiates it when the container does not find the class as id.

The PR should fix #2744 (which should not have been closed I guess, I got the same issue, hence made this PR).

We could also close #2791, given that overriding controllers could be done by creating new aliases in the app, OR new routes as recommended.