### PR TITLE
Fix deprecation warning for UserInterface on Symfony 4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+### 2.2.4 (2022-01-14)
+
+* Fixed a deprecated warning reported by DebugClassLoader in the AdvancedUserInterface BC layer due to the change done in 2.2.3.
+
 ### 2.2.3 (2022-01-14)
 
 * Added missing deprecations on some group-related event classes

--- a/Model/UserInterface.php
+++ b/Model/UserInterface.php
@@ -14,10 +14,31 @@ namespace FOS\UserBundle\Model;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 
+// This is required to support apps that explicitly check if a user is an instance of AdvancedUserInterface
+if (interface_exists('\Symfony\Component\Security\Core\User\AdvancedUserInterface')) {
+    /**
+     * @internal Only for back compatibility. Remove / merge when dropping support for Symfony 4
+     *
+     * @deprecated
+     */
+    interface CompatUserInterface extends \Symfony\Component\Security\Core\User\AdvancedUserInterface
+    {
+    }
+} else {
+    /**
+     * @internal Only for back compatibility. Remove / merge when dropping support for Symfony 4
+     */
+    interface CompatUserInterface extends BaseUserInterface, EquatableInterface
+    {
+    }
+}
+
 /**
- * @internal Only for back compatibility. Remove / merge when dropping support for Symfony 4
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Julian Finkler <julian@developer-heaven.de>
  */
-interface FosUserInterface extends \Serializable
+interface UserInterface extends CompatUserInterface, \Serializable
 {
     public const ROLE_DEFAULT = 'ROLE_USER';
 
@@ -269,24 +290,4 @@ interface FosUserInterface extends \Serializable
      * @see DisabledException
      */
     public function isEnabled();
-}
-
-// This is required to support apps that explicitly check if a user is an instance of AdvancedUserInterface
-if (interface_exists('\Symfony\Component\Security\Core\User\AdvancedUserInterface')) {
-    /**
-     * @author Thibault Duplessis <thibault.duplessis@gmail.com>
-     * @author Johannes M. Schmitt <schmittjoh@gmail.com>
-     */
-    interface UserInterface extends FosUserInterface, \Symfony\Component\Security\Core\User\AdvancedUserInterface
-    {
-    }
-} else {
-    /**
-     * @author Thibault Duplessis <thibault.duplessis@gmail.com>
-     * @author Johannes M. Schmitt <schmittjoh@gmail.com>
-     * @author Julian Finkler <julian@developer-heaven.de>
-     */
-    interface UserInterface extends FosUserInterface, BaseUserInterface, EquatableInterface
-    {
-    }
 }


### PR DESCRIPTION
The deprecated annotation removed in 2.2.3 had a purpose: deprecated interfaces are allowed to extend deprecated interfaces of another package without triggering a warning in DebugClassLoader. However, applying it on the public UserInterface was the mistake. Instead of having an internal interface that is extended by the conditional declaration of the public interface, the implementation is now reversed. An internal CompatUserInterface is now declared conditionally to handle the BC layer, and the public UserInterface extends it.
As our UserInterface and the CompatUserInterface are in the same package, UserInterface is allowed to extend CompatUserInterface without warning even when it is marked as deprecated, making both DebugClassLoader and downstream static analyzers happy.