### PR TITLE
Fix updateUser from Interface

### DIFF
--- a/Model/UserManagerInterface.php
+++ b/Model/UserManagerInterface.php
@@ -110,8 +110,9 @@ interface UserManagerInterface
      * Updates a user.
      *
      * @param UserInterface $user
+     * @param bool          $andFlush
      */
-    public function updateUser(UserInterface $user);
+    public function updateUser(UserInterface $user, $andFlush = true);
 
     /**
      * Updates the canonical username and email fields for a user.


### PR DESCRIPTION
The **updateUser** statement in _Doctrine/UserManager.php_ is not compatible with the _UserManagerInterface.php_ interface.

From [UserManagerInterface.php](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Model/UserManagerInterface.php#L114) :
`public function updateUser(UserInterface $user);`

From [Doctrine/UserManager.php](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Doctrine/UserManager.php#L98) :
`public function updateUser(UserInterface $user, $andFlush = true)`

