### PR TITLE
Remove the creation of an alias for the session service

### DIFF
--- a/DependencyInjection/Compiler/CheckForSessionPass.php
+++ b/DependencyInjection/Compiler/CheckForSessionPass.php
@@ -30,7 +30,7 @@ class CheckForSessionPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->has('fos_user.session') && !$container->has('session.storage.factory') && !$container->has('session')) {
+        if ($container->hasParameter('fos_user.session_needed') && !$container->has('session.storage.factory') && !$container->has('session')) {
             $message = 'FOSUserBundle requires the "session" to be available for the enabled features.';
 
             if (class_exists(Recipe::class)) {
@@ -39,5 +39,7 @@ class CheckForSessionPass implements CompilerPassInterface
 
             throw new \LogicException($message);
         }
+
+        $container->getParameterBag()->remove('fos_user.session_needed');
     }
 }

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -138,8 +138,7 @@ class FOSUserExtension extends Extension
         }
 
         if ($this->sessionNeeded) {
-            // Use a private alias rather than a parameter, to avoid leaking it at runtime (the private alias will be removed)
-            $container->setAlias('fos_user.session', new Alias('session', false));
+            $container->setParameter('fos_user.session_needed', true);
         }
     }
 


### PR DESCRIPTION
This was a hack to avoid leaking a parameter at runtime, but this is better solved by removing the parameter in the compiler pass.
As the session service is deprecated, this avoids referencing it in the alias.