### PR TITLE
Update SV & FI translations

### DIFF
--- a/Resources/translations/FOSUserBundle.fi.yml
+++ b/Resources/translations/FOSUserBundle.fi.yml
@@ -44,7 +44,11 @@ registration:
             Terveisin ylläpito
 
 resetting:
-#    check_email: 'Sähköposti on lähetetty osoitteeseen %email%. Se sisältää linkin, jota klikkaamalla salasana alustetaan.'
+    check_email: |
+        Viesti on lähetetty. Se sisältää linkin jota klikkaamalla voit palauttaa salasanasi.
+        Huom! Et voi palauttaa salasanaasi useammin kuin %tokenLifetime% tunnin välein.
+
+        Jos et saanut viestiä, ole hyvä ja tarkasta roskapostilaatikkosi tai yritä uudelleen.
     request:
         username: 'Käyttäjätunnus tai sähköpostiosoite'
         submit: 'Alusta salasana'

--- a/Resources/translations/FOSUserBundle.sv.yml
+++ b/Resources/translations/FOSUserBundle.sv.yml
@@ -47,7 +47,11 @@ registration:
             Teamet.
 
 resetting:
-    check_email: 'Ett meddelande har skickats till %email%. Det innehåller en länk som du måste klicka på för att återställa ditt lösenord.'
+    check_email: |
+        Ett meddelande har skickats. Det innehåller en länk som du kan klicka för att återställa ditt lösenord.
+        Obs! Man kan inte återställa sitt lösenord oftare än var %tokenLifetime% timme.
+
+        Om du inte har fått ett meddelande, vänligen kolla din skräpinkorg eller försök igen.
     request:
         username: 'Användarnamn eller epost-adress'
         submit: 'Återställ lösenord'


### PR DESCRIPTION
Change `resetting.check_email` in both languages which were not up-to-date with English

See https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2419