### PR TITLE
Remove deprecation warnings triggered when loading some interfaces

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+### 2.2.1 (2021-09-08)
+
+* Fixed a deprecation warning about groups being triggered when loading the User class of the bundle.
+
 ### 2.2.0 (2021-08-26)
 
 * Deprecated the Groups feature.

--- a/Model/GroupInterface.php
+++ b/Model/GroupInterface.php
@@ -11,13 +11,11 @@
 
 namespace FOS\UserBundle\Model;
 
-@trigger_error('Using Groups is deprecated since version 2.2 and will be removed in 3.0.', E_USER_DEPRECATED);
-
 /**
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Christophe Coevoet <stof@notk.org>
  *
- * @deprecated
+ * @deprecated Using Groups is deprecated since version 2.2 and will be removed in 3.0.
  */
 interface GroupInterface
 {

--- a/Model/GroupableInterface.php
+++ b/Model/GroupableInterface.php
@@ -11,14 +11,12 @@
 
 namespace FOS\UserBundle\Model;
 
-@trigger_error('Using Groups is deprecated since version 2.2 and will be removed in 3.0.', E_USER_DEPRECATED);
-
 /**
  * @author Thibault Duplessis <thibault.duplessis@gmail.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Christophe Coevoet <stof@notk.org>
  *
- * @deprecated
+ * @deprecated Using Groups is deprecated since version 2.2 and will be removed in 3.0.
  */
 interface GroupableInterface
 {


### PR DESCRIPTION
Those interfaces gets loaded when loading the User class, so they should not trigger a deprecation warning all the time. The deprecation warning will be triggered by the DebugClassLoader when implementing them in a different package.