### PR TITLE
Fix PHPDoc GroupInterface::getId

### DIFF
--- a/Model/GroupInterface.php
+++ b/Model/GroupInterface.php
@@ -25,7 +25,7 @@ interface GroupInterface
     public function addRole($role);
 
     /**
-     * @return int
+     * @return mixed
      */
     public function getId();
 


### PR DESCRIPTION
Using an ODM the object identifier could be a string, a hash, UUID, Mongo ObjectID...

Check UserInterface::getId