### PR TITLE
Do not create a salt for self-salting password encoders

### DIFF
--- a/Util/PasswordUpdater.php
+++ b/Util/PasswordUpdater.php
@@ -14,6 +14,7 @@ namespace FOS\UserBundle\Util;
 use FOS\UserBundle\Model\UserInterface;
 use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Encoder\SelfSaltingEncoderInterface;
 
 /**
  * Class updating the hashed password in the user when there is a new password.
@@ -39,7 +40,7 @@ class PasswordUpdater implements PasswordUpdaterInterface
 
         $encoder = $this->encoderFactory->getEncoder($user);
 
-        if ($encoder instanceof BCryptPasswordEncoder) {
+        if ($encoder instanceof BCryptPasswordEncoder || $encoder instanceof SelfSaltingEncoderInterface) {
             $user->setSalt(null);
         } else {
             $salt = rtrim(str_replace('+', '.', base64_encode(random_bytes(32))), '=');


### PR DESCRIPTION
Symfony marks `PasswordEncoderInterface` implementations that generate the salt themselves with `SelfSaltingEncoderInterface` since version 3.4. We can use this in `PasswordUpdater` to skip the salt generation for those encoders, the same way we skip it for `BCryptPasswordEncoder`.

Without this PR, useless salts will be stored in the user table if one uses a modern encoder such as `SodiumPasswordEncoder`.