### PR TITLE
Add require translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
         "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0",
         "symfony/templating": "^2.8 || ^3.0 || ^4.0",
+        "symfony/translation": "^2.8 || ^3.0 || ^4.0",
         "symfony/twig-bundle": "^2.8 || ^3.0 || ^4.0",
         "symfony/validator": "^2.8 || ^3.0 || ^4.0",
         "twig/twig": "^1.28 || ^2.0"


### PR DESCRIPTION
Because class FOS\UserBundle\EventListener\FlashListener used TranslatorInterface in constructor so we should add Translation as a required package.