### PR TITLE
Fix the wiring of controllers

### DIFF
--- a/Resources/config/change_password.xml
+++ b/Resources/config/change_password.xml
@@ -22,8 +22,9 @@
             <argument type="service" id="fos_user.change_password.form.factory" />
             <argument type="service" id="fos_user.user_manager" />
             <call method="setContainer">
-                <argument type="service" id="service_container" />
+                <argument type="service" id="Psr\Container\ContainerInterface" />
             </call>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="FOS\UserBundle\Controller\ChangePasswordController" alias="fos_user.change_password.controller" public="true" />

--- a/Resources/config/profile.xml
+++ b/Resources/config/profile.xml
@@ -23,8 +23,9 @@
             <argument type="service" id="fos_user.profile.form.factory" />
             <argument type="service" id="fos_user.user_manager" />
             <call method="setContainer">
-                <argument type="service" id="service_container" />
+                <argument type="service" id="Psr\Container\ContainerInterface" />
             </call>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="FOS\UserBundle\Controller\ProfileController" alias="fos_user.profile.controller" public="true" />

--- a/Resources/config/registration.xml
+++ b/Resources/config/registration.xml
@@ -24,8 +24,9 @@
             <argument type="service" id="fos_user.user_manager" />
             <argument type="service" id="security.token_storage" />
             <call method="setContainer">
-                <argument type="service" id="service_container" />
+                <argument type="service" id="Psr\Container\ContainerInterface" />
             </call>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="FOS\UserBundle\Controller\RegistrationController" alias="fos_user.registration.controller" public="true" />

--- a/Resources/config/resetting.xml
+++ b/Resources/config/resetting.xml
@@ -32,8 +32,9 @@
             <argument type="service" id="fos_user.mailer" />
             <argument>%fos_user.resetting.retry_ttl%</argument>
             <call method="setContainer">
-                <argument type="service" id="service_container" />
+                <argument type="service" id="Psr\Container\ContainerInterface" />
             </call>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="FOS\UserBundle\Controller\ResettingController" alias="fos_user.resetting.controller" public="true" />

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -41,8 +41,9 @@
             <argument type="service" id="security.authentication_utils" />
             <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
             <call method="setContainer">
-                <argument type="service" id="service_container" />
+                <argument type="service" id="Psr\Container\ContainerInterface" />
             </call>
+            <tag name="container.service_subscriber" />
         </service>
 
         <service id="FOS\UserBundle\Controller\SecurityController" alias="fos_user.security.controller" public="true" />


### PR DESCRIPTION
Controllers extending AbstractController must be wired as service subscribers. They should not get the main container injected in them.