### PR TITLE
Added invalid_username to 'es' translation

### DIFF
--- a/Resources/translations/FOSUserBundle.es.yml
+++ b/Resources/translations/FOSUserBundle.es.yml
@@ -54,6 +54,7 @@ resetting:
         Si no recibes un correo electrónico, comprueba tu carpeta de correo no deseado o inténtalo de nuevo.
 
     request:
+        invalid_username: El usuario o correo electrónico "%username%" no existe.
         username: 'Nombre de usuario o correo electrónico'
         submit: 'Restablecer contraseña'
     reset:


### PR DESCRIPTION
The translation exists in the gl translation file and it's used at least in sonata user bundle.