### PR TITLE
Fix deprecations reported on Symfony 5.4

### DIFF
--- a/DependencyInjection/Compiler/InjectRememberMeServicesPass.php
+++ b/DependencyInjection/Compiler/InjectRememberMeServicesPass.php
@@ -34,7 +34,9 @@ class InjectRememberMeServicesPass implements CompilerPassInterface
         $firewallName = $container->getParameter('fos_user.firewall_name');
         $loginManager = $container->getDefinition('fos_user.security.login_manager');
 
-        if ($container->hasDefinition('security.authentication.rememberme.services.persistent.'.$firewallName)) {
+        if ($container->has('security.authenticator.remember_me_handler.'.$firewallName)) {
+            $loginManager->replaceArgument(4, new Reference('security.authenticator.remember_me_handler.'.$firewallName));
+        } elseif ($container->hasDefinition('security.authentication.rememberme.services.persistent.'.$firewallName)) {
             $loginManager->replaceArgument(4, new Reference('security.authentication.rememberme.services.persistent.'.$firewallName));
         } elseif ($container->hasDefinition('security.authentication.rememberme.services.simplehash.'.$firewallName)) {
             $loginManager->replaceArgument(4, new Reference('security.authentication.rememberme.services.simplehash.'.$firewallName));

--- a/Security/LoginManager.php
+++ b/Security/LoginManager.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Http\RememberMe\RememberMeHandlerInterface;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
@@ -102,6 +103,11 @@ class LoginManager implements LoginManagerInterface
      */
     protected function createToken($firewall, UserInterface $user)
     {
-        return new UsernamePasswordToken($user, null, $firewall, $user->getRoles());
+        // Bc layer for Symfony <5.4
+        if (!interface_exists(CacheableVoterInterface::class)) {
+            return new UsernamePasswordToken($user, null, $firewall, $user->getRoles());
+        }
+
+        return new UsernamePasswordToken($user, $firewall, $user->getRoles());
     }
 }

--- a/Tests/Security/EmailProviderTest.php
+++ b/Tests/Security/EmailProviderTest.php
@@ -15,6 +15,7 @@ use FOS\UserBundle\Security\EmailProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
 class EmailProviderTest extends TestCase
 {
@@ -47,7 +48,11 @@ class EmailProviderTest extends TestCase
 
     public function testLoadUserByInvalidUsername()
     {
-        $this->expectException(UsernameNotFoundException::class);
+        if (class_exists(UserNotFoundException::class)) {
+            $this->expectException(UserNotFoundException::class);
+        } else {
+            $this->expectException(UsernameNotFoundException::class);
+        }
 
         $this->userManager->expects($this->once())
             ->method('findUserByEmail')
@@ -82,7 +87,11 @@ class EmailProviderTest extends TestCase
 
     public function testRefreshDeleted()
     {
-        $this->expectException(UsernameNotFoundException::class);
+        if (class_exists(UserNotFoundException::class)) {
+            $this->expectException(UserNotFoundException::class);
+        } else {
+            $this->expectException(UsernameNotFoundException::class);
+        }
 
         $user = $this->getMockForAbstractClass('FOS\UserBundle\Model\User');
         $this->userManager->expects($this->once())

--- a/Tests/Security/EmailUserProviderTest.php
+++ b/Tests/Security/EmailUserProviderTest.php
@@ -15,6 +15,7 @@ use FOS\UserBundle\Security\EmailUserProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
 class EmailUserProviderTest extends TestCase
 {
@@ -47,7 +48,11 @@ class EmailUserProviderTest extends TestCase
 
     public function testLoadUserByInvalidUsername()
     {
-        $this->expectException(UsernameNotFoundException::class);
+        if (class_exists(UserNotFoundException::class)) {
+            $this->expectException(UserNotFoundException::class);
+        } else {
+            $this->expectException(UsernameNotFoundException::class);
+        }
 
         $this->userManager->expects($this->once())
             ->method('findUserByUsernameOrEmail')

--- a/Tests/Security/UserProviderTest.php
+++ b/Tests/Security/UserProviderTest.php
@@ -15,6 +15,7 @@ use FOS\UserBundle\Security\UserProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
 class UserProviderTest extends TestCase
 {
@@ -47,7 +48,11 @@ class UserProviderTest extends TestCase
 
     public function testLoadUserByInvalidUsername()
     {
-        $this->expectException(UsernameNotFoundException::class);
+        if (class_exists(UserNotFoundException::class)) {
+            $this->expectException(UserNotFoundException::class);
+        } else {
+            $this->expectException(UsernameNotFoundException::class);
+        }
 
         $this->userManager->expects($this->once())
             ->method('findUserByUsername')
@@ -82,7 +87,11 @@ class UserProviderTest extends TestCase
 
     public function testRefreshDeleted()
     {
-        $this->expectException(UsernameNotFoundException::class);
+        if (class_exists(UserNotFoundException::class)) {
+            $this->expectException(UserNotFoundException::class);
+        } else {
+            $this->expectException(UsernameNotFoundException::class);
+        }
 
         $user = $this->getMockForAbstractClass('FOS\UserBundle\Model\User');
         $this->userManager->expects($this->once())

--- a/Tests/Util/PasswordUpdaterTest.php
+++ b/Tests/Util/PasswordUpdaterTest.php
@@ -13,19 +13,28 @@ namespace FOS\UserBundle\Tests\Util;
 
 use FOS\UserBundle\Tests\TestUser;
 use FOS\UserBundle\Util\PasswordUpdater;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
+/**
+ * @group legacy
+ */
 class PasswordUpdaterTest extends TestCase
 {
     /**
-     * @var PasswordUpdater
+     * @var PasswordUpdater&MockObject
      */
     private $updater;
     private $encoderFactory;
 
     protected function setUp(): void
     {
-        $this->encoderFactory = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
+        if (!interface_exists(EncoderFactoryInterface::class)) {
+            $this->markTestSkipped('The PasswordUpdater class does not support Symfony 6+.');
+        }
+
+        $this->encoderFactory = $this->getMockBuilder(EncoderFactoryInterface::class)->getMock();
 
         $this->updater = new PasswordUpdater($this->encoderFactory);
     }

--- a/Tests/ignored-deprecations.txt
+++ b/Tests/ignored-deprecations.txt
@@ -1,0 +1,4 @@
+# SwiftMailer does not put phpdoc on overwritten methods and is not maintained anymore to add them.
+/Method "Swift_[^"]++" might add "[^"]++" as a native return type declaration in the future\. Do the same in implementation "Swift_[^"]++" now to avoid errors or add an explicit @return annotation to suppress this message\./
+# Weird error reported for symfony/validator
+/The "Symfony\\Component\\Validator\\Constraint::\$errorNames" property is considered final\. You should not override it in "Symfony\\Component\\Validator\\Constraints\\NotBlank"\./

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "friendsofphp/php-cs-fixer": "^3.0.2, !=3.5.0",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
         "symfony/console": "^4.4 || ^5.0",
-        "symfony/phpunit-bridge": "^5.3",
+        "symfony/phpunit-bridge": "^6.1",
         "symfony/yaml": "^4.4 || ^5.0"
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,8 @@
             </exclude>
         </whitelist>
     </filter>
+
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=Tests/ignored-deprecations.txt&amp;max[total]=0" />
     </php>
 </phpunit>


### PR DESCRIPTION
The testsuite was disabling the reporting of deprecations (probably because of the swiftmailer mess), which caused me to miss some changes when adding support for Symfony 5.

In particular, the programmatic login was not properly creating the remember-me cookie when using the new authentication system.