### PR TITLE
Fix the variance rules for events

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Changelog
 * [BC break] Change the base class for events to `Symfony\Contracts\EventDispatcher\Event` instead of `Symfony\Component\EventDispatcher\Event`
 * [BC break] Remove the `Symfony\Component\Security\Core\User\AdvancedUserInterface` methods from our `UserInterface`
 * [BC break] Made `\FOS\UserBundle\Model\User::serialize` and `\FOS\UserBundle\Model\User::unserialize` final. Child classes needing to extend the serialization must override `__serialize` and `__unserialize` instead.
+* [BC break] `\FOS\UserBundle\Event\GetResponseNullableUserEvent` no longer inherits from `\FOS\UserBundle\Event\GetResponseUserEvent` and `\FOS\UserBundle\Event\UserEvent` as that was breaking variance rules.
 * Add support for Symfony 5.
 
 ### 2.2.3 (2022-01-14)

--- a/Event/GetResponseNullableUserEvent.php
+++ b/Event/GetResponseNullableUserEvent.php
@@ -12,18 +12,32 @@
 namespace FOS\UserBundle\Event;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Response user event that allows null user.
  *
  * @author Konstantinos Christofilos <kostas.christofilos@gmail.com>
  */
-class GetResponseNullableUserEvent extends GetResponseUserEvent
+class GetResponseNullableUserEvent extends Event
 {
     /**
-     * GetResponseNullableUserEvent constructor.
+     * @var Request
      */
+    private $request;
+
+    /**
+     * @var UserInterface|null
+     */
+    private $user;
+
+    /**
+     * @var Response|null
+     */
+    private $response;
+
     public function __construct(UserInterface $user = null, Request $request)
     {
         $this->user = $user;
@@ -36,5 +50,26 @@ class GetResponseNullableUserEvent extends GetResponseUserEvent
     public function getUser()
     {
         return $this->user;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
     }
 }

--- a/Event/GetResponseUserEvent.php
+++ b/Event/GetResponseUserEvent.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 class GetResponseUserEvent extends UserEvent
 {
     /**
-     * @var Response
+     * @var Response|null
      */
     private $response;
 

--- a/Event/UserEvent.php
+++ b/Event/UserEvent.php
@@ -45,7 +45,7 @@ class UserEvent extends Event
     }
 
     /**
-     * @return Request
+     * @return Request|null
      */
     public function getRequest()
     {


### PR DESCRIPTION
Making a child class return a nullable user breaks the variance rules.
So this separate the event instead of using inheritance.