### PR TITLE
Allow to use symfony/mailer and make the mailer service optionnal

### DIFF
--- a/DependencyInjection/Compiler/CheckForMailerPass.php
+++ b/DependencyInjection/Compiler/CheckForMailerPass.php
@@ -19,6 +19,8 @@ use Symfony\Flex\Recipe;
  * Checks to see if the mailer service exists.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
+ *
+ * @deprecated since 2.1, "mailer" service should be optional
  */
 class CheckForMailerPass implements CompilerPassInterface
 {

--- a/FOSUserBundle.php
+++ b/FOSUserBundle.php
@@ -14,7 +14,6 @@ namespace FOS\UserBundle;
 use Doctrine\Bundle\CouchDBBundle\DependencyInjection\Compiler\DoctrineCouchDBMappingsPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
-use FOS\UserBundle\DependencyInjection\Compiler\CheckForMailerPass;
 use FOS\UserBundle\DependencyInjection\Compiler\CheckForSessionPass;
 use FOS\UserBundle\DependencyInjection\Compiler\InjectRememberMeServicesPass;
 use FOS\UserBundle\DependencyInjection\Compiler\InjectUserCheckerPass;
@@ -38,7 +37,6 @@ class FOSUserBundle extends Bundle
         $container->addCompilerPass(new InjectUserCheckerPass());
         $container->addCompilerPass(new InjectRememberMeServicesPass());
         $container->addCompilerPass(new CheckForSessionPass());
-        $container->addCompilerPass(new CheckForMailerPass());
 
         $this->addRegisterMappingsPass($container);
     }

--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -12,6 +12,7 @@
 namespace FOS\UserBundle\Mailer;
 
 use FOS\UserBundle\Model\UserInterface;
+use Swift_Mailer;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -98,7 +99,7 @@ class Mailer implements MailerInterface
             );
         }
 
-        if (!in_array(get_class($this->mailer), ['Symfony\Component\Mailer\MailerInterface', '\Swift_Message'], true)) {
+        if (!in_array(get_class($this->mailer), ['Symfony\Component\Mailer\MailerInterface', 'Swift_Mailer'], true)) {
             throw new \RuntimeException(
                 'Sending email requires either symfony/mailer or symfony/swiftmailer-bundle'.
                 'Run "composer require symfony/mailer" or "composer require symfony/swiftmailer-bundle"'
@@ -118,7 +119,7 @@ class Mailer implements MailerInterface
                 ->html($body);
         }
 
-        if (class_exists('\Swift_Message')) {
+        if (class_exists('Swift_Mailer')) {
             $message = (new \Swift_Message())
                 ->setSubject($subject)
                 ->setFrom($fromEmail)

--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -11,34 +11,15 @@
 
 namespace FOS\UserBundle\Mailer;
 
-use FOS\UserBundle\Model\UserInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @deprecated TwigSwiftMailer class is deprecated since 2.1, use TwigMailer instead.
  */
-class TwigSwiftMailer implements MailerInterface
+class TwigSwiftMailer extends TwigMailer
 {
-    /**
-     * @var \Swift_Mailer
-     */
-    protected $mailer;
-
-    /**
-     * @var UrlGeneratorInterface
-     */
-    protected $router;
-
-    /**
-     * @var \Twig_Environment
-     */
-    protected $twig;
-
-    /**
-     * @var array
-     */
-    protected $parameters;
-
     /**
      * TwigSwiftMailer constructor.
      *
@@ -49,74 +30,10 @@ class TwigSwiftMailer implements MailerInterface
      */
     public function __construct(\Swift_Mailer $mailer, UrlGeneratorInterface $router, \Twig_Environment $twig, array $parameters)
     {
-        $this->mailer = $mailer;
-        $this->router = $router;
-        $this->twig = $twig;
-        $this->parameters = $parameters;
-    }
+        @trigger_error(sprintf(
+            '%s is deprecated, use %s instead.', __CLASS__, TwigMailer::class
+        ), E_USER_DEPRECATED);
 
-    /**
-     * {@inheritdoc}
-     */
-    public function sendConfirmationEmailMessage(UserInterface $user)
-    {
-        $template = $this->parameters['template']['confirmation'];
-        $url = $this->router->generate('fos_user_registration_confirm', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
-
-        $context = array(
-            'user' => $user,
-            'confirmationUrl' => $url,
-        );
-
-        $this->sendMessage($template, $context, $this->parameters['from_email']['confirmation'], (string) $user->getEmail());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function sendResettingEmailMessage(UserInterface $user)
-    {
-        $template = $this->parameters['template']['resetting'];
-        $url = $this->router->generate('fos_user_resetting_reset', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
-
-        $context = array(
-            'user' => $user,
-            'confirmationUrl' => $url,
-        );
-
-        $this->sendMessage($template, $context, $this->parameters['from_email']['resetting'], (string) $user->getEmail());
-    }
-
-    /**
-     * @param string $templateName
-     * @param array  $context
-     * @param array  $fromEmail
-     * @param string $toEmail
-     */
-    protected function sendMessage($templateName, $context, $fromEmail, $toEmail)
-    {
-        $template = $this->twig->load($templateName);
-        $subject = $template->renderBlock('subject', $context);
-        $textBody = $template->renderBlock('body_text', $context);
-
-        $htmlBody = '';
-
-        if ($template->hasBlock('body_html', $context)) {
-            $htmlBody = $template->renderBlock('body_html', $context);
-        }
-
-        $message = (new \Swift_Message())
-            ->setSubject($subject)
-            ->setFrom($fromEmail)
-            ->setTo($toEmail);
-
-        if (!empty($htmlBody)) {
-            $message->setBody($htmlBody, 'text/html')
-                ->addPart($textBody, 'text/plain');
-        } else {
-            $message->setBody($textBody);
-        }
-
-        $this->mailer->send($message);
+        parent::__construct($mailer, $router, $twig, $parameters);
     }
 }

--- a/Resources/config/mailer.xml
+++ b/Resources/config/mailer.xml
@@ -17,7 +17,7 @@
 
     <services>
         <service id="fos_user.mailer.default" class="FOS\UserBundle\Mailer\Mailer" public="false">
-            <argument type="service" id="mailer" />
+            <argument type="service" id="mailer" on-invalid="null" />
             <argument type="service" id="router" />
             <argument type="service" id="templating" />
             <argument type="collection">
@@ -31,8 +31,8 @@
             <tag name="fos_user.requires_swift" />
         </service>
 
-        <service id="fos_user.mailer.twig_swift" class="FOS\UserBundle\Mailer\TwigSwiftMailer" public="false">
-            <argument type="service" id="mailer" />
+        <service id="fos_user.mailer.twig_swift" class="FOS\UserBundle\Mailer\TwigMailer" public="false">
+            <argument type="service" id="mailer" on-invalid="null" />
             <argument type="service" id="router" />
             <argument type="service" id="twig" />
             <argument type="collection">

--- a/Tests/Mailer/TwigMailerTest.php
+++ b/Tests/Mailer/TwigMailerTest.php
@@ -11,19 +11,19 @@
 
 namespace FOS\UserBundle\Tests\Mailer;
 
-use FOS\UserBundle\Mailer\TwigSwiftMailer;
+use FOS\UserBundle\Mailer\TwigMailer;
 use PHPUnit\Framework\TestCase;
 use Swift_Mailer;
 use Swift_Transport_NullTransport;
 
-class TwigSwiftMailerTest extends TestCase
+class TwigMailerTest extends TestCase
 {
     /**
      * @dataProvider goodEmailProvider
      */
     public function testSendConfirmationEmailMessageWithGoodEmails($emailAddress)
     {
-        $mailer = $this->getTwigSwiftMailer();
+        $mailer = $this->getTwigMailer();
         $mailer->sendConfirmationEmailMessage($this->getUser($emailAddress));
 
         $this->assertTrue(true);
@@ -35,7 +35,7 @@ class TwigSwiftMailerTest extends TestCase
      */
     public function testSendConfirmationEmailMessageWithBadEmails($emailAddress)
     {
-        $mailer = $this->getTwigSwiftMailer();
+        $mailer = $this->getTwigMailer();
         $mailer->sendConfirmationEmailMessage($this->getUser($emailAddress));
     }
 
@@ -44,7 +44,7 @@ class TwigSwiftMailerTest extends TestCase
      */
     public function testSendResettingEmailMessageWithGoodEmails($emailAddress)
     {
-        $mailer = $this->getTwigSwiftMailer();
+        $mailer = $this->getTwigMailer();
         $mailer->sendResettingEmailMessage($this->getUser($emailAddress));
 
         $this->assertTrue(true);
@@ -56,7 +56,7 @@ class TwigSwiftMailerTest extends TestCase
      */
     public function testSendResettingEmailMessageWithBadEmails($emailAddress)
     {
-        $mailer = $this->getTwigSwiftMailer();
+        $mailer = $this->getTwigMailer();
         $mailer->sendResettingEmailMessage($this->getUser($emailAddress));
     }
 
@@ -78,9 +78,9 @@ class TwigSwiftMailerTest extends TestCase
         );
     }
 
-    private function getTwigSwiftMailer()
+    private function getTwigMailer()
     {
-        return new TwigSwiftMailer(
+        return new TwigMailer(
             new Swift_Mailer(
                 new Swift_Transport_NullTransport(
                     $this->getMockBuilder('Swift_Events_EventDispatcher')->getMock()

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "friendsofphp/php-cs-fixer": "^2.2",
         "phpunit/phpunit": "^4.8.35 || ^5.7.11 || ^6.5",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
+        "symfony/mailer": "^4.3",
         "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "symfony/phpunit-bridge": "^2.8 || ^3.0 || ^4.0",
         "symfony/yaml": "^2.8 || ^3.0 || ^4.0"

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,10 @@
         "symfony/phpunit-bridge": "^2.8 || ^3.0 || ^4.0",
         "symfony/yaml": "^2.8 || ^3.0 || ^4.0"
     },
+    "suggest": {
+        "symfony/swiftmailer-bundle": "*",
+        "symfony/mailer": "*"
+    },
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
Following [this PR](https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2801) I cherry picked the commit making the `mailer` service optional and then I made possible to work with `symfony/mailer`

Right now, If you only have `symfony/mailer` on your` >=4.3` project, **you can't use FOSUserBundle** because 
```
Argument 1 passed to FOS\UserBundle\Mailer\TwigSwiftMailer::__construct() must be an instance of Swift_Mailer, instance of Symfony\Component\Mailer\Mailer given
```

Also, having both `symfony/mailer` and `symfony/swiftmailer-bundle` is not possible.

*EDIT*: In Symfony 4.3.1, they renamed the service id from `mailer` to `mailer.mailer` for the `MailerInterface`