### PR TITLE
Symfony 2 is old, and making it explicit it works with later versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FOSUserBundle
 =============
 
-The FOSUserBundle adds support for a database-backed user system in Symfony2.
+The FOSUserBundle adds support for a database-backed user system in Symfony2+.
 It provides a flexible framework for user management that aims to handle
 common tasks such as user registration and password retrieval.
 


### PR DESCRIPTION
I'm surprised the docs still somehow stick to Symfony 2, since it is supposed to support Symfony 3 (and 4 ?).

The change is tiny but probably useful for newcomers