### PR TITLE
Make 2.x tests green again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 env:
   global:
     - TARGET=test
+    - SYMFONY_DEPRECATIONS_HELPER=weak
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
@stof The remaining depredations cannot be resolved without introducing BC breaks. We can leave it as it is for 2.x and fix the depredations in 3.0 (already done in https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2947).