### PR TITLE
Revert UserManagerInterface::updateUser() BC break

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,6 @@ Changelog
 * User model will not rely on `AdvancedUserInterface` anymore.
 * Self-salting password encoders will not create a salt anymore.
 * FlashListener constructor now accepts `SessionInterface`.
-* Fixed `UserManagerInterface::updateUser` signature.
 * Fixed several Symfony deprecation notices.
 * Fixed several translations.
 

--- a/Model/UserManagerInterface.php
+++ b/Model/UserManagerInterface.php
@@ -102,10 +102,8 @@ interface UserManagerInterface
 
     /**
      * Updates a user.
-     *
-     * @param bool $andFlush
      */
-    public function updateUser(UserInterface $user, $andFlush = true);
+    public function updateUser(UserInterface $user);
 
     /**
      * Updates the canonical username and email fields for a user.


### PR DESCRIPTION
Reverts #2896
Fixes https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2896#issuecomment-551848296