### PR TITLE
Replace usages of old namespace `Doctrine\Common\Persistence\` with `Doctrine\Persistence\` ("doctrine/persistence" >= 1.3)

### DIFF
--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -13,7 +13,7 @@
         </service>
 
         <!-- The factory is configured in the DI extension class to support more Symfony versions -->
-        <service id="fos_user.object_manager" class="Doctrine\Common\Persistence\ObjectManager" public="false">
+        <service id="fos_user.object_manager" class="Doctrine\Persistence\ObjectManager" public="false">
             <argument>%fos_user.model_manager_name%</argument>
         </service>
 

--- a/Tests/Doctrine/UserManagerTest.php
+++ b/Tests/Doctrine/UserManagerTest.php
@@ -11,6 +11,9 @@
 
 namespace FOS\UserBundle\Tests\Doctrine;
 
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use FOS\UserBundle\Doctrine\UserManager;
 use FOS\UserBundle\Model\User;
 use PHPUnit\Framework\TestCase;
@@ -28,17 +31,17 @@ class UserManagerTest extends TestCase
 
     public function setUp()
     {
-        if (!interface_exists('Doctrine\Common\Persistence\ObjectManager')) {
-            $this->markTestSkipped('Doctrine Common has to be installed for this test to run.');
+        if (!interface_exists(ObjectManager::class)) {
+            $this->markTestSkipped('"doctrine/persistence" ^1.3 has to be installed for this test to run.');
         }
 
         $passwordUpdater = $this->getMockBuilder('FOS\UserBundle\Util\PasswordUpdaterInterface')->getMock();
         $fieldsUpdater = $this->getMockBuilder('FOS\UserBundle\Util\CanonicalFieldsUpdater')
             ->disableOriginalConstructor()
             ->getMock();
-        $class = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadata')->getMock();
-        $this->om = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
-        $this->repository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')->getMock();
+        $class = $this->getMockBuilder(ClassMetadata::class)->getMock();
+        $this->om = $this->getMockBuilder(ObjectManager::class)->getMock();
+        $this->repository = $this->getMockBuilder(ObjectRepository::class)->getMock();
 
         $this->om->expects($this->any())
             ->method('getRepository')


### PR DESCRIPTION
This change is required in order to fix the class used in the `fos_user.object_manager` definition.
```
bin/console lint:container --no-debug
```
```
In CheckTypeDeclarationsPass.php line 314:
                                                                               
  Invalid definition for service "fos_user.user_manager": argument 3 of "FOS\  
  UserBundle\Doctrine\UserManager::__construct()" accepts "Doctrine\Persisten  
  ce\ObjectManager", "Doctrine\Common\Persistence\ObjectManager" passed.  
```

Availability of "doctrine/persistence" >= 1.3 is already guaranteed:
https://github.com/FriendsOfSymfony/FOSUserBundle/blob/813161b132b28806d67e355e39a1a4680bb9e308/composer.json#L41

See #3000.