### PR TITLE
Update change_password.xml

### DIFF
--- a/Resources/config/routing/change_password.xml
+++ b/Resources/config/routing/change_password.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="fos_user_change_password" path="/change-password" methods="GET POST">
-        <default key="_controller">fos_user.change_password.controller:changePasswordAction</default>
+        <default key="_controller">fos_user.change_password.controller::changePasswordAction</default>
     </route>
 
 </routes>


### PR DESCRIPTION
PHPUnit 6.5.10 by Sebastian Bergmann and contributors.
Remaining deprecation notices
Referencing controllers with a single colon is deprecated since Symfony 4.1, use "fos_user.change_password.controller::changePasswordAction" instead.