### PR TITLE
Allow NOP version of paragonie/random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/validator": "^2.8 || ^3.0 || ^4.0",
         "twig/twig": "^1.28 || ^2.0",
         "symfony/templating": "^2.8 || ^3.0 || ^4.0",
-        "paragonie/random_compat": "^1 || ^2"
+        "paragonie/random_compat": "^1 || ^2 || ^9"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.3",


### PR DESCRIPTION
`paragonie/random_compat` ships a [special version 9.99.99](https://github.com/paragonie/random_compat#version-99999) which is only installable on PHP ≥7.0. It consists of an empty `composer.json` and adds no files to the autoloader. It might provide a minor perfomance improvement.