### PR TITLE
Mark `User::eraseCredentials` as deprecated

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -183,6 +183,7 @@ abstract class User implements UserInterface, EquatableInterface, \Serializable
         return $this;
     }
 
+    #[\Deprecated]
     public function eraseCredentials(): void
     {
         $this->plainPassword = null;


### PR DESCRIPTION
This avoids the deprecation warning of Symfony about the deprecation of the method. Our User class already excludes the plain password from the serialized data even when this method is not called.