### PR TITLE
Add return types in all methods

### DIFF
--- a/Doctrine/CouchDB/UserListener.php
+++ b/Doctrine/CouchDB/UserListener.php
@@ -42,7 +42,7 @@ class UserListener implements EventSubscriber
         ];
     }
 
-    public function prePersist(LifecycleEventArgs $args)
+    public function prePersist(LifecycleEventArgs $args): void
     {
         $object = $args->getDocument();
         if ($object instanceof UserInterface) {
@@ -50,7 +50,7 @@ class UserListener implements EventSubscriber
         }
     }
 
-    public function preUpdate(LifecycleEventArgs $args)
+    public function preUpdate(LifecycleEventArgs $args): void
     {
         $object = $args->getDocument();
         if ($object instanceof UserInterface) {
@@ -61,7 +61,7 @@ class UserListener implements EventSubscriber
     /**
      * Updates the user properties.
      */
-    private function updateUserFields(UserInterface $user)
+    private function updateUserFields(UserInterface $user): void
     {
         $this->canonicalFieldsUpdater->updateCanonicalFields($user);
         $this->passwordUpdater->hashPassword($user);

--- a/Doctrine/UserListener.php
+++ b/Doctrine/UserListener.php
@@ -52,7 +52,7 @@ class UserListener implements EventSubscriber
     /**
      * Pre persist listener based on doctrine common.
      */
-    public function prePersist(LifecycleEventArgs $args)
+    public function prePersist(LifecycleEventArgs $args): void
     {
         $object = $args->getObject();
         if ($object instanceof UserInterface) {
@@ -63,7 +63,7 @@ class UserListener implements EventSubscriber
     /**
      * Pre update listener based on doctrine common.
      */
-    public function preUpdate(LifecycleEventArgs $args)
+    public function preUpdate(LifecycleEventArgs $args): void
     {
         $object = $args->getObject();
         if ($object instanceof UserInterface) {
@@ -75,7 +75,7 @@ class UserListener implements EventSubscriber
     /**
      * Updates the user properties.
      */
-    private function updateUserFields(UserInterface $user)
+    private function updateUserFields(UserInterface $user): void
     {
         $this->canonicalFieldsUpdater->updateCanonicalFields($user);
         $this->passwordUpdater->hashPassword($user);
@@ -84,7 +84,7 @@ class UserListener implements EventSubscriber
     /**
      * Recomputes change set for Doctrine implementations not doing it automatically after the event.
      */
-    private function recomputeChangeSet(ObjectManager $om, UserInterface $user)
+    private function recomputeChangeSet(ObjectManager $om, UserInterface $user): void
     {
         $meta = $om->getClassMetadata(get_class($user));
 

--- a/Doctrine/UserManager.php
+++ b/Doctrine/UserManager.php
@@ -43,12 +43,20 @@ class UserManager extends BaseUserManager
         $this->class = $class;
     }
 
+    /**
+     * @return void
+     */
     public function deleteUser(UserInterface $user)
     {
         $this->objectManager->remove($user);
         $this->objectManager->flush();
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<UserInterface>
+     */
     public function getClass()
     {
         if (false !== strpos($this->class, ':')) {
@@ -59,21 +67,33 @@ class UserManager extends BaseUserManager
         return $this->class;
     }
 
+    /**
+     * @return UserInterface|null
+     */
     public function findUserBy(array $criteria)
     {
         return $this->getRepository()->findOneBy($criteria);
     }
 
+    /**
+     * @return \Traversable<UserInterface>
+     */
     public function findUsers()
     {
         return $this->getRepository()->findAll();
     }
 
+    /**
+     * @return void
+     */
     public function reloadUser(UserInterface $user)
     {
         $this->objectManager->refresh($user);
     }
 
+    /**
+     * @return void
+     */
     public function updateUser(UserInterface $user, $andFlush = true)
     {
         $this->updateCanonicalFields($user);
@@ -86,7 +106,7 @@ class UserManager extends BaseUserManager
     }
 
     /**
-     * @return ObjectRepository
+     * @return ObjectRepository<UserInterface>
      */
     protected function getRepository()
     {

--- a/Form/Factory/FormFactory.php
+++ b/Form/Factory/FormFactory.php
@@ -12,6 +12,7 @@
 namespace FOS\UserBundle\Form\Factory;
 
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 class FormFactory implements FactoryInterface
 {
@@ -38,9 +39,9 @@ class FormFactory implements FactoryInterface
     /**
      * FormFactory constructor.
      *
-     * @param string $name
-     * @param string $type
-     * @param array  $validationGroups
+     * @param string        $name
+     * @param string        $type
+     * @param string[]|null $validationGroups
      */
     public function __construct(FormFactoryInterface $formFactory, $name, $type, array $validationGroups = null)
     {
@@ -50,6 +51,9 @@ class FormFactory implements FactoryInterface
         $this->validationGroups = $validationGroups;
     }
 
+    /**
+     * @return FormInterface
+     */
     public function createForm(array $options = [])
     {
         $options = array_merge(['validation_groups' => $this->validationGroups], $options);

--- a/Mailer/MailerInterface.php
+++ b/Mailer/MailerInterface.php
@@ -20,11 +20,15 @@ interface MailerInterface
 {
     /**
      * Send an email to a user to confirm the account creation.
+     *
+     * @return void
      */
     public function sendConfirmationEmailMessage(UserInterface $user);
 
     /**
      * Send an email to a user to confirm the password reset.
+     *
+     * @return void
      */
     public function sendResettingEmailMessage(UserInterface $user);
 }

--- a/Mailer/NoopMailer.php
+++ b/Mailer/NoopMailer.php
@@ -24,11 +24,17 @@ use FOS\UserBundle\Model\UserInterface;
  */
 class NoopMailer implements MailerInterface
 {
+    /**
+     * @return void
+     */
     public function sendConfirmationEmailMessage(UserInterface $user)
     {
         // nothing happens.
     }
 
+    /**
+     * @return void
+     */
     public function sendResettingEmailMessage(UserInterface $user)
     {
         // nothing happens.

--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -48,6 +48,9 @@ class TwigSwiftMailer implements MailerInterface
         $this->parameters = $parameters;
     }
 
+    /**
+     * @return void
+     */
     public function sendConfirmationEmailMessage(UserInterface $user)
     {
         $template = $this->parameters['template']['confirmation'];
@@ -61,6 +64,9 @@ class TwigSwiftMailer implements MailerInterface
         $this->sendMessage($template, $context, $this->parameters['from_email']['confirmation'], (string) $user->getEmail());
     }
 
+    /**
+     * @return void
+     */
     public function sendResettingEmailMessage(UserInterface $user)
     {
         $template = $this->parameters['template']['resetting'];
@@ -79,6 +85,8 @@ class TwigSwiftMailer implements MailerInterface
      * @param array  $context
      * @param array  $fromEmail
      * @param string $toEmail
+     *
+     * @return void
      */
     protected function sendMessage($templateName, $context, $fromEmail, $toEmail)
     {

--- a/Model/UserManager.php
+++ b/Model/UserManager.php
@@ -31,6 +31,9 @@ abstract class UserManager implements UserManagerInterface
         $this->canonicalFieldsUpdater = $canonicalFieldsUpdater;
     }
 
+    /**
+     * @return UserInterface
+     */
     public function createUser()
     {
         $class = $this->getClass();
@@ -39,16 +42,25 @@ abstract class UserManager implements UserManagerInterface
         return $user;
     }
 
+    /**
+     * @return UserInterface|null
+     */
     public function findUserByEmail($email)
     {
         return $this->findUserBy(['emailCanonical' => $this->canonicalFieldsUpdater->canonicalizeEmail($email)]);
     }
 
+    /**
+     * @return UserInterface|null
+     */
     public function findUserByUsername($username)
     {
         return $this->findUserBy(['usernameCanonical' => $this->canonicalFieldsUpdater->canonicalizeUsername($username)]);
     }
 
+    /**
+     * @return UserInterface|null
+     */
     public function findUserByUsernameOrEmail($usernameOrEmail)
     {
         if (preg_match('/^.+\@\S+\.\S+$/', $usernameOrEmail)) {
@@ -61,16 +73,25 @@ abstract class UserManager implements UserManagerInterface
         return $this->findUserByUsername($usernameOrEmail);
     }
 
+    /**
+     * @return UserInterface|null
+     */
     public function findUserByConfirmationToken($token)
     {
         return $this->findUserBy(['confirmationToken' => $token]);
     }
 
+    /**
+     * @return void
+     */
     public function updateCanonicalFields(UserInterface $user)
     {
         $this->canonicalFieldsUpdater->updateCanonicalFields($user);
     }
 
+    /**
+     * @return void
+     */
     public function updatePassword(UserInterface $user)
     {
         $this->passwordUpdater->hashPassword($user);

--- a/Model/UserManagerInterface.php
+++ b/Model/UserManagerInterface.php
@@ -35,6 +35,8 @@ interface UserManagerInterface
 
     /**
      * Deletes a user.
+     *
+     * @return void
      */
     public function deleteUser(UserInterface $user);
 
@@ -84,7 +86,7 @@ interface UserManagerInterface
     /**
      * Returns a collection with all user instances.
      *
-     * @return \Traversable
+     * @return \Traversable<UserInterface>
      */
     public function findUsers();
 
@@ -92,26 +94,36 @@ interface UserManagerInterface
      * Returns the user's fully qualified class name.
      *
      * @return string
+     *
+     * @phpstan-return class-string<UserInterface>
      */
     public function getClass();
 
     /**
      * Reloads a user.
+     *
+     * @return void
      */
     public function reloadUser(UserInterface $user);
 
     /**
      * Updates a user.
+     *
+     * @return void
      */
     public function updateUser(UserInterface $user);
 
     /**
      * Updates the canonical username and email fields for a user.
+     *
+     * @return void
      */
     public function updateCanonicalFields(UserInterface $user);
 
     /**
      * Updates a user password if a plain password is set.
+     *
+     * @return void
      */
     public function updatePassword(UserInterface $user);
 }

--- a/Security/LoginManager.php
+++ b/Security/LoginManager.php
@@ -73,7 +73,7 @@ class LoginManager implements LoginManagerInterface
         $this->rememberMeHandler = $rememberMeHandler;
     }
 
-    final public function logInUser($firewallName, UserInterface $user, Response $response = null)
+    final public function logInUser($firewallName, UserInterface $user, Response $response = null): void
     {
         $this->userChecker->checkPreAuth($user);
 

--- a/Security/LoginManagerInterface.php
+++ b/Security/LoginManagerInterface.php
@@ -18,6 +18,8 @@ interface LoginManagerInterface
 {
     /**
      * @param string $firewallName
+     *
+     * @return void
      */
     public function logInUser($firewallName, UserInterface $user, Response $response = null);
 }

--- a/Util/HashingPasswordUpdater.php
+++ b/Util/HashingPasswordUpdater.php
@@ -29,6 +29,9 @@ class HashingPasswordUpdater implements PasswordUpdaterInterface
         $this->passwordHasherFactory = $passwordHasherFactory;
     }
 
+    /**
+     * @return void
+     */
     public function hashPassword(UserInterface $user)
     {
         $plainPassword = $user->getPlainPassword();

--- a/Util/PasswordUpdater.php
+++ b/Util/PasswordUpdater.php
@@ -29,6 +29,9 @@ class PasswordUpdater implements PasswordUpdaterInterface
         $this->encoderFactory = $encoderFactory;
     }
 
+    /**
+     * @return void
+     */
     public function hashPassword(UserInterface $user)
     {
         $plainPassword = $user->getPlainPassword();

--- a/Util/UserManipulator.php
+++ b/Util/UserManipulator.php
@@ -88,6 +88,8 @@ class UserManipulator
      * Activates the given user.
      *
      * @param string $username
+     *
+     * @return void
      */
     public function activate($username)
     {
@@ -103,6 +105,8 @@ class UserManipulator
      * Deactivates the given user.
      *
      * @param string $username
+     *
+     * @return void
      */
     public function deactivate($username)
     {
@@ -119,6 +123,8 @@ class UserManipulator
      *
      * @param string $username
      * @param string $password
+     *
+     * @return void
      */
     public function changePassword($username, $password)
     {
@@ -134,6 +140,8 @@ class UserManipulator
      * Promotes the given user.
      *
      * @param string $username
+     *
+     * @return void
      */
     public function promote($username)
     {
@@ -149,6 +157,8 @@ class UserManipulator
      * Demotes the given user.
      *
      * @param string $username
+     *
+     * @return void
      */
     public function demote($username)
     {


### PR DESCRIPTION
For non-final classes, the return types are added only in phpdoc for now as adding actual return types will be done in the next major version.