### PR TITLE
fixed bugs with fetching entities

### DIFF
--- a/Doctrine/UserListener.php
+++ b/Doctrine/UserListener.php
@@ -26,13 +26,11 @@ use FOS\UserBundle\Util\PasswordUpdaterInterface;
  * @author Christophe Coevoet <stof@notk.org>
  * @author David Buchmann <mail@davidbu.ch>
  */
-class UserListener implements EventSubscriber
-{
+class UserListener implements EventSubscriber {
     private $passwordUpdater;
     private $canonicalFieldsUpdater;
 
-    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater)
-    {
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater) {
         $this->passwordUpdater = $passwordUpdater;
         $this->canonicalFieldsUpdater = $canonicalFieldsUpdater;
     }
@@ -40,8 +38,7 @@ class UserListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function getSubscribedEvents()
-    {
+    public function getSubscribedEvents() {
         return [
             'prePersist',
             'preUpdate',
@@ -51,8 +48,7 @@ class UserListener implements EventSubscriber
     /**
      * Pre persist listener based on doctrine common.
      */
-    public function prePersist(LifecycleEventArgs $args)
-    {
+    public function prePersist(\Doctrine\ORM\Event\LifecycleEventArgs $args) {
         $object = $args->getObject();
         if ($object instanceof UserInterface) {
             $this->updateUserFields($object);
@@ -62,8 +58,7 @@ class UserListener implements EventSubscriber
     /**
      * Pre update listener based on doctrine common.
      */
-    public function preUpdate(LifecycleEventArgs $args)
-    {
+    public function preUpdate(\Doctrine\ORM\Event\LifecycleEventArgs $args) {
         $object = $args->getObject();
         if ($object instanceof UserInterface) {
             $this->updateUserFields($object);
@@ -71,11 +66,10 @@ class UserListener implements EventSubscriber
         }
     }
 
-    /**
+    /**`
      * Updates the user properties.
      */
-    private function updateUserFields(UserInterface $user)
-    {
+    private function updateUserFields(UserInterface $user) {
         $this->canonicalFieldsUpdater->updateCanonicalFields($user);
         $this->passwordUpdater->hashPassword($user);
     }
@@ -83,8 +77,7 @@ class UserListener implements EventSubscriber
     /**
      * Recomputes change set for Doctrine implementations not doing it automatically after the event.
      */
-    private function recomputeChangeSet(ObjectManager $om, UserInterface $user)
-    {
+    private function recomputeChangeSet(EntityManager $om, UserInterface $user) {
         $meta = $om->getClassMetadata(get_class($user));
 
         if ($om instanceof EntityManager) {

--- a/Doctrine/UserManager.php
+++ b/Doctrine/UserManager.php
@@ -11,17 +11,16 @@
 
 namespace FOS\UserBundle\Doctrine;
 
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManager;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManager as BaseUserManager;
 use FOS\UserBundle\Util\CanonicalFieldsUpdater;
 use FOS\UserBundle\Util\PasswordUpdaterInterface;
 
-class UserManager extends BaseUserManager
-{
+class UserManager extends BaseUserManager {
     /**
-     * @var ObjectManager
+     * @var EntityManager
      */
     protected $objectManager;
 
@@ -35,8 +34,7 @@ class UserManager extends BaseUserManager
      *
      * @param string $class
      */
-    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater, ObjectManager $om, $class)
-    {
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater, EntityManager $om, $class) {
         parent::__construct($passwordUpdater, $canonicalFieldsUpdater);
 
         $this->objectManager = $om;
@@ -46,8 +44,7 @@ class UserManager extends BaseUserManager
     /**
      * {@inheritdoc}
      */
-    public function deleteUser(UserInterface $user)
-    {
+    public function deleteUser(UserInterface $user) {
         $this->objectManager->remove($user);
         $this->objectManager->flush();
     }
@@ -55,8 +52,7 @@ class UserManager extends BaseUserManager
     /**
      * {@inheritdoc}
      */
-    public function getClass()
-    {
+    public function getClass() {
         if (false !== strpos($this->class, ':')) {
             $metadata = $this->objectManager->getClassMetadata($this->class);
             $this->class = $metadata->getName();
@@ -68,32 +64,28 @@ class UserManager extends BaseUserManager
     /**
      * {@inheritdoc}
      */
-    public function findUserBy(array $criteria)
-    {
+    public function findUserBy(array $criteria) {
         return $this->getRepository()->findOneBy($criteria);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function findUsers()
-    {
+    public function findUsers() {
         return $this->getRepository()->findAll();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function reloadUser(UserInterface $user)
-    {
+    public function reloadUser(UserInterface $user) {
         $this->objectManager->refresh($user);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function updateUser(UserInterface $user, $andFlush = true)
-    {
+    public function updateUser(UserInterface $user, $andFlush = true) {
         $this->updateCanonicalFields($user);
         $this->updatePassword($user);
 
@@ -106,8 +98,7 @@ class UserManager extends BaseUserManager
     /**
      * @return ObjectRepository
      */
-    protected function getRepository()
-    {
+    protected function getRepository() {
         return $this->objectManager->getRepository($this->getClass());
     }
 }


### PR DESCRIPTION
I faced some FOSUserBundle issues with entities while using Symfony 4.4. Sorry for screenshots. Unfortunately, I haven't saved exceptions' texts.

![image](https://user-images.githubusercontent.com/44964661/94278730-892ba800-ff8e-11ea-8a2c-3b3b5faed52d.png)
![image](https://user-images.githubusercontent.com/44964661/94278753-9052b600-ff8e-11ea-9177-cf8efa6d5860.png)
![image](https://user-images.githubusercontent.com/44964661/94278775-95176a00-ff8e-11ea-88a3-29c5b12574c4.png)
![image](https://user-images.githubusercontent.com/44964661/94278802-9ba5e180-ff8e-11ea-88c3-b415ecd383e9.png)

So, to fix these issues, I had to change parameters' types in providing functions, such as __construct, prePersist(), preUpdate(), recomputeChangeSet(). After these manipulations my Symfony 4.4 project was perfectly running with FOSUserBundle.
