### PR TITLE
add support for symfony mailer

### DIFF
--- a/Mailer/SymfonyMailer.php
+++ b/Mailer/SymfonyMailer.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Mailer;
+
+use FOS\UserBundle\Model\UserInterface;
+use FOS\UserBundle\Mailer\MailerInterface;
+use Symfony\Component\Mailer\MailerInterface as SymfonyMailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+
+
+class SymfonyMailer implements MailerInterface
+{
+    /**
+     * @var SymfonyMailerInterface
+     */
+    protected $mailer;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    protected $router;
+
+    /**
+     * @var Environment
+     */
+    protected $twig;
+
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    public function __construct(SymfonyMailerInterface $mailer, UrlGeneratorInterface $router, Environment $twig, array $parameters)
+    {
+        $this->mailer = $mailer;
+        $this->router = $router;
+        $this->twig = $twig;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendConfirmationEmailMessage(UserInterface $user)
+    {
+        $template = $this->parameters['template']['confirmation'];
+        $url = $this->router->generate('fos_user_registration_confirm', ['token' => $user->getConfirmationToken()], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $context = [
+            'user' => $user,
+            'confirmationUrl' => $url,
+        ];
+
+        $this->sendMessage($template, $context, $this->parameters['from_email']['confirmation'], (string) $user->getEmail());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendResettingEmailMessage(UserInterface $user)
+    {
+        $template = $this->parameters['template']['resetting'];
+        $url = $this->router->generate('fos_user_resetting_reset', ['token' => $user->getConfirmationToken()], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $context = [
+            'user' => $user,
+            'confirmationUrl' => $url,
+        ];
+
+        $this->sendMessage($template, $context, $this->parameters['from_email']['resetting'], (string) $user->getEmail());
+    }
+
+    /**
+     * @param string $templateName
+     * @param array  $context
+     * @param array  $fromEmail
+     * @param string $toEmail
+     */
+    protected function sendMessage($templateName, $context, $fromEmail, $toEmail)
+    {
+        $template = $this->twig->load($templateName);
+        $subject = $template->renderBlock('subject', $context);
+        $textBody = $template->renderBlock('body_text', $context);
+
+        $htmlBody = '';
+
+        if ($template->hasBlock('body_html', $context)) {
+            $htmlBody = $template->renderBlock('body_html', $context);
+        }
+
+        $mail_address = array_key_first($fromEmail);
+        $mail_display_name = $fromEmail[$mail_address];
+        
+        $message = (new Email())
+            ->subject($subject)
+            ->from(new Address($mail_address, $mail_display_name))
+            ->to($toEmail);
+
+        if (!empty($htmlBody)) {
+            $message->html($htmlBody, 'text/html')
+                ->text($textBody);
+        } else {
+            $message->text($textBody);
+        }
+
+        $this->mailer->send($message);
+    }
+}

--- a/Resources/config/mailer.xml
+++ b/Resources/config/mailer.xml
@@ -33,6 +33,22 @@
             <tag name="fos_user.requires_swift" />
         </service>
 
+        <service id="fos_user.mailer.mailer" class="FOS\UserBundle\Mailer\SymfonyMailer" public="false">
+            <argument type="service" id="mailer" />
+            <argument type="service" id="router" />
+            <argument type="service" id="twig" />
+            <argument type="collection">
+                <argument key="template" type="collection">
+                    <argument key="confirmation">%fos_user.registration.confirmation.template%</argument>
+                    <argument key="resetting">%fos_user.resetting.email.template%</argument>
+                </argument>
+                <argument key="from_email" type="collection">
+                    <argument key="confirmation">%fos_user.registration.confirmation.from_email%</argument>
+                    <argument key="resetting">%fos_user.resetting.email.from_email%</argument>
+                </argument>
+            </argument>
+        </service>
+
         <service id="fos_user.mailer.noop" class="FOS\UserBundle\Mailer\NoopMailer" public="false" />
     </services>
 

--- a/Resources/doc/emails.rst
+++ b/Resources/doc/emails.rst
@@ -38,10 +38,11 @@ a form to enter in a new password.
 Default Mailer Implementations
 ------------------------------
 
-The bundle comes with 2 mailer implementations. They are listed below
+The bundle comes with 3 mailer implementations. They are listed below
 by service id:
 
 - ``fos_user.mailer.twig_swift`` uses Swiftmailer to send emails and Twig blocks to render the message.
+- ``fos_user.mailer.mailer`` uses Symfony Mailer to send emails and Twig blocks to render the message.
 - ``fos_user.mailer.noop`` is a mailer implementation which performs no operation, so no emails are sent.
 
 .. note::


### PR DESCRIPTION
Added support for [Symfony Mailer](https://symfony.com/doc/5.4/mailer.html), allowing to eliminate dependency on deprecated [Swift Mailer](https://swiftmailer.symfony.com/docs/introduction.html).

Tested with Symfony 5.4.