### PR TITLE
removed left-over from deleted docs

### DIFF
--- a/Resources/doc/configuration_reference.rst
+++ b/Resources/doc/configuration_reference.rst
@@ -21,7 +21,7 @@ All available configuration options are listed below with their default values.
             form:
                 type:               FOS\UserBundle\Form\Type\ProfileFormType
                 name:               fos_user_profile_form
-                validation_groups:  [Profile, Default]openssl_get_cipher_methods will be used. See http://php.net/manual/function.openssl-get-cipher-methods.php
+                validation_groups:  [Profile, Default]
         change_password:
             form:
                 type:               FOS\UserBundle\Form\Type\ChangePasswordFormType


### PR DESCRIPTION
In [this commit](https://github.com/FriendsOfSymfony/FOSUserBundle/commit/8bb87890cbd872c870f7bd146922906f6e8ddf5c#diff-916c4e668fd1e1cfda4031b70606f5b1) a bit of docu was left, which doesn't belong there