### PR TITLE
Remove fieldName attribute in MongoDB mapping

### DIFF
--- a/Resources/config/doctrine-mapping/Group.mongodb.xml
+++ b/Resources/config/doctrine-mapping/Group.mongodb.xml
@@ -6,9 +6,9 @@
 
     <mapped-superclass name="FOS\UserBundle\Model\Group" collection="fos_user_group">
 
-        <field name="name" fieldName="name" type="string" />
+        <field name="name" type="string" />
 
-        <field name="roles" fieldName="roles" type="collection" />
+        <field name="roles" type="collection" />
 
         <indexes>
             <index>

--- a/Resources/config/doctrine-mapping/User.mongodb.xml
+++ b/Resources/config/doctrine-mapping/User.mongodb.xml
@@ -6,27 +6,27 @@
 
     <mapped-superclass name="FOS\UserBundle\Model\User" collection="fos_user_user">
 
-        <field name="username" fieldName="username" type="string" />
+        <field name="username" type="string" />
 
-        <field name="usernameCanonical" fieldName="usernameCanonical" type="string" />
+        <field name="usernameCanonical" type="string" />
 
-        <field name="email" fieldName="email" type="string" />
+        <field name="email" type="string" />
 
-        <field name="emailCanonical" fieldName="emailCanonical" type="string" />
+        <field name="emailCanonical" type="string" />
 
-        <field name="enabled" fieldName="enabled" type="boolean" />
+        <field name="enabled" type="boolean" />
 
-        <field name="salt" fieldName="salt" type="string" />
+        <field name="salt" type="string" />
 
-        <field name="password" fieldName="password" type="string" />
+        <field name="password" type="string" />
 
-        <field name="lastLogin" fieldName="lastLogin" type="date" />
+        <field name="lastLogin" type="date" />
 
-        <field name="confirmationToken" fieldName="confirmationToken" type="string" />
+        <field name="confirmationToken" type="string" />
 
-        <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="date" />
+        <field name="passwordRequestedAt" type="date" />
 
-        <field name="roles" fieldName="roles" type="collection" />
+        <field name="roles" type="collection" />
 
         <indexes>
             <index>


### PR DESCRIPTION
Since MongoDB ODM 2.0, `fieldName` attribute in XML mapping has been replaced by `field-name`:
https://github.com/doctrine/mongodb-odm/commit/9ece37380272e1e517577b659dafcaf69d506cc3
In order to be able to use both 2.0 and <2.0 versions, I have removed the `fieldName` attribute.
It was not useful anyway since the field name is equal to the name by default.
cc @alcaeus