### PR TITLE
Changed suggested example encoder from bcrypt to auto

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -261,7 +261,7 @@ in your application:
     # app/config/security.yml
     security:
         encoders:
-            FOS\UserBundle\Model\UserInterface: bcrypt
+            FOS\UserBundle\Model\UserInterface: auto
 
         role_hierarchy:
             ROLE_ADMIN:       ROLE_USER


### PR DESCRIPTION
In Symfony 4.4.2 and PHP 7.4.1 causes error 500 similar to this:
https://github.com/Sylius/Sylius/issues/10887