### PR TITLE
Add missing deprecations on group-related event classes

### DIFF
--- a/Event/FilterGroupResponseEvent.php
+++ b/Event/FilterGroupResponseEvent.php
@@ -11,12 +11,16 @@
 
 namespace FOS\UserBundle\Event;
 
+@trigger_error('Using Groups is deprecated since version 2.2 and will be removed in 3.0.', E_USER_DEPRECATED);
+
 use FOS\UserBundle\Model\GroupInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @final
+ *
+ * @deprecated
  */
 class FilterGroupResponseEvent extends GroupEvent
 {

--- a/Event/GetResponseGroupEvent.php
+++ b/Event/GetResponseGroupEvent.php
@@ -11,10 +11,14 @@
 
 namespace FOS\UserBundle\Event;
 
+@trigger_error('Using Groups is deprecated since version 2.2 and will be removed in 3.0.', E_USER_DEPRECATED);
+
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @final
+ *
+ * @deprecated
  */
 class GetResponseGroupEvent extends GroupEvent
 {


### PR DESCRIPTION
GroupEvent was marked as deprecated, but not its child classes.