### PR TITLE
Allow usage of php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^5.5.9 || ^7.0",
+        "php": "^5.5.9 || ^7.0 || ^8.0",
         "paragonie/random_compat": "^1 || ^2 || ^9",
         "symfony/form": "^2.8 || ^3.0 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",


### PR DESCRIPTION
As FOSUserBundle is not compatible with newer phpunit versions and currently supported versions don't support php8, I didn't add php8 into tests.

- fixes: https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2994

Maybe FOSUserBundle could drop support for older unsupported packages (php, symfony, ...)? Projects that use these old versions could still use older version of FOSUserBundle.