### PR TITLE
Fix the deprecation of usage Twig without namespaces

### DIFF
--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -13,6 +13,7 @@ namespace FOS\UserBundle\Mailer;
 
 use FOS\UserBundle\Model\UserInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
 
 /**
  * @author Christophe Coevoet <stof@notk.org>
@@ -30,7 +31,7 @@ class TwigSwiftMailer implements MailerInterface
     protected $router;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     protected $twig;
 
@@ -42,7 +43,7 @@ class TwigSwiftMailer implements MailerInterface
     /**
      * TwigSwiftMailer constructor.
      */
-    public function __construct(\Swift_Mailer $mailer, UrlGeneratorInterface $router, \Twig_Environment $twig, array $parameters)
+    public function __construct(\Swift_Mailer $mailer, UrlGeneratorInterface $router, Environment $twig, array $parameters)
     {
         $this->mailer = $mailer;
         $this->router = $router;

--- a/Tests/Mailer/TwigSwiftMailerTest.php
+++ b/Tests/Mailer/TwigSwiftMailerTest.php
@@ -15,6 +15,8 @@ use FOS\UserBundle\Mailer\TwigSwiftMailer;
 use PHPUnit\Framework\TestCase;
 use Swift_Mailer;
 use Swift_Transport_NullTransport;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class TwigSwiftMailerTest extends TestCase
 {
@@ -103,7 +105,7 @@ class TwigSwiftMailerTest extends TestCase
 
     private function getTwigEnvironment()
     {
-        return new \Twig_Environment(new \Twig_Loader_Array(['foo' => <<<'TWIG'
+        return new Environment(new ArrayLoader(['foo' => <<<'TWIG'
 {% block subject 'foo' %}
 
 {% block body_text %}Test{% endblock %}


### PR DESCRIPTION
Fix deprecation errors:

```
Using the "Twig_Environment" class is deprecated since Twig version 2.7, use "Twig\Environment" instead.
```

```
Using the "Twig_Loader_Array" class is deprecated since Twig version 2.7, use "Twig\Loader\ArrayLoader" instead.
```