### PR TITLE
Fix the deprecation of usage Templating

### DIFF
--- a/Tests/Mailer/MailerTest.php
+++ b/Tests/Mailer/MailerTest.php
@@ -15,9 +15,18 @@ use FOS\UserBundle\Mailer\Mailer;
 use PHPUnit\Framework\TestCase;
 use Swift_Mailer;
 use Swift_Transport_NullTransport;
+use Symfony\Component\Templating\EngineInterface;
 
 class MailerTest extends TestCase
 {
+    protected function setUp()
+    {
+        // skip test for Symfony > 5
+        if (!interface_exists(EngineInterface::class)) {
+            $this->markTestSkipped(sprintf('%s class not exists', EngineInterface::class));
+        }
+    }
+
     /**
      * @dataProvider goodEmailProvider
      */


### PR DESCRIPTION
Fix deprecation error:
```
The Symfony\Bundle\FrameworkBundle\Templating\EngineInterface interface is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.
```