### PR TITLE
Fix the symfony locking in the CI setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,8 @@ jobs:
 
             - name: Install dependencies
               env:
-                SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
-              run: composer install
+                SYMFONY_REQUIRE: ${{ matrix.symfony-versions }}
+              run: composer update
 
             - name: Install PHPUnit
               run: ./vendor/bin/simple-phpunit install


### PR DESCRIPTION
Apparently, the version filtering of Flex does not trigger when running an install without lock file (which fallbacks to an update).