### PR TITLE
Fix a deprecation about groups being triggered when loading ORM metadata

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+### 2.2.2 (2021-09-08)
+
+* Fixed a deprecation warning about groups being triggered when loading all Doctrine metadata.
+
 ### 2.2.1 (2021-09-08)
 
 * Fixed a deprecation warning about groups being triggered when loading the User class of the bundle.

--- a/Model/Group.php
+++ b/Model/Group.php
@@ -11,12 +11,10 @@
 
 namespace FOS\UserBundle\Model;
 
-@trigger_error('Using Groups is deprecated since version 2.2 and will be removed in 3.0.', E_USER_DEPRECATED);
-
 /**
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  *
- * @deprecated
+ * @deprecated Using Groups is deprecated since version 2.2 and will be removed in 3.0.
  */
 abstract class Group implements GroupInterface
 {


### PR DESCRIPTION
When using the `getAllMetadata` API of the Doctrine ORM, it will load the abstract Group class due to being a MappedSuperClass in the mapping. This was triggering the deprecation warning about using groups, even though they were not actually used.
Given that this class is abstract, the only way to actually use it involves extending it, which gets a deprecation warning triggered by the DebugClassLoader.