### PR TITLE
Revert "Bump the default minimal password length to 8 characters"

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -63,7 +63,7 @@
                 </option>
             </constraint>
             <constraint name="Length">
-                <option name="min">8</option>
+                <option name="min">2</option>
                 <option name="max">4096</option>
                 <option name="minMessage">fos_user.password.short</option>
                 <option name="groups">


### PR DESCRIPTION
This reverts commit 4281aa6be162e21ee2c3b083731a549b453face1.