### PR TITLE
Remove legacy BC layer

### DIFF
--- a/Util/PasswordUpdater.php
+++ b/Util/PasswordUpdater.php
@@ -12,7 +12,6 @@
 namespace FOS\UserBundle\Util;
 
 use FOS\UserBundle\Model\UserInterface;
-use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Encoder\SelfSaltingEncoderInterface;
 
@@ -40,7 +39,7 @@ class PasswordUpdater implements PasswordUpdaterInterface
 
         $encoder = $this->encoderFactory->getEncoder($user);
 
-        if ($encoder instanceof BCryptPasswordEncoder || $encoder instanceof SelfSaltingEncoderInterface) {
+        if ($encoder instanceof SelfSaltingEncoderInterface) {
             $salt = null;
         } else {
             $salt = rtrim(str_replace('+', '.', base64_encode(random_bytes(32))), '=');


### PR DESCRIPTION
The bundle requires Symfony 4.4+, so it does not need to support Symfony versions where BcryptPasswordEncoder was not implementing the SelfSaltingEncoderInterface.