### PR TITLE
Updating user_checker service name

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -274,7 +274,7 @@ in your application:
         firewalls:
             main:
                 pattern: ^/
-                user_checker: fos_user.user_checker
+                user_checker: security.user_checker
                 form_login:
                     provider: fos_userbundle
                     csrf_token_generator: security.csrf.token_manager


### PR DESCRIPTION
Changing service name used inside `security.yaml` according to https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2855